### PR TITLE
Interop module docs. Closes #77

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ For performance reasons, fibers will attempt to execute on the same thread for a
 
 These defaults help guarantee stack safety and cooperative multitasking. They can be changed in `RTS` if automatic thread shifting is not desired.
 
-# ZIO in the wild
+# ZIO in the Wild
 
 In an ideal world ZIO would be the one and only effect system, but we live in this world and more often than not we have to interact with code using other libraries. `zio-interop` is the module enabling the necessary integrations to achieve that in a seamless manner. Read the docs for more details: [Interop Docs](interop/README.md)
 

--- a/README.md
+++ b/README.md
@@ -368,6 +368,16 @@ For performance reasons, fibers will attempt to execute on the same thread for a
 
 These defaults help guarantee stack safety and cooperative multitasking. They can be changed in `RTS` if automatic thread shifting is not desired.
 
+# ZIO in the wild
+
+In an ideal world ZIO would be the one and only effect system, but we live in this world and more often than not we have to interact with code using other libraries. `zio-interop` is the module enabling the necessary integrations to achieve that in a seamless manner. Read the docs for more details: [Interop Docs](interop/README.md)
+
+If you're using SBT, add the following line to your build file:
+
+```scala
+libraryDependencies += "org.scalaz" %% "scalaz-zio-interop" % "0.1-SNAPSHOT"
+```
+
 # Legal
 
 Copyright (C) 2017-2018 John A. De Goes. All rights reserved.

--- a/interop/README.md
+++ b/interop/README.md
@@ -1,0 +1,60 @@
+ZIO Interop module
+==================
+
+This module provides the following integrations:
+
+- `IO` conversions to and from stdlib's `Future`
+- `IO` instances for Scalaz 7.2.x typeclasses
+- `IO` instance for cats' `Effect` typeclass as required by Typelevel libs, such as `fs2`, `doobie` and `http4s`
+
+## Stdlib `Future`
+
+### From `Future`
+
+This is the extension method added to `IO` companion object:
+
+```scala
+def fromFuture[A](ftr: () => Future[A])(ec: ExecutionContext): IO[Throwable, A] =
+```
+
+There are a few things to clarify here:
+
+- `ftr`, the expression producing the `Future` value, is a *thunk* (or `Function0`). The reason for that is, `Future` is eager, it means as soon as you call `Future.apply` the effect has started performing, that's not a desired behavior in Pure FP (which ZIO encourages). So it's recommended to declare expressions creating `Future`s using `def` instead of `val`.
+- Also you have to be explicit on which EC you want to use, having it as implicit in stdlib is a bad practice we don't want to cargo cult.
+- Finally, as you can see, the `IO` returned fixes the error type to `Throwable` since that's the only possible cause for a failed `Future`.
+
+#### Example
+
+```scala
+// EC is not implicit
+val myEC: ExecutionContext = ...
+
+// future defined in thunk using def
+def myFuture: Future[ALotOfData] = myLegacyHeavyJobReturningFuture(...)
+val myIO: IO[Throwable, ALotOfData] = IO.fromFuture(myFuture _)(myEC)
+```
+
+### To `Future`
+
+This extension method is added to values of type `IO[Throwable, A]`:
+
+```scala
+def toFuture[E]: IO[E, Future[A]] =
+```
+
+Notice that we don't actually return a `Future` but an infallible `IO` producing the `Future` when it's performed, that's again because as soon as we have a `Future` in our hands, whatever it does is already happening.
+
+As an alternative, a more flexible extension method is added to any `IO[E, A]` to convert to `Future` as long as you can provide a function to convert from `E` to `Throwable`.
+
+```scala
+def toFutureE[E2](f: E => Throwable): IO[E2, Future[A]] = io.leftMap(f).toFuture
+```
+
+#### Example
+
+```scala
+val safeFuture: IO[Nothing, Future[MoarData]] = myShinyNewApiBasedOnZio(...).toFuture(MyError.toThrowable)
+val itsHappening: Future[MoarData] = unsafeRun(safeFuture)
+```
+
+

--- a/interop/README.md
+++ b/interop/README.md
@@ -39,7 +39,7 @@ val myIO: IO[Throwable, ALotOfData] = IO.fromFuture(myFuture _)(myEC)
 This extension method is added to values of type `IO[Throwable, A]`:
 
 ```scala
-def toFuture[E]: IO[E, Future[A]] =
+def toFuture: IO[Nothing, Future[A]]
 ```
 
 Notice that we don't actually return a `Future` but an infallible `IO` producing the `Future` when it's performed, that's again because as soon as we have a `Future` in our hands, whatever it does is already happening.
