### PR TITLE
Retry with predicate on the error

### DIFF
--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -378,6 +378,11 @@ sealed abstract class IO[E, A] { self =>
    */
   final def retry: IO[E, A] = self orElse retry
 
+  final def retryIf(p: E => Boolean): IO[E, A] =
+    self.catchSome {
+      case e: Any if p(e.asInstanceOf[E]) => retryIf(p)
+    }
+
   /**
    * Retries this action the specified number of times, until the first success.
    * Note that the action will always be run at least once, even if `n < 1`.


### PR DESCRIPTION
A common thing to do when retrying is to check if the error is retriable. I implemented it only for one of the functions but if you think it's a good idea I can finish up the PR by implementing the other flavors of `retry` and add some docs and tests. If not, I can keep using it as a custom combinator.