### PR TITLE
add snapshot releases until we figure out a way to append commitSha on each build

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.0"
+version in ThisBuild := "0.1.0-SNAPSHOT"


### PR DESCRIPTION
this fix is to fix a broken build which is trying to release non-snapshot version to snapshot repo.

```bash
[error] (interopJS / publish) java.io.IOException: PUT operation to URL https://oss.sonatype.org/content/repositories/snapshots/org/scalaz/scalaz-zio-interop_sjs0.6_2.12/0.1.0/scalaz-zio-interop_sjs0.6_2.12-0.1.0.pom failed with status code 400: Bad Request
```

1) I could have done `isSnapshot in ThisBuild := false` which will then release to sonatype-releases repo but we have to find a way to append commitSha on each release otherwise it will fail on another build anyway. So, to prevent that I added `snapshot` version and let's publish to snapshot repo for a while.

2) Could have done `sbt "release with-defaults"` but we decided not to use release plugin for that purpose, so we are sticking with `sbt-publish`

Sorry @ktonga I know you are anti-snapshot :) but we have to have snapshot until we add commitSHA on each release.

@jdegoes Please review.