### PR TITLE
Test that IO.asyncPure terminates

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -66,6 +66,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends Specification with AroundTimeou
 
   RTS asynchronous correctness
     simple async must return                $testAsyncEffectReturns
+    simple asyncIO must return              $testAsyncIOEffectReturns
     sleep 0 must return                     ${upTo(1.second)(testSleepZeroReturns)}
 
   RTS concurrency correctness
@@ -353,6 +354,9 @@ class RTSSpec(implicit ee: ExecutionEnv) extends Specification with AroundTimeou
 
   def testAsyncEffectReturns =
     unsafeRun(IO.async[Throwable, Int](cb => cb(ExitResult.Completed(42)))) must_=== 42
+
+  def testAsyncIOEffectReturns =
+    unsafeRun(IO.asyncPure[Throwable, Int](cb => IO.sync(cb(ExitResult.Completed(42))))) must_=== 42
 
   def testSleepZeroReturns =
     unsafeRun(IO.sleep(1.nanoseconds)) must_=== ((): Unit)


### PR DESCRIPTION
I was on a 2 week old master and was bitten by https://github.com/scalaz/scalaz-zio/commit/8e55a4e46ec75eb933c51c2651226d1c6e1b7ac3

Took me awhile before figured it out. WDYT about adding a test on this?