### PR TITLE
Add `IO.bimap`

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/IOSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/IOSpec.scala
@@ -19,6 +19,8 @@ class IOSpec extends Specification with GenIO with RTS with ScalaCheck {
       `IO.traverse` fails with a NumberFormatException exception. $t3
    Create a list of Strings and pass an f: String => IO[String, Int]:
       `IO.parTraverse` returns the list of Ints in any order. $t4
+   Create an integer and an f: Int => String:
+      `IO.bimap(f, identity)` maps an IO[Int, String] into an IO[String, String]. $t5
    Check done lifts exit result into IO. $testDone
     """
 
@@ -50,6 +52,11 @@ class IOSpec extends Specification with GenIO with RTS with ScalaCheck {
     val list = List("1", "2", "3")
     val res  = unsafePerformIO(IO.parTraverse(list)(x => IO.point[String, Int](x.toInt)))
     res must containTheSameElementsAs(List(1, 2, 3))
+  }
+
+  def t5 = forAll { (i: Int) =>
+    val res = unsafePerformIO(IO.fail[Int, String](i).bimap(_.toString, identity).attempt)
+    res must_=== Left(i.toString)
   }
 
   def testDone = {

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -72,7 +72,7 @@ sealed abstract class IO[E, A] { self =>
   /**
    * Maps an `IO[E, A]` into an `IO[E2, B]` by applying the specified `E => E2` and
    * `A => B` functions to the output of this action. Repeated applications of `bimap`
-   * (`io.bimap(f1, g1).map(f2, g2)...map(f10000, g20000)`) are guaranteed stack safe to a depth
+   * (`io.bimap(f1, g1).bimap(f2, g2)...bimap(f10000, g20000)`) are guaranteed stack safe to a depth
    * of at least 10,000.
    */
   final def bimap[E2, B](f: E => E2, g: A => B): IO[E2, B] = (self.tag: @switch) match {

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -91,7 +91,7 @@ sealed abstract class IO[E, A] { self =>
 
       new IO.SyncEffect(() => g(io.effect()))
 
-    case IO.Tags.Fail => 
+    case IO.Tags.Fail =>
       val io = self.asInstanceOf[IO.Fail[E, A]]
 
       new IO.Fail(f(io.error))

--- a/interop/shared/src/main/scala/scalaz/zio/interop/scalaz72.scala
+++ b/interop/shared/src/main/scala/scalaz/zio/interop/scalaz72.scala
@@ -61,7 +61,7 @@ private class IOMonadPlus[E: Monoid] extends IOMonadError[E] with MonadPlus[IO[E
 
 private trait IOBifunctor extends Bifunctor[IO] {
   override def bimap[A, B, C, D](fab: IO[A, B])(f: A => C, g: B => D): IO[C, D] =
-    fab.leftMap(f).map(g)
+    fab.bimap(f, g)
 }
 
 private class IOParApplicative[E] extends Applicative[ParIO[E, ?]] {


### PR DESCRIPTION
I thought this would be useful when defining an efficient `Bifunctor`.