@@ -47,7 +47,7 @@ Notice that we don't actually return a `Future` but an infallible `IO` producing
 As an alternative, a more flexible extension method is added to any `IO[E, A]` to convert to `Future` as long as you can provide a function to convert from `E` to `Throwable`.
 
 ```scala
-def toFutureE[E2](f: E => Throwable): IO[E2, Future[A]] = io.leftMap(f).toFuture
+def toFutureE(f: E => Throwable): IO[Nothing, Future[A]]
 ```
 
 #### Example

--- a/interop/README.md
+++ b/interop/README.md
@@ -57,4 +57,40 @@ val safeFuture: IO[Nothing, Future[MoarData]] = myShinyNewApiBasedOnZio(...).toF
 val itsHappening: Future[MoarData] = unsafeRun(safeFuture)
 ```
 
+## Scalaz 7.2
+
+### `IO` Instances
+
+If you are a happy Scalaz 7.2 user `interop` module offers `IO` instances for several typeclasses, check out [the source code](shared/src/main/scala/scalaz/zio/interop/scalaz72.scala) for more details.
+
+#### Example
+
+```scala
+import scalaz._, Scalaz._
+import scalaz.zio.interop.scalaz72._
+
+def findUser(id: UserId): IO[UserError, User] = ...
+def findUsers(ids: IList[UserId]): IO[UserError, IList[User]] = ids.traverse(findUser)
+```
+
+### `IO` parallel `Applicative` instance
+
+Due to `Applicative` and `Monad` coherence law `IO`'s `Applicative` instance has to be implemented in terms of `bind` hence when composing multiple effects using `Applicative` they will be sequenced. To cope with that limitation `IO` tagged with `Parallel` has an `Applicative` instance which is not `Monad` and operates in parallel.
+
+#### Example
+
+```scala
+import scalaz._, Scalaz._, Tags.Parallel
+import scalaz.zio.interop.scalaz72._
+
+case class Dashboard(details: UserDetails, history: TransactionHistory)
+
+def getDetails(id: UserId): IO[UserError, UserDetails] = ...
+def getHistory(id: UserId): IO[UserError, TransactionHistory] = ...
+
+def buildDashboard(id: UserId): IO[UserError, Dashboard] =
+  Tag.unwrap(^(par(getDetails(id)), par(getHistory(id)))(Dashboard.apply))
+
+def par[E, A](io: IO[E, A]): IO[E, A] @@ Parallel = Tag(io)
+```
 

--- a/interop/jvm/src/test/scala/scalaz/zio/interop/futureSpec.scala
+++ b/interop/jvm/src/test/scala/scalaz/zio/interop/futureSpec.scala
@@ -62,7 +62,7 @@ class futureSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec {
 
   val toFuturePoly = {
     val unitIO: IO[Throwable, Unit]      = IO.unit
-    val polyIO: IO[String, Future[Unit]] = unitIO.toFuture[String]
+    val polyIO: IO[String, Future[Unit]] = unitIO.toFuture
     val _                                = polyIO // avoid warning
     ok
   }

--- a/interop/shared/src/main/scala/scalaz/zio/interop/future.scala
+++ b/interop/shared/src/main/scala/scalaz/zio/interop/future.scala
@@ -17,12 +17,12 @@ object future {
   }
 
   implicit class IOThrowableOps[A](private val io: IO[Throwable, A]) extends AnyVal {
-    def toFuture[E]: IO[E, Future[A]] =
-      io.redeemPure[E, Future[A]](Future.failed, Future.successful)
+    def toFuture: IO[Nothing, Future[A]] =
+      io.redeemPure(Future.failed, Future.successful)
   }
 
   implicit class IOOps[E, A](private val io: IO[E, A]) extends AnyVal {
-    def toFutureE[E2](f: E => Throwable): IO[E2, Future[A]] = io.leftMap(f).toFuture
+    def toFutureE(f: E => Throwable): IO[Nothing, Future[A]] = io.leftMap(f).toFuture
   }
 
 }


### PR DESCRIPTION
- Add introductory section in main README
- Add README in interop module folder
- Add docs about how to integrate with:
  -  stdlib's `Future`
  -  Scalaz 7.2
  - Typelevel libs
