### PR TITLE
Add helper IO.fromEither

### DIFF
--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -752,7 +752,13 @@ object IO {
    * operation of `IO.attempt`.
    */
   final def absolve[E, A](v: IO[E, Either[E, A]]): IO[E, A] =
-    v.flatMap(_.fold[IO[E, A]](IO.fail, IO.now))
+    v.flatMap(fromEither)
+
+  /**
+    * Lifts an `Either` into an `IO`.
+    */
+  final def fromEither[E, A](v: Either[E, A]): IO[E, A] =
+    v.fold(IO.fail, IO.now)
 
   /**
    * Retrieves the supervisor associated with the fiber running the action

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -755,8 +755,8 @@ object IO {
     v.flatMap(fromEither)
 
   /**
-    * Lifts an `Either` into an `IO`.
-    */
+   * Lifts an `Either` into an `IO`.
+   */
   final def fromEither[E, A](v: Either[E, A]): IO[E, A] =
     v.fold(IO.fail, IO.now)
 


### PR DESCRIPTION
Since errors can already be retrieved as `Either`, I suppose we can allow to create `IO` from `Either` as well.

My goal is to create a simple way to lift a “value-or-error” in an `IO` in order to avoid temptation to use `IO` whereas simpler error handling works fine.