### PR TITLE
defects list in Terminated kept separatedly from termination causes

### DIFF
--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -20,8 +20,9 @@ trait RTS {
    */
   final def unsafeRun[E, A](io: IO[E, A]): A = unsafeRunSync(io) match {
     case ExitResult.Completed(v)       => v
-    case ExitResult.Terminated(Nil)    => throw Errors.TerminatedFiber
-    case ExitResult.Terminated(t :: _) => throw t
+    case ExitResult.Terminated(Nil, Nil)    => throw Errors.TerminatedFiber
+    case ExitResult.Terminated(Nil, t :: _) => throw t
+    case ExitResult.Terminated(t :: _, _) => throw t
     case ExitResult.Failed(e, ts)      => throw Errors.UnhandledError(e, ts)
   }
 
@@ -222,7 +223,7 @@ private object RTS {
 
     private final def collectDefect[E, A](e: ExitResult[E, A]): Option[List[Throwable]] =
       e match {
-        case ExitResult.Terminated(ts @ _ :: _) => Some(ts)
+        case ExitResult.Terminated(_, ts @ _ :: _) => Some(ts)
         case ExitResult.Failed(_, ts @ _ :: _)  => Some(ts)
         case _                                  => None
       }
@@ -459,8 +460,8 @@ private object RTS {
                                 if (curIo eq null) {
                                   result = value
                                 }
-                              case ExitResult.Terminated(ts) =>
-                                curIo = IO.terminate0(ts)
+                              case ExitResult.Terminated(ts, d) =>
+                                curIo = IO.terminate0(ts ++ d)
                               case ExitResult.Failed(e, _) =>
                                 curIo = IO.fail(e)
                             }
@@ -554,10 +555,10 @@ private object RTS {
                       // No finalizers, simply produce error:
                       val causes    = status.get.terminationCauses.getOrElse(Nil)
                       val defects   = status.get.defects
-                      val allCauses = io.causes ++ causes ++ defects
+                      val allCauses = io.causes ++ causes
 
                       curIo = null
-                      result = ExitResult.Terminated(allCauses)
+                      result = ExitResult.Terminated(allCauses, defects)
                     } else {
                       // Must run finalizers first before failing:
                       val finalization = finalizer.flatMap(accumFailures)
@@ -669,7 +670,7 @@ private object RTS {
 
         case ExitResult.Failed(t, _) => evaluate(IO.fail[E](t))
 
-        case ExitResult.Terminated(ts) => evaluate(IO.terminate0(ts))
+        case ExitResult.Terminated(ts, d) => evaluate(IO.terminate0(ts ++ d))
       }
 
     /**
@@ -945,9 +946,9 @@ private object RTS {
             rts.unsafeRun(unhandled(Errors.UnhandledError(error, defects) :: Nil))
           )
 
-        case ExitResult.Terminated(causes) =>
+        case ExitResult.Terminated(causes, defects) =>
           // Report the termination cause to the supervisor:
-          rts.submit(rts.unsafeRun(unhandled(causes)))
+          rts.submit(rts.unsafeRun(unhandled(causes ++ defects)))
 
         case _ =>
       }

--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -223,9 +223,10 @@ private object RTS {
 
     private final def collectDefect[E, A](e: ExitResult[E, A]): Option[List[Throwable]] =
       e match {
-        case ExitResult.Terminated(_, ts @ _ :: _) => Some(ts)
-        case ExitResult.Failed(_, ts @ _ :: _)     => Some(ts)
-        case _                                     => None
+        case ExitResult.Terminated(cs @ _ :: _, ts)  => Some(cs ++ ts)
+        case ExitResult.Terminated(Nil, ts @ _ :: _) => Some(ts)
+        case ExitResult.Failed(_, ts @ _ :: _)       => Some(ts)
+        case _                                       => None
       }
 
     /**

--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -19,11 +19,11 @@ trait RTS {
    * error, running forever, or producing an `A`.
    */
   final def unsafeRun[E, A](io: IO[E, A]): A = unsafeRunSync(io) match {
-    case ExitResult.Completed(v)       => v
+    case ExitResult.Completed(v)            => v
     case ExitResult.Terminated(Nil, Nil)    => throw Errors.TerminatedFiber
     case ExitResult.Terminated(Nil, t :: _) => throw t
-    case ExitResult.Terminated(t :: _, _) => throw t
-    case ExitResult.Failed(e, ts)      => throw Errors.UnhandledError(e, ts)
+    case ExitResult.Terminated(t :: _, _)   => throw t
+    case ExitResult.Failed(e, ts)           => throw Errors.UnhandledError(e, ts)
   }
 
   final def unsafeRunAsync[E, A](io: IO[E, A])(k: Callback[E, A]): Unit = {
@@ -224,8 +224,8 @@ private object RTS {
     private final def collectDefect[E, A](e: ExitResult[E, A]): Option[List[Throwable]] =
       e match {
         case ExitResult.Terminated(_, ts @ _ :: _) => Some(ts)
-        case ExitResult.Failed(_, ts @ _ :: _)  => Some(ts)
-        case _                                  => None
+        case ExitResult.Failed(_, ts @ _ :: _)     => Some(ts)
+        case _                                     => None
       }
 
     /**

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -36,6 +36,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec with AroundTime
     catch multiple causes                   $testEvalOfMultipleFail
     catch failing finalizers with fail      $testFailOfMultipleFailingFinalizers
     catch failing finalizers with terminate $testTerminateOfMultipleFailingFinalizers
+    catch finalizers with empty terminate   $testTerminate0OfMultipleFailingFinalizers
 
   RTS finalizers
     fail ensuring                           $testEvalOfFailEnsuring
@@ -198,7 +199,16 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec with AroundTime
         .ensuring(IO.sync(throw InterruptCause2))
         .ensuring(IO.sync(throw InterruptCause3))
         .run
-    ) must_=== ExitResult.Terminated(List(ExampleError, InterruptCause1, InterruptCause2, InterruptCause3))
+    ) must_=== ExitResult.Terminated(List(ExampleError), List(InterruptCause1, InterruptCause2, InterruptCause3))
+
+  def testTerminate0OfMultipleFailingFinalizers =
+    unsafeRun(
+      IO.terminate
+        .ensuring(IO.sync(throw InterruptCause1))
+        .ensuring(IO.sync(throw InterruptCause2))
+        .ensuring(IO.sync(throw InterruptCause3))
+        .run
+    ) must_=== ExitResult.Terminated(Nil, List(InterruptCause1, InterruptCause2, InterruptCause3))
 
   def testEvalOfFailEnsuring = {
     var finalized = false

--- a/core/shared/src/main/scala/scalaz/zio/ExitResult.scala
+++ b/core/shared/src/main/scala/scalaz/zio/ExitResult.scala
@@ -26,10 +26,12 @@ sealed trait ExitResult[+E, +A] { self =>
 
   final def failed: Boolean = !succeeded
 
-  final def fold[Z](completed: A => Z, failed: (E, List[Throwable]) => Z, interrupted: (List[Throwable], List[Throwable]) => Z): Z =
+  final def fold[Z](completed: A => Z,
+                    failed: (E, List[Throwable]) => Z,
+                    interrupted: (List[Throwable], List[Throwable]) => Z): Z =
     self match {
-      case Completed(v)  => completed(v)
-      case Failed(e, ts) => failed(e, ts)
+      case Completed(v)     => completed(v)
+      case Failed(e, ts)    => failed(e, ts)
       case Terminated(e, d) => interrupted(e, d)
     }
 }

--- a/core/shared/src/main/scala/scalaz/zio/ExitResult.scala
+++ b/core/shared/src/main/scala/scalaz/zio/ExitResult.scala
@@ -26,11 +26,11 @@ sealed trait ExitResult[+E, +A] { self =>
 
   final def failed: Boolean = !succeeded
 
-  final def fold[Z](completed: A => Z, failed: (E, List[Throwable]) => Z, interrupted: List[Throwable] => Z): Z =
+  final def fold[Z](completed: A => Z, failed: (E, List[Throwable]) => Z, interrupted: (List[Throwable], List[Throwable]) => Z): Z =
     self match {
       case Completed(v)  => completed(v)
       case Failed(e, ts) => failed(e, ts)
-      case Terminated(e) => interrupted(e)
+      case Terminated(e, d) => interrupted(e, d)
     }
 }
 object ExitResult {
@@ -46,5 +46,5 @@ object ExitResult {
    * `causes` accretes interruption causes and exceptions thrown during finalization:
    * first element in list = first failure, last element in list = last failure.
    */
-  final case class Terminated[E, A](causes: List[Throwable]) extends ExitResult[E, A]
+  final case class Terminated[E, A](causes: List[Throwable], defects: List[Throwable] = Nil) extends ExitResult[E, A]
 }

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -685,7 +685,7 @@ object IO {
    */
   final def done[E, A](r: ExitResult[E, A]): IO[E, A] = r match {
     case ExitResult.Completed(b)   => now(b)
-    case ExitResult.Terminated(ts) => terminate0(ts)
+    case ExitResult.Terminated(ts, d) => terminate0(ts ++ d)
     case ExitResult.Failed(e, _)   => fail(e)
   }
 

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -684,9 +684,9 @@ object IO {
    * Creates an `IO` value from `ExitResult`
    */
   final def done[E, A](r: ExitResult[E, A]): IO[E, A] = r match {
-    case ExitResult.Completed(b)   => now(b)
+    case ExitResult.Completed(b)      => now(b)
     case ExitResult.Terminated(ts, d) => terminate0(ts ++ d)
-    case ExitResult.Failed(e, _)   => fail(e)
+    case ExitResult.Failed(e, _)      => fail(e)
   }
 
   /**

--- a/interop/jvm/src/main/scala/scalaz/zio/interop/catz.scala
+++ b/interop/jvm/src/main/scala/scalaz/zio/interop/catz.scala
@@ -14,11 +14,11 @@ object catz extends RTS {
       fa: Task[A]
     )(cb: Either[Throwable, A] => effect.IO[Unit]): effect.IO[Unit] = {
       val cbZ2C: ExitResult[Throwable, A] => Either[Throwable, A] = {
-        case ExitResult.Completed(a)       => Right(a)
-        case ExitResult.Failed(t, _)       => Left(t)
+        case ExitResult.Completed(a)            => Right(a)
+        case ExitResult.Failed(t, _)            => Left(t)
         case ExitResult.Terminated(Nil, Nil)    => Left(Errors.TerminatedFiber)
         case ExitResult.Terminated(Nil, t :: _) => Left(t)
-        case ExitResult.Terminated(t :: _, _) => Left(t)
+        case ExitResult.Terminated(t :: _, _)   => Left(t)
       }
       effect.IO {
         unsafeRunAsync(fa) {

--- a/interop/jvm/src/main/scala/scalaz/zio/interop/catz.scala
+++ b/interop/jvm/src/main/scala/scalaz/zio/interop/catz.scala
@@ -16,8 +16,9 @@ object catz extends RTS {
       val cbZ2C: ExitResult[Throwable, A] => Either[Throwable, A] = {
         case ExitResult.Completed(a)       => Right(a)
         case ExitResult.Failed(t, _)       => Left(t)
-        case ExitResult.Terminated(Nil)    => Left(Errors.TerminatedFiber)
-        case ExitResult.Terminated(t :: _) => Left(t)
+        case ExitResult.Terminated(Nil, Nil)    => Left(Errors.TerminatedFiber)
+        case ExitResult.Terminated(Nil, t :: _) => Left(t)
+        case ExitResult.Terminated(t :: _, _) => Left(t)
       }
       effect.IO {
         unsafeRunAsync(fa) {


### PR DESCRIPTION
It may be nice to keep consistency and allow the user to easily distinguish between defects and causes when the evaluation terminates.

Also I'm curious what happens when computation succeds but bracket finalizers fail?
It seems logical to return the value computed. At the same time in case it happens user may wish to get a list of defects as well. So I think it may be a good idea to add defects list into `ExitStatus.Completed` as well. What do you think?