### PR TITLE
ISSUE#145 - add commitSHA on each dev builds instead of snapshots

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - export PATH=${PATH}:./vendor/bundle
 script:
   - sbt ++$TRAVIS_SCALA_VERSION scalafmtCheck test:scalafmtCheck scalafmtSbtCheck test
-  - sbt ++$TRAVIS_SCALA_VERSION publish
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then sbt ++$TRAVIS_SCALA_VERSION publish; fi
 env:
   global:
   - secure: "1KShGbny4TgD86w5/huvJEwcLYEQKjiUZeornS8W0rt8+j2emfFpb2VoyCfOQmXQrh0t5N96dS/hT0C+cDE0+/12rOE4zpm5RDDT7skY+ayTb3SKkIP9Qk5behvyIZi8xc5ny6z6UZoFBeTGJMZQgeuADhfcQHw68cZl4kEM9fU8L6Yc8jKUN6xTENnVpIDmM29Tbx/WyNA9EKw+1CL2fJVVLmvsQphieYoVjQfhZjl1+M289cZ+dX1UjsuvfrfwBTwFoabnZbQATZ9ALvwIfuOKYIdapS3rAayaKC7uihWZmCnNT4mmleob+zXdUjOWl/GXlHAgeCWU1GP7qZ65aLRx+URs/Vh+VAi5gXceF9Mka0VYMb/nm+noJIy9WLKa4kfnHruqR5NzxTq8D0xkgSa2v1tRCT7Vf98+RlzPTVF+rG/8lGa/nFoxqAkbB8ycTYSoAIswan4lx2PhD2GPWsCdiUBrMljPTr2ie88x45w4b5f5eZbsxc1qi2ks1oFTVJhk36l9+E+V8iFi3uZbs2x5Qfar7301mWwarcwfxt/CgDqSz4naWXyPfRbh9KwwFnjl2yEiYoPb0zU8eKhBid+JBi94gvlm2ykmHTYWD39govSgW69PSBoW8JROE10skpiLFsowe/U6FkVNA+tWavk/PNHPpHb4dlP63mbiOTU="

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - export PATH=${PATH}:./vendor/bundle
 script:
   - sbt ++$TRAVIS_SCALA_VERSION scalafmtCheck test:scalafmtCheck scalafmtSbtCheck test
-  - sbt ++$TRAVIS_SCALA_VERSION publish; fi
+  - sbt ++$TRAVIS_SCALA_VERSION publish
 env:
   global:
   - secure: "1KShGbny4TgD86w5/huvJEwcLYEQKjiUZeornS8W0rt8+j2emfFpb2VoyCfOQmXQrh0t5N96dS/hT0C+cDE0+/12rOE4zpm5RDDT7skY+ayTb3SKkIP9Qk5behvyIZi8xc5ny6z6UZoFBeTGJMZQgeuADhfcQHw68cZl4kEM9fU8L6Yc8jKUN6xTENnVpIDmM29Tbx/WyNA9EKw+1CL2fJVVLmvsQphieYoVjQfhZjl1+M289cZ+dX1UjsuvfrfwBTwFoabnZbQATZ9ALvwIfuOKYIdapS3rAayaKC7uihWZmCnNT4mmleob+zXdUjOWl/GXlHAgeCWU1GP7qZ65aLRx+URs/Vh+VAi5gXceF9Mka0VYMb/nm+noJIy9WLKa4kfnHruqR5NzxTq8D0xkgSa2v1tRCT7Vf98+RlzPTVF+rG/8lGa/nFoxqAkbB8ycTYSoAIswan4lx2PhD2GPWsCdiUBrMljPTr2ie88x45w4b5f5eZbsxc1qi2ks1oFTVJhk36l9+E+V8iFi3uZbs2x5Qfar7301mWwarcwfxt/CgDqSz4naWXyPfRbh9KwwFnjl2yEiYoPb0zU8eKhBid+JBi94gvlm2ykmHTYWD39govSgW69PSBoW8JROE10skpiLFsowe/U6FkVNA+tWavk/PNHPpHb4dlP63mbiOTU="

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - export PATH=${PATH}:./vendor/bundle
 script:
   - sbt ++$TRAVIS_SCALA_VERSION scalafmtCheck test:scalafmtCheck scalafmtSbtCheck test
