### PR TITLE
Rewrite `io.bracket*` with the new `IO.bracket` primitive

### DIFF
--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -252,8 +252,8 @@ private object RTS {
           case a: IO.Attempt[_, _, _, _] =>
             errorHandler = a.err.asInstanceOf[Any => IO[Any, Any]]
           case f0: Finalizer[_] =>
-            val f                                           = f0.asInstanceOf[Finalizer[E]]
-            val currentFinalizer: IO[Void, List[Throwable]] = f.finalizer.run.map(collectDefect)
+            val f                                           = f0.finalizer
+            val currentFinalizer: IO[Void, List[Throwable]] = f.run.map(collectDefect)
             if (finalizer eq null) finalizer = currentFinalizer
             else finalizer = finalizer.zipWith(currentFinalizer)(_ ++ _)
           case _ =>
@@ -286,8 +286,8 @@ private object RTS {
         // (reverse chronological).
         stack.pop() match {
           case f0: Finalizer[_] =>
-            val f                                           = f0.asInstanceOf[Finalizer[E]]
-            val currentFinalizer: IO[Void, List[Throwable]] = f.finalizer.run.map(collectDefect)
+            val f                                           = f0.finalizer
+            val currentFinalizer: IO[Void, List[Throwable]] = f.run.map(collectDefect)
             if (finalizer eq null) finalizer = currentFinalizer
             else finalizer = finalizer.zipWith(currentFinalizer)(_ ++ _)
           case _ =>

--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -244,7 +244,7 @@ private object RTS {
      * @param err   The exception that is being thrown.
      */
     final def catchError: IO[Void, List[Throwable]] = {
-      var errorHandler: Any => IO[Any, Any] = null
+      var errorHandler: Any => IO[Any, Any]    = null
       var finalizer: IO[Void, List[Throwable]] = null
 
       // Unwind the stack, looking for exception handlers and coalescing
@@ -254,7 +254,7 @@ private object RTS {
           case a: IO.Attempt[_, _, _, _] =>
             errorHandler = a.err.asInstanceOf[Any => IO[Any, Any]]
           case f0: Finalizer[_] =>
-            val f = f0.asInstanceOf[Finalizer[E]]
+            val f                                           = f0.asInstanceOf[Finalizer[E]]
             val currentFinalizer: IO[Void, List[Throwable]] = f(()).run.map(collectDefect)
             if (finalizer eq null) finalizer = currentFinalizer
             else finalizer = finalizer.zipWith(currentFinalizer)(_ ++ _)
@@ -290,7 +290,7 @@ private object RTS {
         // (reverse chronological).
         stack.pop() match {
           case f0: Finalizer[_] =>
-            val f = f0.asInstanceOf[Finalizer[E]]
+            val f                                           = f0.asInstanceOf[Finalizer[E]]
             val currentFinalizer: IO[Void, List[Throwable]] = f(()).run.map(collectDefect)
             if (finalizer eq null) finalizer = currentFinalizer
             else finalizer = finalizer.zipWith(currentFinalizer)(_ ++ _)

--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -252,10 +252,9 @@ private object RTS {
           case a: IO.Attempt[_, _, _, _] =>
             errorHandler = a.err.asInstanceOf[Any => IO[Any, Any]]
           case f0: Finalizer[_] =>
-            val f                                           = f0.finalizer
-            val currentFinalizer: IO[Void, List[Throwable]] = f.run.map(collectDefect)
-            if (finalizer eq null) finalizer = currentFinalizer
-            else finalizer = finalizer.zipWith(currentFinalizer)(_ ++ _)
+            val f: IO[Void, List[Throwable]] = f0.finalizer.run.map(collectDefect)
+            if (finalizer eq null) finalizer = f
+            else finalizer = finalizer.zipWith(f)(_ ++ _)
           case _ =>
         }
       }
@@ -286,10 +285,9 @@ private object RTS {
         // (reverse chronological).
         stack.pop() match {
           case f0: Finalizer[_] =>
-            val f                                           = f0.finalizer
-            val currentFinalizer: IO[Void, List[Throwable]] = f.run.map(collectDefect)
-            if (finalizer eq null) finalizer = currentFinalizer
-            else finalizer = finalizer.zipWith(currentFinalizer)(_ ++ _)
+            val f: IO[Void, List[Throwable]] = f0.finalizer.run.map(collectDefect)
+            if (finalizer eq null) finalizer = f
+            else finalizer = finalizer.zipWith(f)(_ ++ _)
           case _ =>
         }
       }

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -177,7 +177,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends Specification with AroundTimeou
 
   def testEvalOfFailOnError = {
     var finalized = false
-    val cleanup: Throwable => IO[Void, Unit] =
+    val cleanup: Option[Throwable] => IO[Void, Unit] =
       _ => IO.sync[Void, Unit] { finalized = true; () }
 
     unsafePerformIO(

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -38,7 +38,6 @@ class RTSSpec(implicit ee: ExecutionEnv) extends Specification with AroundTimeou
 
   RTS bracket
     fail ensuring                           $testEvalOfFailEnsuring
-    fail on error                           $testEvalOfFailOnError
     finalizer errors not caught             $testErrorInFinalizerCannotBeCaught
     finalizer errors reported               ${upTo(1.second)(testErrorInFinalizerIsReported)}
     bracket result is usage result          $testExitResultIsUsageResult
@@ -172,18 +171,6 @@ class RTSSpec(implicit ee: ExecutionEnv) extends Specification with AroundTimeou
     unsafePerformIO(IO.fail[Throwable, Unit](ExampleError).ensuring(IO.sync[Void, Unit] { finalized = true; () })) must (throwA(
       UnhandledError(ExampleError)
     ))
-    finalized must_=== true
-  }
-
-  def testEvalOfFailOnError = {
-    var finalized = false
-    val cleanup: Throwable => IO[Void, Unit] =
-      _ => IO.sync[Void, Unit] { finalized = true; () }
-
-    unsafePerformIO(
-      IO.fail[Throwable, Unit](ExampleError).onError(cleanup)(cleanup)
-    ) must (throwA(UnhandledError(ExampleError)))
-
     finalized must_=== true
   }
 
@@ -426,6 +413,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends Specification with AroundTimeou
 
   // Utility stuff
   val ExampleError = new Exception("Oh noes!")
+  val ExampleError2 = new Exception("Oh noes Regis!")
 
   def asyncExampleError[A]: IO[Throwable, A] = IO.async[Throwable, A](_(ExitResult.Failed(ExampleError)))
 

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -38,6 +38,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends Specification with AroundTimeou
 
   RTS bracket
     fail ensuring                           $testEvalOfFailEnsuring
+    fail on error                           $testEvalOfFailOnError
     finalizer errors not caught             $testErrorInFinalizerCannotBeCaught
     finalizer errors reported               ${upTo(1.second)(testErrorInFinalizerIsReported)}
     bracket result is usage result          $testExitResultIsUsageResult
@@ -171,6 +172,18 @@ class RTSSpec(implicit ee: ExecutionEnv) extends Specification with AroundTimeou
     unsafePerformIO(IO.fail[Throwable, Unit](ExampleError).ensuring(IO.sync[Void, Unit] { finalized = true; () })) must (throwA(
       UnhandledError(ExampleError)
     ))
+    finalized must_=== true
+  }
+
+  def testEvalOfFailOnError = {
+    var finalized = false
+    val cleanup: Throwable => IO[Void, Unit] =
+      _ => IO.sync[Void, Unit] { finalized = true; () }
+
+    unsafePerformIO(
+      IO.fail[Throwable, Unit](ExampleError).onError(cleanup)(cleanup)
+    ) must (throwA(UnhandledError(ExampleError)))
+
     finalized must_=== true
   }
 
@@ -413,7 +426,6 @@ class RTSSpec(implicit ee: ExecutionEnv) extends Specification with AroundTimeou
 
   // Utility stuff
   val ExampleError = new Exception("Oh noes!")
-  val ExampleError2 = new Exception("Oh noes Regis!")
 
   def asyncExampleError[A]: IO[Throwable, A] = IO.async[Throwable, A](_(ExitResult.Failed(ExampleError)))
 

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -181,7 +181,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends Specification with AroundTimeou
       _ => IO.sync[Void, Unit] { finalized = true; () }
 
     unsafePerformIO(
-      IO.fail[Throwable, Unit](ExampleError).onError(cleanup)(cleanup)
+      IO.fail[Throwable, Unit](ExampleError).onError(cleanup)
     ) must (throwA(UnhandledError(ExampleError)))
 
     finalized must_=== true

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -51,17 +51,6 @@ class RTSSpec(implicit ee: ExecutionEnv) extends Specification with AroundTimeou
     test eval of async fail                 $testEvalOfAsyncAttemptOfFail
     bracket regression 1                    ${upTo(10.seconds)(testBracketRegression1)}
 
-  RTS bracket (refactor)
-    bracket result is usage result          $testExitResultIsUsageResult_new
-    error in just acquisition               $testBracketErrorInAcquisition_new
-    error in just release                   $testBracketErrorInRelease_new
-    error in just usage                     $testBracketErrorInUsage_new
-    rethrown caught error in acquisition    $testBracketRethrownCaughtErrorInAcquisition_new
-    rethrown caught error in release        $testBracketRethrownCaughtErrorInRelease_new
-    rethrown caught error in usage          $testBracketRethrownCaughtErrorInUsage_new
-    test eval of async fail                 $testEvalOfAsyncAttemptOfFail_new
-    bracket regression 1                    ${upTo(10.seconds)(testBracketRegression1_new)}
-
   RTS synchronous stack safety
     deep map of point                       $testDeepMapOfPoint
     deep map of now                         $testDeepMapOfNow
@@ -223,89 +212,21 @@ class RTSSpec(implicit ee: ExecutionEnv) extends Specification with AroundTimeou
   }
 
   def testExitResultIsUsageResult =
-    unsafePerformIO(IO.unit.bracket_(IO.unit[Void])(IO.point[Throwable, Int](42))) must_=== 42
-
-  def testBracketErrorInAcquisition =
-    unsafePerformIO(IO.fail[Throwable, Unit](ExampleError).bracket_(IO.unit)(IO.unit)) must
-      (throwA(UnhandledError(ExampleError)))
-
-  def testBracketErrorInRelease =
-    unsafePerformIO(IO.unit[Void].bracket_(IO.terminate(ExampleError))(IO.unit[Void])) must
-      (throwA(ExampleError))
-
-  def testBracketErrorInUsage =
-    unsafePerformIO(IO.unit.bracket_(IO.unit)(IO.fail[Throwable, Unit](ExampleError))) must
-      (throwA(UnhandledError(ExampleError)))
-
-  def testBracketRethrownCaughtErrorInAcquisition = {
-    lazy val actual = unsafePerformIO(
-      IO.absolve(IO.fail[Throwable, Unit](ExampleError).bracket_(IO.unit)(IO.unit).attempt[Throwable])
-    )
-
-    actual must (throwA(UnhandledError(ExampleError)))
-  }
-
-  def testBracketRethrownCaughtErrorInRelease = {
-    lazy val actual = unsafePerformIO(
-      IO.unit[Void].bracket_(IO.terminate(ExampleError))(IO.unit[Void])
-    )
-
-    actual must (throwA(ExampleError))
-  }
-
-  def testBracketRethrownCaughtErrorInUsage = {
-    lazy val actual = unsafePerformIO(
-      IO.absolve(IO.unit.bracket_(IO.unit)(IO.fail[Throwable, Unit](ExampleError)).attempt[Throwable])
-    )
-
-    actual must (throwA(UnhandledError(ExampleError)))
-  }
-
-  def testEvalOfAsyncAttemptOfFail = {
-    val io1 = IO.unit.bracket_(AsyncUnit[Void])(asyncExampleError[Unit])
-    val io2 = AsyncUnit[Throwable].bracket_(IO.unit)(asyncExampleError[Unit])
-
-    unsafePerformIO(io1) must (throwA(UnhandledError(ExampleError)))
-    unsafePerformIO(io2) must (throwA(UnhandledError(ExampleError)))
-    unsafePerformIO(IO.absolve(io1.attempt[Throwable])) must (throwA(UnhandledError(ExampleError)))
-    unsafePerformIO(IO.absolve(io2.attempt[Throwable])) must (throwA(UnhandledError(ExampleError)))
-  }
-
-  def testBracketRegression1 = {
-    def makeLogger: IORef[List[String]] => String => IO[Void, Unit] =
-      (ref: IORef[List[String]]) => (line: String) => ref.modify[Void](_ ::: List(line)).toUnit
-
-    unsafePerformIO(for {
-      ref <- IORef[Void, List[String]](Nil)
-      log = makeLogger(ref)
-      f <- IO
-            .unit[Void]
-            .bracket[Unit](_ => log("start 1") *> IO.sleep(10.milliseconds) *> log("release 1"))(_ => IO.unit[Void])
-            .bracket[Unit](_ => log("start 2") *> IO.sleep(10.milliseconds) *> log("release 2"))(_ => IO.unit[Void])
-            .fork
-      _ <- (ref.read <* IO.sleep[Void](1.millisecond)).doUntil(_.contains("start 1"))
-      _ <- f.interrupt(new RuntimeException("cancel"))
-      _ <- (ref.read <* IO.sleep[Void](1.millisecond)).doUntil(_.contains("release 2"))
-      l <- ref.read
-    } yield l) must_=== ("start 1" :: "release 1" :: "start 2" :: "release 2" :: Nil)
-  }
-
-  def testExitResultIsUsageResult_new =
     unsafePerformIO(IO.bracket(IO.unit[Throwable])(_ => IO.unit[Void])(_ => IO.point[Throwable, Int](42))) must_=== 42
 
-  def testBracketErrorInAcquisition_new =
+  def testBracketErrorInAcquisition =
     unsafePerformIO(IO.bracket(IO.fail[Throwable, Unit](ExampleError))(_ => IO.unit)(_ => IO.unit)) must
       (throwA(UnhandledError(ExampleError)))
 
-  def testBracketErrorInRelease_new =
+  def testBracketErrorInRelease =
     unsafePerformIO(IO.bracket(IO.unit[Void])(_ => IO.terminate(ExampleError))(_ => IO.unit[Void])) must
       (throwA(ExampleError))
 
-  def testBracketErrorInUsage_new =
+  def testBracketErrorInUsage =
     unsafePerformIO(IO.bracket(IO.unit[Throwable])(_ => IO.unit)(_ => IO.fail[Throwable, Unit](ExampleError))) must
       (throwA(UnhandledError(ExampleError)))
 
-  def testBracketRethrownCaughtErrorInAcquisition_new = {
+  def testBracketRethrownCaughtErrorInAcquisition = {
     lazy val actual = unsafePerformIO(
       IO.absolve(IO.bracket(IO.fail[Throwable, Unit](ExampleError))(_ => IO.unit)(_ => IO.unit).attempt[Throwable])
     )
@@ -313,7 +234,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends Specification with AroundTimeou
     actual must (throwA(UnhandledError(ExampleError)))
   }
 
-  def testBracketRethrownCaughtErrorInRelease_new = {
+  def testBracketRethrownCaughtErrorInRelease = {
     lazy val actual = unsafePerformIO(
       IO.bracket(IO.unit[Void])(_ => IO.terminate(ExampleError))(_ => IO.unit[Void])
     )
@@ -321,7 +242,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends Specification with AroundTimeou
     actual must (throwA(ExampleError))
   }
 
-  def testBracketRethrownCaughtErrorInUsage_new = {
+  def testBracketRethrownCaughtErrorInUsage = {
     lazy val actual = unsafePerformIO(
       IO.absolve(
         IO.bracket(IO.unit[Throwable])(_ => IO.unit)(_ => IO.fail[Throwable, Unit](ExampleError)).attempt[Throwable]
@@ -331,7 +252,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends Specification with AroundTimeou
     actual must (throwA(UnhandledError(ExampleError)))
   }
 
-  def testEvalOfAsyncAttemptOfFail_new = {
+  def testEvalOfAsyncAttemptOfFail = {
     val io1 = IO.bracket(IO.unit[Throwable])(_ => AsyncUnit[Void])(_ => asyncExampleError[Unit])
     val io2 = IO.bracket(AsyncUnit[Throwable])(_ => IO.unit)(_ => asyncExampleError[Unit])
 
@@ -341,7 +262,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends Specification with AroundTimeou
     unsafePerformIO(IO.absolve(io2.attempt[Throwable])) must (throwA(UnhandledError(ExampleError)))
   }
 
-  def testBracketRegression1_new = {
+  def testBracketRegression1 = {
     def makeLogger: IORef[List[String]] => String => IO[Void, Unit] =
       (ref: IORef[List[String]]) => (line: String) => ref.modify[Void](_ ::: List(line)).toUnit
 

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -800,7 +800,9 @@ object IO {
   )(release: (A, ExitResult[E, B]) => Infallible[Unit])(use: A => IO[E, B]): IO[E, B] =
     IORef[E, Option[(A, ExitResult[E, B])]](None).flatMap { m =>
       (for {
-        a <- acquire.flatMap(a => m.write[E](Some((a, ExitResult.Terminated(new Throwable)))).const(a)).uninterruptibly
+        a <- acquire
+              .flatMap(a => m.write[E](Some((a, ExitResult.Terminated(new Throwable("Interrupted fiber"))))).const(a))
+              .uninterruptibly
         b <- use(a).run.flatMap(
               r =>
                 m.write[E](Some((a, r))) *> (r match {

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -809,7 +809,7 @@ object IO {
                   case ExitResult.Terminated(t) => terminate[E, B](t)
                 })
             )
-      } yield b).ensuring(m.read.flatMap(_.fold(unit[Void]) { case (a, r) => release(a, r) }).uninterruptibly)
+      } yield b).ensuring(m.read.flatMap(_.fold(unit[Void]) { case (a, r) => release(a, r) }))
     }
 
   final def bracket[E, A, B](
@@ -819,7 +819,7 @@ object IO {
       (for {
         a <- acquire.flatMap(a => m.write[E](Some(a)).const(a)).uninterruptibly
         b <- use(a)
-      } yield b).ensuring(m.read.flatMap(_.fold(unit[Void])(release(_))).uninterruptibly)
+      } yield b).ensuring(m.read.flatMap(_.fold(unit[Void])(release(_))))
     }
 
   /**

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -795,6 +795,11 @@ object IO {
         } yield fiberA.zipWith(fiberAs)(_ :: _)
     }
 
+  /**
+   * Acquires a resource, do some work with it, and then release that resource. With `bracket0`
+   * not only is the acquired resource be cleaned up, the outcome of the computation is also
+   * reified for processing.
+   */
   final def bracket0[E, A, B](
     acquire: IO[E, A]
   )(release: (A, ExitResult[E, B]) => Infallible[Unit])(use: A => IO[E, B]): IO[E, B] =
@@ -814,6 +819,11 @@ object IO {
       } yield b).ensuring(m.read.flatMap(_.fold(unit[Void]) { case (a, r) => release(a, r) }))
     }
 
+  /**
+   * Acquires a resource, do some work with it, and then release that resource. `bracket`
+   * will release the resource no matter the outcome of the computation, and will
+   * re-throw any exception that occured in between.
+   */
   final def bracket[E, A, B](
     acquire: IO[E, A]
   )(release: A => Infallible[Unit])(use: A => IO[E, B]): IO[E, B] =

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -253,18 +253,6 @@ sealed abstract class IO[E, A] { self =>
     new IO.Ensuring(self, finalizer)
 
   /**
-   * Runs one of the specified cleanup actions if this action errors, providing the
-   * error to the cleanup action. The cleanup action will not be interrupted.
-   * Cleanup actions for handled and unhandled errors can be provided separately.
-   */
-  final def onError(cleanupT: Throwable => Infallible[Unit])(cleanupE: E => Infallible[Unit]): IO[E, A] =
-    IO.bracket(IO.unit[E]) {
-      case ExitResult.Failed(e)     => cleanupE(e)
-      case ExitResult.Terminated(t) => cleanupT(t)
-      case _                        => IO.unit
-    }(_ => self)
-
-  /**
    * Supervises this action, which ensures that any fibers that are forked by
    * the action are interrupted with the specified error when this action
    * completes.

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -800,7 +800,7 @@ object IO {
   )(release: (A, ExitResult[E, B]) => Infallible[Unit])(use: A => IO[E, B]): IO[E, B] =
     IORef[E, Option[(A, ExitResult[E, B])]](None).flatMap { m =>
       (for {
-        a <- acquire.uninterruptibly
+        a <- acquire.flatMap(a => m.write[E](Some((a, ExitResult.Terminated(new Throwable)))).const(a)).uninterruptibly
         b <- use(a).run.flatMap(
               r =>
                 m.write[E](Some((a, r))) *> (r match {

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -248,6 +248,12 @@ sealed abstract class IO[E, A] { self =>
   final def ensuring(finalizer: Infallible[Unit]): IO[E, A] =
     new IO.Ensuring(self, finalizer)
 
+  /**	
+   * Executes the release action only if there was an error.	
+   */
+  final def bracketOnError[B](release: A => Infallible[Unit])(use: A => IO[E, B]): IO[E, B] =
+    IO.bracket0(this)((a: A, _: ExitResult[E, B]) => release(a))(use)
+
   /**
    * Runs one of the specified cleanup actions if this action errors, providing the
    * error to the cleanup action. The cleanup action will not be interrupted.

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -778,17 +778,30 @@ object IO {
         } yield fiberA.zipWith(fiberAs)(_ :: _)
     }
 
+  final def bracket0[E, A, B](
+    acquire: IO[E, A]
+  )(release: (A, ExitResult[E, B]) => Infallible[Unit])(use: A => IO[E, B]): IO[E, B] =
+    IORef[E, Option[(A, ExitResult[E, B])]](None).flatMap { m =>
+      (for {
+        a <- acquire.uninterruptibly
+        b <- use(a).run.flatMap(
+              r =>
+                m.write[E](Some((a, r))) *> (r match {
+                  case ExitResult.Completed(b)  => IO.now(b)
+                  case ExitResult.Failed(e)     => fail[E, B](e)
+                  case ExitResult.Terminated(t) => terminate[E, B](t)
+                })
+            )
+      } yield b).ensuring(m.read.flatMap(_.fold(unit[Void]) { case (a, r) => release(a, r) }).uninterruptibly)
+    }
+
   final def bracket[E, A, B](
     acquire: IO[E, A]
-  )(release: ExitResult[E, A] => Infallible[Unit])(use: A => IO[E, B]): IO[E, B] =
-    IORef[E, Option[ExitResult[E, A]]](None).flatMap { m =>
+  )(release: A => Infallible[Unit])(use: A => IO[E, B]): IO[E, B] =
+    IORef[E, Option[A]](None).flatMap { m =>
       (for {
-        er <- acquire.run.flatMap(er => m.write[E](Some(er)) *> point(er)).uninterruptibly
-        b <- er match {
-              case ExitResult.Completed(a)  => use(a)
-              case ExitResult.Failed(e)     => fail[E, B](e)
-              case ExitResult.Terminated(t) => terminate[E, B](t)
-            }
+        a <- acquire.flatMap(a => m.write[E](Some(a)).const(a)).uninterruptibly
+        b <- use(a)
       } yield b).ensuring(m.read.flatMap(_.fold(unit[Void])(release(_))).uninterruptibly)
     }
 

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -224,22 +224,22 @@ sealed abstract class IO[E, A] { self =>
    * }
    * }}}
    */
-  final def bracket[B](release: A => Infallible[Unit])(use: A => IO[E, B]): IO[E, B] =
-    new IO.Bracket(this, (_: ExitResult[E, B], a: A) => release(a), use)
+  // final def bracket[B](release: A => Infallible[Unit])(use: A => IO[E, B]): IO[E, B] =
+  //   new IO.Bracket(this, (_: ExitResult[E, B], a: A) => release(a), use)
 
   /**
    * A more powerful version of `bracket` that provides information on whether
    * or not `use` succeeded to the release action.
    */
-  final def bracket0[B](release: (ExitResult[E, B], A) => Infallible[Unit])(use: A => IO[E, B]): IO[E, B] =
-    new IO.Bracket(this, release, use)
+  // final def bracket0[B](release: (ExitResult[E, B], A) => Infallible[Unit])(use: A => IO[E, B]): IO[E, B] =
+  //   new IO.Bracket(this, release, use)
 
   /**
    * A less powerful variant of `bracket` where the value produced by this
    * action is not needed.
    */
-  final def bracket_[B](release: Infallible[Unit])(use: IO[E, B]): IO[E, B] =
-    self.bracket(_ => release)(_ => use)
+  // final def bracket_[B](release: Infallible[Unit])(use: IO[E, B]): IO[E, B] =
+  //   self.bracket(_ => release)(_ => use)
 
   /**
    * Executes the specified finalizer, whether this action succeeds, fails, or
@@ -251,31 +251,31 @@ sealed abstract class IO[E, A] { self =>
   /**
    * Executes the release action only if there was an error.
    */
-  final def bracketOnError[B](release: A => Infallible[Unit])(use: A => IO[E, B]): IO[E, B] =
-    bracket0(
-      (r: ExitResult[E, B], a: A) =>
-        r match {
-          case ExitResult.Failed(_)     => release(a)
-          case ExitResult.Terminated(_) => release(a)
-          case _                        => IO.unit
-      }
-    )(use)
+  // final def bracketOnError[B](release: A => Infallible[Unit])(use: A => IO[E, B]): IO[E, B] =
+  //   bracket0(
+  //     (r: ExitResult[E, B], a: A) =>
+  //       r match {
+  //         case ExitResult.Failed(_)     => release(a)
+  //         case ExitResult.Terminated(_) => release(a)
+  //         case _                        => IO.unit
+  //     }
+  //   )(use)
 
   /**
    * Runs one of the specified cleanup actions if this action errors, providing the
    * error to the cleanup action. The cleanup action will not be interrupted.
    * Cleanup actions for handled and unhandled errors can be provided separately.
    */
-  final def onError(cleanupT: Throwable => Infallible[Unit])(cleanupE: E => Infallible[Unit]): IO[E, A] =
-    IO.unit[E]
-      .bracket0(
-        (r: ExitResult[E, A], a: Unit) =>
-          r match {
-            case ExitResult.Failed(e)     => cleanupE(e)
-            case ExitResult.Terminated(t) => cleanupT(t)
-            case _                        => IO.unit
-        }
-      )(_ => self)
+  // final def onError(cleanupT: Throwable => Infallible[Unit])(cleanupE: E => Infallible[Unit]): IO[E, A] =
+  //   IO.unit[E]
+  //     .bracket0(
+  //       (r: ExitResult[E, A], a: Unit) =>
+  //         r match {
+  //           case ExitResult.Failed(e)     => cleanupE(e)
+  //           case ExitResult.Terminated(t) => cleanupT(t)
+  //           case _                        => IO.unit
+  //       }
+  //     )(_ => self)
 
   /**
    * Supervises this action, which ensures that any fibers that are forked by
@@ -526,14 +526,13 @@ object IO {
     final val Fork            = 8
     final val Race            = 9
     final val Suspend         = 10
-    final val Bracket         = 11
-    final val Uninterruptible = 12
-    final val Sleep           = 13
-    final val Supervise       = 14
-    final val Terminate       = 15
-    final val Supervisor      = 16
-    final val Run             = 17
-    final val Ensuring        = 18
+    final val Uninterruptible = 11
+    final val Sleep           = 12
+    final val Supervise       = 13
+    final val Terminate       = 14
+    final val Supervisor      = 15
+    final val Run             = 16
+    final val Ensuring        = 17
   }
   final class FlatMap[E, A0, A] private[IO] (val io: IO[E, A0], val flatMapper: A0 => IO[E, A]) extends IO[E, A] {
     override def tag = Tags.FlatMap
@@ -590,13 +589,6 @@ object IO {
 
   final class Suspend[E, A] private[IO] (val value: () => IO[E, A]) extends IO[E, A] {
     override def tag = Tags.Suspend
-  }
-
-  final class Bracket[E, A, B] private[IO] (val acquire: IO[E, A],
-                                            val release: (ExitResult[E, B], A) => Infallible[Unit],
-                                            val use: A => IO[E, B])
-      extends IO[E, B] {
-    override def tag = Tags.Bracket
   }
 
   final class Uninterruptible[E, A] private[IO] (val io: IO[E, A]) extends IO[E, A] {


### PR DESCRIPTION
One test is failing ~~I assume because of #68~~ . I removed `io.bracketOnError` because it ended up being the same as `io.bracket`.

@jdegoes I now realise the release action in `bracket0` had an additional parameter, that assumed the acquiring computation went through. 