### PR TITLE
[DO NOT MERGE] [CONTROVERSIAL] More flexible `Effect` instance based on evidence for `E <=> Throwable` 

### DIFF
--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -103,10 +103,6 @@ trait RTS {
 }
 
 private object RTS {
-  // Utility function to avoid catching truly fatal exceptions. Do not allocate
-  // memory here since this would defeat the point of checking for OOME.
-  def nonFatal(t: Throwable): Boolean =
-    !t.isInstanceOf[InternalError] && !t.isInstanceOf[OutOfMemoryError]
 
   sealed trait RaceState
   object RaceState {

--- a/core/shared/src/main/scala/scalaz/zio/package.scala
+++ b/core/shared/src/main/scala/scalaz/zio/package.scala
@@ -22,4 +22,9 @@ package object zio {
 
   type Canceler     = Throwable => Unit
   type PureCanceler = Throwable => IO[Void, Unit]
+
+  // Utility function to avoid catching truly fatal exceptions. Do not allocate
+  // memory here since this would defeat the point of checking for OOME.
+  def nonFatal(t: Throwable): Boolean =
+    !t.isInstanceOf[InternalError] && !t.isInstanceOf[OutOfMemoryError]
 }

--- a/interop/jvm/src/main/scala/scalaz/zio/interop/catz.scala
+++ b/interop/jvm/src/main/scala/scalaz/zio/interop/catz.scala
@@ -5,17 +5,21 @@ import cats.effect
 import cats.effect.Effect
 import cats.syntax.all._
 
-import scala.util.control.NonFatal
-
 object catz extends RTS {
 
-  implicit val catsEffectInstance: Effect[Task] = new Effect[Task] {
+  case class FromToThrowable[E](to: E => Throwable, from: Throwable => Option[E])
+
+  object FromToThrowable {
+    implicit val IdFromToThrowable: FromToThrowable[Throwable] = FromToThrowable(identity, Some.apply)
+  }
+
+  implicit def catsEffectInstance[E](implicit ftt: FromToThrowable[E]): Effect[IO[E, ?]] = new Effect[IO[E, ?]] {
     def runAsync[A](
-      fa: Task[A]
+      fa: IO[E, A]
     )(cb: Either[Throwable, A] => effect.IO[Unit]): effect.IO[Unit] = {
-      val cbZ2C: ExitResult[Throwable, A] => Either[Throwable, A] = {
+      val cbZ2C: ExitResult[E, A] => Either[Throwable, A] = {
         case ExitResult.Completed(a)  => Right(a)
-        case ExitResult.Failed(t)     => Left(t)
+        case ExitResult.Failed(e)     => Left(ftt.to(e))
         case ExitResult.Terminated(t) => Left(t)
       }
       effect.IO {
@@ -25,36 +29,40 @@ object catz extends RTS {
       }.attempt.void
     }
 
-    def async[A](k: (Either[Throwable, A] => Unit) => Unit): Task[A] = {
-      val kk = k.compose[ExitResult[Throwable, A] => Unit] {
+    def async[A](k: (Either[Throwable, A] => Unit) => Unit): IO[E, A] = {
+      val kk = k.compose[ExitResult[E, A] => Unit] {
         _.compose[Either[Throwable, A]] {
-          case Left(t)  => ExitResult.Failed(t)
-          case Right(r) => ExitResult.Completed(r)
+          case Left(t) =>
+            ftt.from(t).fold[ExitResult[E, A]](ExitResult.Terminated(t))(ExitResult.Failed(_))
+          case Right(r) =>
+            ExitResult.Completed(r)
         }
       }
 
       IO.async(kk)
     }
 
-    def suspend[A](thunk: => Task[A]): Task[A] = IO.suspend(
+    def suspend[A](thunk: => IO[E, A]): IO[E, A] = IO.suspend(
       try {
         thunk
       } catch {
-        case NonFatal(e) => IO.fail(e)
+        case t: Throwable if nonFatal(t) =>
+          ftt.from(t).fold[IO[E, A]](IO.terminate(t))(IO.fail(_))
       }
     )
 
-    def raiseError[A](e: Throwable): Task[A] = IO.fail(e)
+    def raiseError[A](t: Throwable): IO[E, A] =
+      ftt.from(t).fold[IO[E, A]](IO.terminate(t))(IO.fail(_))
 
-    def handleErrorWith[A](fa: Task[A])(f: Throwable => Task[A]): Task[A] =
-      fa.catchAll(f)
+    def handleErrorWith[A](fa: IO[E, A])(f: Throwable => IO[E, A]): IO[E, A] =
+      fa.catchAll(f.compose(ftt.to))
 
-    def pure[A](x: A): Task[A] = IO.now(x)
+    def pure[A](x: A): IO[E, A] = IO.now(x)
 
-    def flatMap[A, B](fa: Task[A])(f: A => Task[B]): Task[B] = fa.flatMap(f)
+    def flatMap[A, B](fa: IO[E, A])(f: A => IO[E, B]): IO[E, B] = fa.flatMap(f)
 
     //LOL monad "law"
-    def tailRecM[A, B](a: A)(f: A => Task[Either[A, B]]): Task[B] =
+    def tailRecM[A, B](a: A)(f: A => IO[E, Either[A, B]]): IO[E, B] =
       f(a).flatMap {
         case Left(l)  => tailRecM(l)(f)
         case Right(r) => IO.now(r)


### PR DESCRIPTION
I really dislike the proliferation of `Task` all over the place in my code, in order to solve that i decided to try fixing my `F[_]` to `type MyIO[A] = IO[MyError, A]` but doing that the current instance for `Effect` fixed to `Throwable` does not resolve. This PR is to achieve that. WDYT?

I'm rolling my own `Iso` to avoid pulling scalaz just for this and cats doesn't seem to have one.