### PR TITLE
Add sbt sonatype resolver to code example under Getting ZIO section in README. Fixes #153

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ Use `IO` because it's simply not practical to write real-world, correct software
 
 The current snapshot release of ZIO is 0.1, which is cross-built against Scala 2.11.x and 2.12.x.
 
-If you're using SBT, add the following line to your build file:
+If you're using SBT, add the following lines to your build file:
 
 ```scala
 libraryDependencies += "org.scalaz" %% "scalaz-zio" % "0.1-SNAPSHOT"
+
+resolvers += Resolver.sonatypeRepo("snapshots")
 ```
 For Maven and other build tools, you can visit <https://search.maven.org> and search for Scalaz.
 


### PR DESCRIPTION
Now it's not "The single line that will transform the way you write Scala applications", but it works and still transform the way you writ Scala applications :-)

The code sample now looks like this:

```scala
libraryDependencies += "org.scalaz" %% "scalaz-zio" % "0.1-SNAPSHOT"

resolvers += Resolver.sonatypeRepo("snapshots")
```

Fixes #153