### PR TITLE
Rename `redeem` to `redeemWith` and introduce `redeem` as a less powerful option

### DIFF
--- a/benchmarks/src/main/scala/scalaz/zio/IODeepAttemptBenchmark.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/IODeepAttemptBenchmark.scala
@@ -54,7 +54,7 @@ class IODeepAttemptBenchmark {
   def scalazDeepAttempt(): BigInt = {
     def descend(n: Int): IO[Error, BigInt] =
       if (n == depth) IO.fail(new Error("Oh noes!"))
-      else if (n == halfway) descend(n + 1).redeem[Error, BigInt](_ => 50, identity)
+      else if (n == halfway) descend(n + 1).redeemPure[Error, BigInt](_ => 50, identity)
       else descend(n + 1).map(_ + n)
 
     unsafePerformIO(descend(0))

--- a/benchmarks/src/main/scala/scalaz/zio/IODeepAttemptBenchmark.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/IODeepAttemptBenchmark.scala
@@ -54,7 +54,7 @@ class IODeepAttemptBenchmark {
   def scalazDeepAttempt(): BigInt = {
     def descend(n: Int): IO[Error, BigInt] =
       if (n == depth) IO.fail(new Error("Oh noes!"))
-      else if (n == halfway) descend(n + 1).redeem[Error, BigInt](_ => IO.now(50))(a => IO.now(a))
+      else if (n == halfway) descend(n + 1).redeem[Error, BigInt](_ => 50, identity)
       else descend(n + 1).map(_ + n)
 
     unsafePerformIO(descend(0))

--- a/benchmarks/src/main/scala/scalaz/zio/IOShallowAttemptBenchmark.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/IOShallowAttemptBenchmark.scala
@@ -57,9 +57,9 @@ class IOShallowAttemptBenchmark {
   @Benchmark
   def scalazShallowAttempt(): BigInt = {
     def throwup(n: Int): IO[Error, BigInt] =
-      if (n == 0) throwup(n + 1).redeem[Error, BigInt](_ => 50, identity)
+      if (n == 0) throwup(n + 1).redeemPure[Error, BigInt](_ => 50, identity)
       else if (n == depth) IO.point(1)
-      else throwup(n + 1).redeemWith[Error, BigInt](_ => IO.now(0), _ => IO.fail(new Error("Oh noes!")))
+      else throwup(n + 1).redeem[Error, BigInt](_ => IO.now(0), _ => IO.fail(new Error("Oh noes!")))
 
     unsafePerformIO(throwup(0))
   }

--- a/benchmarks/src/main/scala/scalaz/zio/IOShallowAttemptBenchmark.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/IOShallowAttemptBenchmark.scala
@@ -57,9 +57,9 @@ class IOShallowAttemptBenchmark {
   @Benchmark
   def scalazShallowAttempt(): BigInt = {
     def throwup(n: Int): IO[Error, BigInt] =
-      if (n == 0) throwup(n + 1).redeem[Error, BigInt](_ => IO.now(50))(a => IO.now(a))
+      if (n == 0) throwup(n + 1).redeem[Error, BigInt](_ => 50, identity)
       else if (n == depth) IO.point(1)
-      else throwup(n + 1).redeem[Error, BigInt](_ => IO.now(0))(_ => IO.fail(new Error("Oh noes!")))
+      else throwup(n + 1).redeemWith[Error, BigInt](_ => IO.now(0), _ => IO.fail(new Error("Oh noes!")))
 
     unsafePerformIO(throwup(0))
   }

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -138,8 +138,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends Specification with AroundTimeou
   @silent
   def testEvalOfRedeemOfSyncEffectError =
     unsafePerformIO(
-      IO.syncThrowable(throw ExampleError)
-        .redeem[Throwable, Option[Throwable]](e => IO.now(Some(e)))(_ => IO.now(None))
+      IO.syncThrowable[Unit](throw ExampleError).redeem[Throwable, Option[Throwable]](Some(_), _ => None)
     ) must_=== Some(ExampleError)
 
   def testEvalOfAttemptOfFail = Seq(

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -138,7 +138,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends Specification with AroundTimeou
   @silent
   def testEvalOfRedeemOfSyncEffectError =
     unsafePerformIO(
-      IO.syncThrowable[Unit](throw ExampleError).redeem[Throwable, Option[Throwable]](Some(_), _ => None)
+      IO.syncThrowable[Unit](throw ExampleError).redeemPure[Throwable, Option[Throwable]](Some(_), _ => None)
     ) must_=== Some(ExampleError)
 
   def testEvalOfAttemptOfFail = Seq(

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -146,14 +146,14 @@ sealed abstract class IO[E, A] { self =>
    * otherwise executes the specified action.
    */
   final def orElse(that: => IO[E, A]): IO[E, A] =
-    self.redeemWith(_ => that, IO.now)
+    self.redeem(_ => that, IO.now)
 
   /**
    * Maps over the error type. This can be used to lift a "smaller" error into
    * a "larger" error.
    */
   final def leftMap[E2](f: E => E2): IO[E2, A] =
-    self.redeemWith[E2, A](f.andThen(IO.fail), IO.now)
+    self.redeem[E2, A](f.andThen(IO.fail), IO.now)
 
   /**
    * Lets define separate continuations for the case of failure (`err`) or
@@ -167,7 +167,7 @@ sealed abstract class IO[E, A] { self =>
    * The error parameter of the returned `IO` may be chosen arbitrarily, since
    * it will depend on the `IO`s returned by the given continuations.
    */
-  final def redeemWith[E2, B](err: E => IO[E2, B], succ: A => IO[E2, B]): IO[E2, B] =
+  final def redeem[E2, B](err: E => IO[E2, B], succ: A => IO[E2, B]): IO[E2, B] =
     (self.tag: @switch) match {
       case IO.Tags.Fail =>
         val io = self.asInstanceOf[IO.Fail[E, A]]
@@ -177,12 +177,12 @@ sealed abstract class IO[E, A] { self =>
     }
 
   /**
-   * Less powerful version of `redeemWith` which always returns a successful
+   * Less powerful version of `redeem` which always returns a successful
    * `IO[E2, B]` after applying one of the given mapping functions depending
    * on the result of `this` `IO`
    */
-  final def redeem[E2, B](err: E => B, succ: A => B): IO[E2, B] =
-    redeemWith(err.andThen(IO.now), succ.andThen(IO.now))
+  final def redeemPure[E2, B](err: E => B, succ: A => B): IO[E2, B] =
+    redeem(err.andThen(IO.now), succ.andThen(IO.now))
 
   /**
    * Executes this action, capturing both failure and success and returning
@@ -193,7 +193,7 @@ sealed abstract class IO[E, A] { self =>
    * it is guaranteed the `IO` action does not raise any errors.
    */
   final def attempt[E2]: IO[E2, Either[E, A]] =
-    self.redeemWith[E2, Either[E, A]](IO.nowLeft, IO.nowRight)
+    self.redeem[E2, Either[E, A]](IO.nowLeft, IO.nowRight)
 
   /**
    * When this action represents acquisition of a resource (for example,
@@ -299,7 +299,7 @@ sealed abstract class IO[E, A] { self =>
    * }}}
    */
   final def catchAll[E2](h: E => IO[E2, A]): IO[E2, A] =
-    self.redeemWith[E2, A](h, IO.now)
+    self.redeem[E2, A](h, IO.now)
 
   /**
    * Recovers from some or all of the error cases.
@@ -313,7 +313,7 @@ sealed abstract class IO[E, A] { self =>
   final def catchSome(pf: PartialFunction[E, IO[E, A]]): IO[E, A] = {
     def tryRescue(t: E): IO[E, A] = pf.applyOrElse(t, (_: E) => IO.fail(t))
 
-    self.redeemWith[E, A](tryRescue, IO.now)
+    self.redeem[E, A](tryRescue, IO.now)
   }
 
   /**

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -146,14 +146,14 @@ sealed abstract class IO[E, A] { self =>
    * otherwise executes the specified action.
    */
   final def orElse(that: => IO[E, A]): IO[E, A] =
-    self.redeem(_ => that)(IO.now)
+    self.redeemWith(_ => that, IO.now)
 
   /**
    * Maps over the error type. This can be used to lift a "smaller" error into
    * a "larger" error.
    */
   final def leftMap[E2](f: E => E2): IO[E2, A] =
-    self.redeem[E2, A](e => IO.fail(f(e)))(IO.now)
+    self.redeemWith[E2, A](f.andThen(IO.fail), IO.now)
 
   /**
    * Lets define separate continuations for the case of failure (`err`) or
@@ -167,7 +167,7 @@ sealed abstract class IO[E, A] { self =>
    * The error parameter of the returned `IO` may be chosen arbitrarily, since
    * it will depend on the `IO`s returned by the given continuations.
    */
-  final def redeem[E2, B](err: E => IO[E2, B])(succ: A => IO[E2, B]): IO[E2, B] =
+  final def redeemWith[E2, B](err: E => IO[E2, B], succ: A => IO[E2, B]): IO[E2, B] =
     (self.tag: @switch) match {
       case IO.Tags.Fail =>
         val io = self.asInstanceOf[IO.Fail[E, A]]
@@ -175,6 +175,14 @@ sealed abstract class IO[E, A] { self =>
 
       case _ => new IO.Attempt(self, err, succ)
     }
+
+  /**
+   * Less powerful version of `redeemWith` which always returns a successful
+   * `IO[E2, B]` after applying one of the given mapping functions depending
+   * on the result of `this` `IO`
+   */
+  final def redeem[E2, B](err: E => B, succ: A => B): IO[E2, B] =
+    redeemWith(err.andThen(IO.now), succ.andThen(IO.now))
 
   /**
    * Executes this action, capturing both failure and success and returning
@@ -185,7 +193,7 @@ sealed abstract class IO[E, A] { self =>
    * it is guaranteed the `IO` action does not raise any errors.
    */
   final def attempt[E2]: IO[E2, Either[E, A]] =
-    self.redeem[E2, Either[E, A]](IO.nowLeft)(IO.nowRight)
+    self.redeemWith[E2, Either[E, A]](IO.nowLeft, IO.nowRight)
 
   /**
    * When this action represents acquisition of a resource (for example,
@@ -291,7 +299,7 @@ sealed abstract class IO[E, A] { self =>
    * }}}
    */
   final def catchAll[E2](h: E => IO[E2, A]): IO[E2, A] =
-    self.redeem[E2, A](h)(IO.now)
+    self.redeemWith[E2, A](h, IO.now)
 
   /**
    * Recovers from some or all of the error cases.
@@ -305,7 +313,7 @@ sealed abstract class IO[E, A] { self =>
   final def catchSome(pf: PartialFunction[E, IO[E, A]]): IO[E, A] = {
     def tryRescue(t: E): IO[E, A] = pf.applyOrElse(t, (_: E) => IO.fail(t))
 
-    self.redeem[E, A](tryRescue)(IO.now)
+    self.redeemWith[E, A](tryRescue, IO.now)
   }
 
   /**


### PR DESCRIPTION
I find myself very often not needing the full power of `redeem` (as previously know) and combining it with just `IO.now` or using the combo `attempt.map(_.fold(f, g))` so I think this new flavor of redeem is very useful.
I decided for the renaming instead of naming the new method differently to remain in sync with monix `Task` names.