### PR TITLE
Leverage typed errors in benchmarks

### DIFF
--- a/benchmarks/src/main/scala/scalaz/zio/IODeepAttemptBenchmark.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/IODeepAttemptBenchmark.scala
@@ -63,6 +63,16 @@ class IODeepAttemptBenchmark {
   }
 
   @Benchmark
+  def scalazDeepAttemptBaseline(): BigInt = {
+    def descend(n: Int): IO[Error, BigInt] =
+      if (n == depth) IO.fail(new Error("Oh noes!"))
+      else if (n == halfway) descend(n + 1).redeemPure[Error, BigInt](_ => 50, identity)
+      else descend(n + 1).map(_ + n)
+
+    unsafeRun(descend(0))
+  }
+
+  @Benchmark
   def catsDeepAttempt(): BigInt = {
     import cats.effect._
 

--- a/benchmarks/src/main/scala/scalaz/zio/IODeepAttemptBenchmark.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/IODeepAttemptBenchmark.scala
@@ -11,6 +11,8 @@ import IOBenchmarks._
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
 class IODeepAttemptBenchmark {
+  case class ScalazError(message: String)
+
   @Param(Array("1000"))
   var depth: Int = _
 
@@ -52,9 +54,9 @@ class IODeepAttemptBenchmark {
 
   @Benchmark
   def scalazDeepAttempt(): BigInt = {
-    def descend(n: Int): IO[Error, BigInt] =
-      if (n == depth) IO.fail(new Error("Oh noes!"))
-      else if (n == halfway) descend(n + 1).redeemPure[Error, BigInt](_ => 50, identity)
+    def descend(n: Int): IO[ScalazError, BigInt] =
+      if (n == depth) IO.fail(ScalazError("Oh noes!"))
+      else if (n == halfway) descend(n + 1).redeemPure[ScalazError, BigInt](_ => 50, identity)
       else descend(n + 1).map(_ + n)
 
     unsafePerformIO(descend(0))

--- a/benchmarks/src/main/scala/scalaz/zio/IOShallowAttemptBenchmark.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/IOShallowAttemptBenchmark.scala
@@ -67,6 +67,16 @@ class IOShallowAttemptBenchmark {
   }
 
   @Benchmark
+  def scalazShallowAttemptBaseline(): BigInt = {
+    def throwup(n: Int): IO[Error, BigInt] =
+      if (n == 0) throwup(n + 1).redeemPure[Error, BigInt](_ => 50, identity)
+      else if (n == depth) IO.point(1)
+      else throwup(n + 1).redeem[Error, BigInt](_ => IO.now(0), _ => IO.fail(new Error("Oh noes!")))
+
+    unsafeRun(throwup(0))
+  }
+
+  @Benchmark
   def catsShallowAttempt(): BigInt = {
     import cats.effect._
 

--- a/benchmarks/src/main/scala/scalaz/zio/IOShallowAttemptBenchmark.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/IOShallowAttemptBenchmark.scala
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 John A. De Goes. All rights reserved.
+// Copyright (C) 2017-2018 John A. De Goes. All rights reserved.
 package scalaz.zio
 
 import java.util.concurrent.TimeUnit
@@ -11,6 +11,8 @@ import IOBenchmarks._
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
 class IOShallowAttemptBenchmark {
+  case class ScalazError(message: String)
+
   @Param(Array("1000"))
   var depth: Int = _
 
@@ -56,10 +58,10 @@ class IOShallowAttemptBenchmark {
 
   @Benchmark
   def scalazShallowAttempt(): BigInt = {
-    def throwup(n: Int): IO[Error, BigInt] =
-      if (n == 0) throwup(n + 1).redeemPure[Error, BigInt](_ => 50, identity)
+    def throwup(n: Int): IO[ScalazError, BigInt] =
+      if (n == 0) throwup(n + 1).redeemPure[ScalazError, BigInt](_ => 50, identity)
       else if (n == depth) IO.point(1)
-      else throwup(n + 1).redeem[Error, BigInt](_ => IO.now(0), _ => IO.fail(new Error("Oh noes!")))
+      else throwup(n + 1).redeem[ScalazError, BigInt](_ => IO.now(0), _ => IO.fail(ScalazError("Oh noes!")))
 
     unsafePerformIO(throwup(0))
   }


### PR DESCRIPTION
The typed error channel in ZIO provides a way to use errors of any type—even types that do not extend `Throwable`. This is one of the major differentiating points between ZIO and other effect monads, and a compelling reason to choose ZIO over other approaches.

This pull request leverages ZIO's capability to use an ordinary case class for all errors in error handling benchmarks.