### PR TITLE
Add IO.bracket

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -244,9 +244,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends Specification with AroundTimeou
 
   def testBracketRethrownCaughtErrorInUsage = {
     lazy val actual = unsafePerformIO(
-      IO.absolve(
-        IO.bracket(IO.unit[Throwable])(_ => IO.unit)(_ => IO.fail[Throwable, Unit](ExampleError)).attempt[Throwable]
-      )
+      IO.absolve(IO.bracket(IO.unit[Throwable])(_ => IO.unit)(_ => IO.fail[Throwable, Unit](ExampleError)).attempt[Throwable])
     )
 
     actual must (throwA(UnhandledError(ExampleError)))

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -244,7 +244,9 @@ class RTSSpec(implicit ee: ExecutionEnv) extends Specification with AroundTimeou
 
   def testBracketRethrownCaughtErrorInUsage = {
     lazy val actual = unsafePerformIO(
-      IO.absolve(IO.bracket(IO.unit[Throwable])(_ => IO.unit)(_ => IO.fail[Throwable, Unit](ExampleError)).attempt[Throwable])
+      IO.absolve(
+        IO.bracket(IO.unit[Throwable])(_ => IO.unit)(_ => IO.fail[Throwable, Unit](ExampleError)).attempt[Throwable]
+      )
     )
 
     actual must (throwA(UnhandledError(ExampleError)))

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -212,23 +212,23 @@ class RTSSpec(implicit ee: ExecutionEnv) extends Specification with AroundTimeou
   }
 
   def testExitResultIsUsageResult =
-    unsafePerformIO(IO.bracket(IO.unit[Void])(_ => IO.unit[Void])(_ => IO.point[Void, Int](42))) must_=== 42
+    unsafePerformIO(IO.unit.bracket_(IO.unit[Void])(IO.point[Throwable, Int](42))) must_=== 42
 
   def testBracketErrorInAcquisition =
-    unsafePerformIO(IO.bracket(IO.fail[Throwable, Unit](ExampleError))(_ => IO.unit)(_ => IO.unit)) must
+    unsafePerformIO(IO.fail[Throwable, Unit](ExampleError).bracket_(IO.unit)(IO.unit)) must
       (throwA(UnhandledError(ExampleError)))
 
   def testBracketErrorInRelease =
-    unsafePerformIO(IO.bracket(IO.unit[Void])(_ => IO.terminate(ExampleError))(_ => IO.unit[Void])) must
+    unsafePerformIO(IO.unit[Void].bracket_(IO.terminate(ExampleError))(IO.unit[Void])) must
       (throwA(ExampleError))
 
   def testBracketErrorInUsage =
-    unsafePerformIO(IO.bracket(IO.unit[Throwable])(_ => IO.unit)(_ => IO.fail[Throwable, Unit](ExampleError))) must
+    unsafePerformIO(IO.unit.bracket_(IO.unit)(IO.fail[Throwable, Unit](ExampleError))) must
       (throwA(UnhandledError(ExampleError)))
 
   def testBracketRethrownCaughtErrorInAcquisition = {
     lazy val actual = unsafePerformIO(
-      IO.absolve(IO.bracket(IO.fail[Throwable, Unit](ExampleError))(_ => IO.unit)(_ => IO.unit).attempt[Throwable])
+      IO.absolve(IO.fail[Throwable, Unit](ExampleError).bracket_(IO.unit)(IO.unit).attempt[Throwable])
     )
 
     actual must (throwA(UnhandledError(ExampleError)))
@@ -236,7 +236,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends Specification with AroundTimeou
 
   def testBracketRethrownCaughtErrorInRelease = {
     lazy val actual = unsafePerformIO(
-      IO.bracket(IO.unit[Void])(_ => IO.terminate(ExampleError))(_ => IO.unit[Void])
+      IO.unit[Void].bracket_(IO.terminate(ExampleError))(IO.unit[Void])
     )
 
     actual must (throwA(ExampleError))
@@ -244,15 +244,15 @@ class RTSSpec(implicit ee: ExecutionEnv) extends Specification with AroundTimeou
 
   def testBracketRethrownCaughtErrorInUsage = {
     lazy val actual = unsafePerformIO(
-      IO.absolve(IO.bracket(IO.unit[Throwable])(_ => IO.unit)(_ => IO.fail[Throwable, Unit](ExampleError)).attempt[Throwable])
+      IO.absolve(IO.unit.bracket_(IO.unit)(IO.fail[Throwable, Unit](ExampleError)).attempt[Throwable])
     )
 
     actual must (throwA(UnhandledError(ExampleError)))
   }
 
   def testEvalOfAsyncAttemptOfFail = {
-    val io1 = IO.bracket(IO.unit[Throwable])(_ => AsyncUnit[Void])(_ => asyncExampleError[Unit])
-    val io2 = IO.bracket(AsyncUnit[Throwable])(_ => IO.unit)(_ => asyncExampleError[Unit])
+    val io1 = IO.unit.bracket_(AsyncUnit[Void])(asyncExampleError[Unit])
+    val io2 = AsyncUnit[Throwable].bracket_(IO.unit)(asyncExampleError[Unit])
 
     unsafePerformIO(io1) must (throwA(UnhandledError(ExampleError)))
     unsafePerformIO(io2) must (throwA(UnhandledError(ExampleError)))

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -784,11 +784,8 @@ object IO {
 
   final def bracket[E, A, B](acquire: IO[E, A])(release: A => Infallible[Unit])(use: A => IO[E, B]): IO[E, B] =
     for {
-      e <- acquire.uninterruptibly.attempt
-      b <- (e match {
-            case Right(a) => use(a).ensuring(release(a).uninterruptibly)
-            case Left(e)  => IO.fail(e)
-          })
+      a <- acquire.uninterruptibly
+      b <- use(a).ensuring(release(a).uninterruptibly)
     } yield b
 
   /**

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -786,11 +786,10 @@ object IO {
     for {
       e <- acquire.uninterruptibly.attempt
       b <- (e match {
-        case Right(a) => use(a).ensuring(release(a).uninterruptibly)
-        case Left(e)  => IO.fail(e)
-      })
+            case Right(a) => use(a).ensuring(release(a).uninterruptibly)
+            case Left(e)  => IO.fail(e)
+          })
     } yield b
-
 
   /**
    * Apply the function fn to each element of the `TraversableOnce[A]` and

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -782,11 +782,11 @@ object IO {
         } yield fiberA.zipWith(fiberAs)(_ :: _)
     }
 
-  final def bracket[E, A, B](acquire: IO[E, A])(release: Infallible[Unit])(use: A => IO[E, B]): IO[E, B] =
+  final def bracket[E, A, B](acquire: IO[E, A])(release: A => Infallible[Unit])(use: A => IO[E, B]): IO[E, B] =
     for {
       e <- acquire.uninterruptibly.attempt
       b <- (e match {
-        case Right(a) => use(a).ensuring(release.uninterruptibly)
+        case Right(a) => use(a).ensuring(release(a).uninterruptibly)
         case Left(e)  => IO.fail(e)
       })
     } yield b


### PR DESCRIPTION
I wanted to have a go at #53 and was wondering if it was necessary for the outside world to deal with the exit state of the acquiring fiber? If not, then does the rendering below convey the proper semantics?

The only difference with the draft @jdegoes wrote is that resource acquisition is not running in a separate fiber—I thought that was not necessary.

If the below is correct then I'll remove the `IO.Bracket` stuff.