-  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then sbt ++$TRAVIS_SCALA_VERSION publish; fi
+  - sbt ++$TRAVIS_SCALA_VERSION publish; fi
 env:
   global:
   - secure: "1KShGbny4TgD86w5/huvJEwcLYEQKjiUZeornS8W0rt8+j2emfFpb2VoyCfOQmXQrh0t5N96dS/hT0C+cDE0+/12rOE4zpm5RDDT7skY+ayTb3SKkIP9Qk5behvyIZi8xc5ny6z6UZoFBeTGJMZQgeuADhfcQHw68cZl4kEM9fU8L6Yc8jKUN6xTENnVpIDmM29Tbx/WyNA9EKw+1CL2fJVVLmvsQphieYoVjQfhZjl1+M289cZ+dX1UjsuvfrfwBTwFoabnZbQATZ9ALvwIfuOKYIdapS3rAayaKC7uihWZmCnNT4mmleob+zXdUjOWl/GXlHAgeCWU1GP7qZ65aLRx+URs/Vh+VAi5gXceF9Mka0VYMb/nm+noJIy9WLKa4kfnHruqR5NzxTq8D0xkgSa2v1tRCT7Vf98+RlzPTVF+rG/8lGa/nFoxqAkbB8ycTYSoAIswan4lx2PhD2GPWsCdiUBrMljPTr2ie88x45w4b5f5eZbsxc1qi2ks1oFTVJhk36l9+E+V8iFi3uZbs2x5Qfar7301mWwarcwfxt/CgDqSz4naWXyPfRbh9KwwFnjl2yEiYoPb0zU8eKhBid+JBi94gvlm2ykmHTYWD39govSgW69PSBoW8JROE10skpiLFsowe/U6FkVNA+tWavk/PNHPpHb4dlP63mbiOTU="

--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,7 @@ publishTo in ThisBuild := {
 }
 
 dynverSonatypeSnapshots in ThisBuild := true
+isSnapshot in ThisBuild := false
 
 lazy val sonataCredentials = for {
   username <- sys.env.get("SONATYPE_USERNAME")

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,6 @@
 // shadow sbt-scalajs' crossProject from Scala.js 0.6.x
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
 import Scalaz._
-import scala.sys.process.Process
-import ReleaseTransformations._
 
 organization in ThisBuild := "org.scalaz"
 
@@ -154,19 +152,3 @@ lazy val microsite = project.module
       "white-color"     -> "#FFFFFF"
     )
   )
-
-lazy val commitSha = Process("git rev-parse --short HEAD").lineStream.head
-
-releaseVersion := ((version: String) => s"$version-$commitSha")
-
-releaseTagName := s"v${version.value}"
-
-releaseProcess := Seq[ReleaseStep](
-  checkSnapshotDependencies,
-  inquireVersions,
-  runClean,
-  runTest,
-  setReleaseVersion,
-  tagRelease,
-  publishArtifacts
-)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.0-SNAPSHOT"
+version in ThisBuild := "0.1.0"

--- a/zio.sbt
+++ b/zio.sbt
@@ -1,0 +1,7 @@
+import scala.sys.process.Process
+
+lazy val commitSha = Process("git rev-parse --short HEAD").lineStream.head
+
+version in ThisBuild ~= { verzion =>
+  s"$verzion-$commitSha"
+}


### PR DESCRIPTION
1) **build dev artifacts** of formats `$version-$commitSha` using `sbt publish` (with the help of `sbt-DynVer` plugin). This is what CI/CD will do. Its definitely better than having snapshots.

2) **release artifact, commit/push tag**, set next version using `sbt "release release-version X.Y.Z next-version X.Y.Z+1 with-defaults"`. As discussed will be done by core zio maintainer.

The order of sbts is, 

```
[info] Loading settings from build.sbt,version.sbt,zio.sbt ...
```

The reason I introduced `zio.sbt` is to override version for dev builds only which will be read by sbt-DynVer. Actual version is read from `version.sbt` and appended commit sha for sbt-DynVer which is `sbt publish`

Hi @jdegoes and @ktonga please take a look and provide the feedbacks.