### PR TITLE
Suppress stack traces from unhandled exceptions.

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/AbstractRTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/AbstractRTSSpec.scala
@@ -1,0 +1,13 @@
+package scalaz.zio
+
+import org.specs2.Specification
+
+trait AbstractRTSSpec extends Specification with RTS {
+  override def defaultHandler[E]: Throwable => IO[E, Unit] = {
+    case Errors.UnhandledError(_)      => IO.unit[E]
+    case Errors.TerminatedException(_) => IO.unit[E]
+    case Errors.LostRace(_)            => IO.unit[E]
+    case Errors.NothingRaced           => IO.unit[E]
+    case e                             => IO sync Console.err.println(s"""[info] Discarding ${e.getClass.getName} ("${e.getMessage}")""")
+  }
+}

--- a/core/jvm/src/test/scala/scalaz/zio/IOSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/IOSpec.scala
@@ -1,13 +1,12 @@
 package scalaz.zio
 
 import org.scalacheck._
-import org.specs2.Specification
 import org.specs2.ScalaCheck
 import scalaz.zio.ExitResult.{ Completed, Failed, Terminated }
 
 import scala.util.Try
 
-class IOSpec extends Specification with GenIO with RTS with ScalaCheck {
+class IOSpec extends AbstractRTSSpec with GenIO with ScalaCheck {
   import Prop.forAll
 
   def is = "IOSpec".title ^ s2"""

--- a/core/jvm/src/test/scala/scalaz/zio/KleisliIOSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/KleisliIOSpec.scala
@@ -1,10 +1,8 @@
 package scalaz.zio
 
-import org.specs2.Specification
-
 import KleisliIO._
 
-class KleisliIOSpec extends Specification with RTS {
+class KleisliIOSpec extends AbstractRTSSpec {
   def is = "KleisliIOSpec".title ^ s2"""
    Check if the functions in `KleisliIO` work correctly
      `lift` lifts from A => B into effectful function $e1

--- a/core/jvm/src/test/scala/scalaz/zio/PromiseSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/PromiseSpec.scala
@@ -1,8 +1,6 @@
 package scalaz.zio
 
-import org.specs2.Specification
-
-class PromiseSpec extends Specification with RTS {
+class PromiseSpec extends AbstractRTSSpec {
 
   def is = "PromiseSpec".title ^ s2"""
         Make a promise and retrieve its value correctly after complete it with:

--- a/core/jvm/src/test/scala/scalaz/zio/QueueSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/QueueSpec.scala
@@ -1,13 +1,12 @@
 package scalaz.zio
 
-import org.specs2.Specification
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.specification.AroundTimeout
 
 import scala.collection.immutable.Range
 import scala.concurrent.duration._
 
-class QueueSpec(implicit ee: ExecutionEnv) extends Specification with AroundTimeout with RTS {
+class QueueSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec with AroundTimeout {
 
   def is =
     "QueueSpec".title ^ s2"""

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -6,14 +6,11 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import scala.concurrent.duration._
 import org.specs2.concurrent.ExecutionEnv
-import org.specs2.Specification
 import org.specs2.specification.AroundTimeout
 import Errors.UnhandledError
 import com.github.ghik.silencer.silent
 
-class RTSSpec(implicit ee: ExecutionEnv) extends Specification with AroundTimeout with RTS {
-
-  override def defaultHandler[E]: Throwable => IO[E, Unit] = _ => IO.unit[E]
+class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec with AroundTimeout {
 
   def is = s2"""
   RTS synchronous correctness

--- a/core/jvm/src/test/scala/scalaz/zio/RefSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RefSpec.scala
@@ -1,8 +1,6 @@
 package scalaz.zio
 
-import org.specs2.Specification
-
-class RefSpec extends Specification with RTS {
+class RefSpec extends AbstractRTSSpec {
 
   def is = "RefSpec".title ^ s2"""
    Create a new Ref with a specified value and check if:

--- a/interop/jvm/src/test/scala/scalaz/zio/interop/futureSpec.scala
+++ b/interop/jvm/src/test/scala/scalaz/zio/interop/futureSpec.scala
@@ -3,12 +3,11 @@ package interop
 
 import scala.concurrent.Future
 
-import org.specs2.Specification
 import org.specs2.concurrent.ExecutionEnv
 
 import future._
 
-class futureSpec(implicit ee: ExecutionEnv) extends Specification with RTS {
+class futureSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec {
 
   def is = s2"""
   `IO.fromFuture` must

--- a/interop/jvm/src/test/scala/scalaz/zio/interop/scalaz72Spec.scala
+++ b/interop/jvm/src/test/scala/scalaz/zio/interop/scalaz72Spec.scala
@@ -2,14 +2,14 @@ package scalaz
 package zio
 package interop
 
-import org.specs2.{ ScalaCheck, Specification }
+import org.specs2.ScalaCheck
 import org.scalacheck.{ Arbitrary, Cogen }
 import scalaz.scalacheck.ScalazProperties._
 import Scalaz._
 
 import scalaz72._
 
-class scalaz72Spec extends Specification with ScalaCheck with GenIO with RTS {
+class scalaz72Spec extends AbstractRTSSpec with ScalaCheck with GenIO {
 
   def is = s2"""
     laws must hold for


### PR DESCRIPTION
What I'd like to accomplish is only suppressing the stack traces of unhandled exceptions which occur as a test is passing. So far I haven't found a satisfying and clean way to accomplish that, so submitting this PR for input, or in case it's desirable as-is.