### PR TITLE
Add IO.parTraverse

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/IOSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/IOSpec.scala
@@ -16,6 +16,8 @@ class IOSpec extends Specification with GenIO with RTS with ScalaCheck {
       `IO.traverse` returns the list of Ints in the same order. $t2
    Create a list of String and pass an f: String => IO[String, Int]:
       `IO.traverse` fails with a NumberFormatException exception. $t3
+   Create a list of Strings and pass an f: String => IO[String, Int]:
+      `IO.parTraverse` returns the list of Ints in any order. $t2
     """
 
   def functionIOGen: Gen[String => IO[Throwable, Int]] =
@@ -40,6 +42,14 @@ class IOSpec extends Specification with GenIO with RTS with ScalaCheck {
     val list = List("1", "h", "3")
     val res  = Try(unsafePerformIO(IO.traverse(list)(x => IO.point[String, Int](x.toInt))))
     res must beAFailedTry.withThrowable[NumberFormatException]
+  }
+
+  def t4 = {
+    val list = List("1", "2", "3")
+    val res = unsafePerformIO(IO.parTraverse(list)(x => IO.point[String, Int](x.toInt)))
+    res must contain(1)
+    res must contain(2)
+    res must contain(3)
   }
 
 }

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -799,6 +799,8 @@ object IO {
   /**
    * Evaluate the elements of a traversable data structure in parallel
    * and collect the results.
+   *
+   * _Note_: ordering in the input collection is not preserved
    */
   def parTraverse[E, A, B, M[X] <: TraversableOnce[X]](
     in: M[A]

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -806,7 +806,7 @@ object IO {
     in: M[A]
   )(fn: A => IO[E, B])(implicit cbf: CanBuildFrom[M[A], B, M[B]]): IO[E, M[B]] =
     in.foldLeft(point[E, mutable.Builder[B, M[B]]](cbf(in)))(
-        (io, a) => io.par(fn(a)).map { case (builder, a) => builder += a }
+        (io, a) => io.par(fn(a)).flatMap { case (builder, a) => sync(builder += a) }
       )
       .map(_.result())
 


### PR DESCRIPTION
Said @jdegoes 

| Uses `par` for parallel composition.

Provides a traversal where effects are computed in parallel. I refrained from defining `parSequence` because the name sounded weird 😅 