### PR TITLE
Import correct Void in usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Your main function can extend `IOApp`, which provides a complete runtime
 system and allows your entire program to be purely functional.
 
 ```scala
-import scalaz.zio.{IO, IOApp}
+import scalaz.zio.{IO, IOApp, Void}
 import scalaz.zio.console._
 
 import java.io.IOException

--- a/core/jvm/src/main/scala/scalaz/zio/IOApp.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/IOApp.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration.Duration
  *
  * {{{
  * import java.io.IOException
- * import scalaz.zio.{IO, IOApp}
+ * import scalaz.zio.{IO, IOApp, Void}
  * import scalaz.zio.console._
  *
  * object MyApp extends IOApp {


### PR DESCRIPTION
java.lang.Void is imported by default, causing an incompatibility error.