### PR TITLE
Relax `IO.forkAll` to accept any traversable structure

### DIFF
--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -795,7 +795,7 @@ object IO {
   final def forkAll[E, A, M[X] <: TraversableOnce[X]](
     as: M[IO[E, A]]
   )(implicit cbf: CanBuildFrom[M[IO[E, A]], A, M[A]]): IO[E, Fiber[E, M[A]]] =
-    as.foldRight(point[E, Fiber[E, mutable.Builder[A, M[A]]]](Fiber.point(cbf(as)))) {
+    as.foldRight(IO.point[E, Fiber[E, mutable.Builder[A, M[A]]]](Fiber.point(cbf(as)))) {
         case (a, as) => as.par(a.fork).map { case (as, a) => as.zipWith(a)(_ += _) }
       }
       .map(as => as.zipWith(Fiber.point(())) { case (as, _) => as.result })

--- a/core/shared/src/main/scala/scalaz/zio/IOQueue.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IOQueue.scala
@@ -86,7 +86,7 @@ class IOQueue[A] private (capacity: Int, ref: IORef[State[A]]) {
     IO.flatten(ref.modifyFold[E, IO[E, Boolean]] {
       case Deficit(takers) if takers.nonEmpty =>
         // TODO: use the composite fiber
-        val forked: IO[E, Unit] = IO.forkAll(takers.toList.map(_.interrupt[E](t))).toUnit
+        val forked: IO[E, Unit] = IO.forkAll(takers.map(_.interrupt[E](t))).toUnit
         (forked.const(true), Deficit(Queue.empty[Promise[_, A]]))
       case s =>
         (IO.now(false), s)
@@ -101,7 +101,7 @@ class IOQueue[A] private (capacity: Int, ref: IORef[State[A]]) {
     IO.flatten(ref.modifyFold[E, IO[E, Boolean]] {
       case Surplus(_, putters) if putters.nonEmpty =>
         // TODO: use the composite fiber
-        val forked: IO[E, Unit] = IO.forkAll(putters.toList.map(_._2.interrupt[E](t))).toUnit
+        val forked: IO[E, Unit] = IO.forkAll(putters.map(_._2.interrupt[E](t))).toUnit
         (forked.const(true), Deficit(Queue.empty[Promise[_, A]]))
       case s =>
         (IO.now(false), s)


### PR DESCRIPTION
I noticed `forkAll` was the only primitive that only worked on `List[A]`. There's at least [one spot](https://github.com/scalaz/scalaz-zio/pull/65/files#diff-45be27ecd553cdc2afb69a47234eacdaR113) in this library where it is not optimal.