### PR TITLE
Move `Task` alias to `interop`

### DIFF
--- a/core/shared/src/main/scala/scalaz/zio/package.scala
+++ b/core/shared/src/main/scala/scalaz/zio/package.scala
@@ -18,8 +18,6 @@ package object zio {
     def widenError[E2 >: E]: IO[E2, A] = io.asInstanceOf[IO[E2, A]]
   }
 
-  type Task[A] = IO[Throwable, A]
-
   type Infallible[A] = IO[Void, A]
 
   type Canceler     = Throwable => Unit

--- a/interop/jvm/src/test/scala/scalaz/zio/interop/Fs2ZioSpec.scala
+++ b/interop/jvm/src/test/scala/scalaz/zio/interop/Fs2ZioSpec.scala
@@ -1,4 +1,5 @@
-package scalaz.zio.interop
+package scalaz.zio
+package interop
 
 import scala.concurrent.duration._
 
@@ -12,8 +13,8 @@ class ZioWithFs2Spec(implicit ee: ExecutionEnv) extends Specification with Aroun
 
   def is = s2"""
   A simple fs2 join must
-    work if `F` is `cats.effect.IO`  ${simpleJoin(fIsCats)}
-    work if `F` is `scalaz.zio.Task` ${simpleJoin(fIsZio)}
+    work if `F` is `cats.effect.IO`          ${simpleJoin(fIsCats)}
+    work if `F` is `scalaz.zio.interop.Task` ${simpleJoin(fIsZio)}
   """
 
   def simpleJoin(ints: => List[Int]) = upTo(2.seconds) {
@@ -24,7 +25,7 @@ class ZioWithFs2Spec(implicit ee: ExecutionEnv) extends Specification with Aroun
 
   def fIsZio: List[Int] = {
     import catz._
-    unsafePerformIO(testCaseJoin[scalaz.zio.Task])
+    unsafePerformIO(testCaseJoin[scalaz.zio.interop.Task])
   }
 
   def testCaseJoin[F[_]: Effect]: F[List[Int]] = {

--- a/interop/shared/src/main/scala/scalaz/zio/interop/package.scala
+++ b/interop/shared/src/main/scala/scalaz/zio/interop/package.scala
@@ -1,0 +1,7 @@
+package scalaz.zio
+
+package object interop {
+
+  type Task[A] = IO[Throwable, A]
+
+}


### PR DESCRIPTION
We don't want to encourage people to use ZIO in this way,
so this type alias is purely for interoperability with other
libs which don't support errors other than `Throwable`, hence
it should not be part of `core` but only of `interop`