### PR TITLE
Add cats instances for generic IO[E, A]

### DIFF
--- a/interop-cats-laws/src/test/scala/scalaz/zio/interop/catzSpec.scala
+++ b/interop-cats-laws/src/test/scala/scalaz/zio/interop/catzSpec.scala
@@ -1,22 +1,22 @@
 package scalaz.zio
 package interop
 
-import java.io.{ByteArrayOutputStream, PrintStream}
+import java.io.{ ByteArrayOutputStream, PrintStream }
+
+import cats.Eq
+import cats.effect.laws.discipline.EffectTests
+import cats.effect.laws.util.{ TestContext, TestInstances }
+import cats.implicits._
+import cats.laws.discipline.{ AlternativeTests, BifunctorTests, MonadErrorTests, SemigroupKTests }
+import cats.syntax.all._
+import org.scalacheck.{ Arbitrary, Cogen }
+import org.scalatest.prop.Checkers
+import org.scalatest.{ FunSuite, Matchers }
+import org.typelevel.discipline.Laws
+import org.typelevel.discipline.scalatest.Discipline
+import scalaz.zio.interop.catz._
 
 import scala.util.control.NonFatal
-import cats.Eq
-import cats.implicits._
-import cats.syntax.all._
-import cats.effect.laws.discipline.EffectTests
-import org.typelevel.discipline.scalatest.Discipline
-import cats.effect.laws.util.{TestContext, TestInstances}
-import org.typelevel.discipline.Laws
-import org.scalatest.prop.Checkers
-import org.scalatest.{FunSuite, Matchers}
-import org.scalacheck.{Arbitrary, Cogen}
-import cats.laws.discipline.{BifunctorTests, MonadErrorTests, AlternativeTests, SemigroupKTests}
-
-import catz._
 
 class catzSpec extends FunSuite with Matchers with Checkers with Discipline with TestInstances with GenIO with RTS {
 

--- a/interop-cats-laws/src/test/scala/scalaz/zio/interop/catzSpec.scala
+++ b/interop-cats-laws/src/test/scala/scalaz/zio/interop/catzSpec.scala
@@ -1,23 +1,24 @@
 package scalaz.zio
 package interop
 
-import java.io.{ ByteArrayOutputStream, PrintStream }
-import scala.util.control.NonFatal
+import java.io.{ByteArrayOutputStream, PrintStream}
 
+import scala.util.control.NonFatal
 import cats.Eq
 import cats.implicits._
 import cats.syntax.all._
 import cats.effect.laws.discipline.EffectTests
 import org.typelevel.discipline.scalatest.Discipline
-import cats.effect.laws.util.{ TestContext, TestInstances }
+import cats.effect.laws.util.{TestContext, TestInstances}
 import org.typelevel.discipline.Laws
 import org.scalatest.prop.Checkers
-import org.scalatest.{ FunSuite, Matchers }
-import org.scalacheck.{ Arbitrary, Cogen }
+import org.scalatest.{FunSuite, Matchers}
+import org.scalacheck.{Arbitrary, Cogen}
+import cats.laws.discipline.{BifunctorTests, MonadErrorTests, AlternativeTests, SemigroupKTests}
 
 import catz._
 
-class catzSpec extends FunSuite with Matchers with Checkers with Discipline with TestInstances with GenIO {
+class catzSpec extends FunSuite with Matchers with Checkers with Discipline with TestInstances with GenIO with RTS {
 
   /**
    * Silences `System.err`, only printing the output in case exceptions are
@@ -55,14 +56,18 @@ class catzSpec extends FunSuite with Matchers with Checkers with Discipline with
   }
 
   checkAllAsync("Effect[Task]", implicit e => EffectTests[Task].effect[Int, Int, Int])
+  checkAllAsync("MonadError[IO[Int, ?]]", implicit e => MonadErrorTests[IO[Int, ?], Int].monadError[Int, Int, Int])
+  checkAllAsync("Alternative[IO[Int, ?]]", implicit e => AlternativeTests[IO[Int, ?]].alternative[Int, Int, Int])
+  checkAllAsync("SemigroupK[IO[Nothing, ?]]", implicit e => SemigroupKTests[IO[Nothing, ?]].semigroupK[Int])
+  checkAllAsync("Bifunctor[IO]", implicit e => BifunctorTests[IO].bifunctor[Int, Int, Int, Int, Int, Int])
 
-  implicit def catsEQ[A: Eq]: Eq[Task[A]] =
-    new Eq[Task[A]] {
-      def eqv(io1: Task[A], io2: Task[A]): Boolean =
+  implicit def catsEQ[E, A: Eq]: Eq[IO[E, A]] =
+    new Eq[IO[E, A]] {
+      def eqv(io1: IO[E, A], io2: IO[E, A]): Boolean =
         unsafeRun(io1.attempt) === unsafeRun(io2.attempt)
     }
 
-  implicit def ioArbitrary[A: Arbitrary: Cogen]: Arbitrary[Task[A]] =
-    Arbitrary(genSuccess[Throwable, A])
+  implicit def ioArbitrary[E, A: Arbitrary: Cogen]: Arbitrary[IO[E, A]] =
+    Arbitrary(genSuccess[E, A])
 
 }

--- a/interop/jvm/src/main/scala/scalaz/zio/interop/catz.scala
+++ b/interop/jvm/src/main/scala/scalaz/zio/interop/catz.scala
@@ -78,7 +78,7 @@ private class CatsMonadError[E] extends CatsMonad[E] with MonadError[IO[E, ?], E
   override def raiseError[A](e: E): IO[E, A]                                = IO.fail(e)
 }
 
-// lossy, throws away errors using the "first success" interpretation of Plus
+// lossy, throws away errors using the "first success" interpretation of SemigroupK
 private trait CatsSemigroupK[E] extends SemigroupK[IO[E, ?]] {
   override def combineK[A](a: IO[E, A], b: IO[E, A]): IO[E, A] = a.orElse(b)
 }

--- a/interop/jvm/src/main/scala/scalaz/zio/interop/catz.scala
+++ b/interop/jvm/src/main/scala/scalaz/zio/interop/catz.scala
@@ -3,63 +3,97 @@ package interop
 
 import cats.effect
 import cats.effect.Effect
-import cats.syntax.all._
+import cats._
+import cats.syntax.functor._
 
 import scala.util.control.NonFatal
 
-object catz extends RTS {
+object catz extends CatsInstances
 
-  implicit val catsEffectInstance: Effect[Task] = new Effect[Task] {
-    def runAsync[A](
-      fa: Task[A]
-    )(cb: Either[Throwable, A] => effect.IO[Unit]): effect.IO[Unit] = {
-      val cbZ2C: ExitResult[Throwable, A] => Either[Throwable, A] = {
-        case ExitResult.Completed(a)       => Right(a)
-        case ExitResult.Failed(t, _)       => Left(t)
-        case ExitResult.Terminated(Nil)    => Left(Errors.TerminatedFiber)
-        case ExitResult.Terminated(t :: _) => Left(t)
-      }
-      effect.IO {
-        unsafeRunAsync(fa) {
-          cb.compose(cbZ2C).andThen(_.unsafeRunAsync(_ => ()))
-        }
-      }.attempt.void
+abstract class CatsInstances extends CatsInstances1 {
+  implicit val taskEffectInstances: Effect[Task] with SemigroupK[Task] =
+    new CatsEffect with CatsSemigroupK[Throwable]
+}
+
+sealed abstract class CatsInstances1 extends CatsInstances2 {
+  implicit def ioMonoidInstances[E: Monoid]: MonadError[IO[E, ?], E] with Bifunctor[IO] with Alternative[IO[E, ?]] =
+    new CatsAlternative[E] with CatsBifunctor
+}
+
+sealed abstract class CatsInstances2 {
+  implicit def ioInstances[E]: MonadError[IO[E, ?], E] with Bifunctor[IO] with SemigroupK[IO[E, ?]] =
+    new CatsMonadError[E] with CatsSemigroupK[E] with CatsBifunctor
+}
+
+private class CatsEffect extends CatsMonadError[Throwable] with Effect[Task] with CatsSemigroupK[Throwable] with RTS {
+  def runAsync[A](
+    fa: Task[A]
+  )(cb: Either[Throwable, A] => effect.IO[Unit]): effect.IO[Unit] = {
+    val cbZ2C: ExitResult[Throwable, A] => Either[Throwable, A] = {
+      case ExitResult.Completed(a)       => Right(a)
+      case ExitResult.Failed(t, _)       => Left(t)
+      case ExitResult.Terminated(Nil)    => Left(Errors.TerminatedFiber)
+      case ExitResult.Terminated(t :: _) => Left(t)
     }
-
-    def async[A](k: (Either[Throwable, A] => Unit) => Unit): Task[A] = {
-      val kk = k.compose[ExitResult[Throwable, A] => Unit] {
-        _.compose[Either[Throwable, A]] {
-          case Left(t)  => ExitResult.Failed(t)
-          case Right(r) => ExitResult.Completed(r)
-        }
+    effect.IO {
+      unsafeRunAsync(fa) {
+        cb.compose(cbZ2C).andThen(_.unsafeRunAsync(_ => ()))
       }
-
-      IO.async(kk)
-    }
-
-    def suspend[A](thunk: => Task[A]): Task[A] = IO.suspend(
-      try {
-        thunk
-      } catch {
-        case NonFatal(e) => IO.fail(e)
-      }
-    )
-
-    def raiseError[A](e: Throwable): Task[A] = IO.fail(e)
-
-    def handleErrorWith[A](fa: Task[A])(f: Throwable => Task[A]): Task[A] =
-      fa.catchAll(f)
-
-    def pure[A](x: A): Task[A] = IO.now(x)
-
-    def flatMap[A, B](fa: Task[A])(f: A => Task[B]): Task[B] = fa.flatMap(f)
-
-    //LOL monad "law"
-    def tailRecM[A, B](a: A)(f: A => Task[Either[A, B]]): Task[B] =
-      f(a).flatMap {
-        case Left(l)  => tailRecM(l)(f)
-        case Right(r) => IO.now(r)
-      }
+    }.attempt.void
   }
 
+  def async[A](k: (Either[Throwable, A] => Unit) => Unit): Task[A] = {
+    val kk = k.compose[ExitResult[Throwable, A] => Unit] {
+      _.compose[Either[Throwable, A]] {
+        case Left(t)  => ExitResult.Failed(t)
+        case Right(r) => ExitResult.Completed(r)
+      }
+    }
+
+    IO.async(kk)
+  }
+
+  def suspend[A](thunk: => Task[A]): Task[A] = IO.suspend(
+    try {
+      thunk
+    } catch {
+      case NonFatal(e) => IO.fail(e)
+    }
+  )
+}
+
+private class CatsMonad[E] extends Monad[IO[E, ?]] {
+  override def pure[A](a: A): IO[E, A]                                 = IO.now(a)
+  override def map[A, B](fa: IO[E, A])(f: A => B): IO[E, B]            = fa.map(f)
+  override def flatMap[A, B](fa: IO[E, A])(f: A => IO[E, B]): IO[E, B] = fa.flatMap(f)
+  override def tailRecM[A, B](a: A)(f: A => IO[E, Either[A, B]]): IO[E, B] =
+    f(a).flatMap {
+      case Left(l)  => tailRecM(l)(f)
+      case Right(r) => IO.now(r)
+    }
+}
+
+private class CatsMonadError[E] extends CatsMonad[E] with MonadError[IO[E, ?], E] {
+  override def handleErrorWith[A](fa: IO[E, A])(f: E => IO[E, A]): IO[E, A] = fa.catchAll(f)
+  override def raiseError[A](e: E): IO[E, A]                                = IO.fail(e)
+}
+
+// lossy, throws away errors using the "first success" interpretation of Plus
+private trait CatsSemigroupK[E] extends SemigroupK[IO[E, ?]] {
+  override def combineK[A](a: IO[E, A], b: IO[E, A]): IO[E, A] = a.orElse(b)
+}
+
+private class CatsAlternative[E: Monoid] extends CatsMonadError[E] with Alternative[IO[E, ?]] {
+  override def combineK[A](a: IO[E, A], b: IO[E, A]): IO[E, A] =
+    a.catchAll { e1 =>
+      b.catchAll { e2 =>
+        IO.fail(Monoid[E].combine(e1, e2))
+      }
+    }
+  override def empty[A]: IO[E, A] = raiseError(Monoid[E].empty)
+}
+
+trait CatsBifunctor extends Bifunctor[IO] {
+  override def bimap[A, B, C, D](fab: IO[A, B])(f: A => C, g: B => D): IO[C, D] =
+    fab.bimap(f, g)
 }

--- a/interop/jvm/src/test/scala/scalaz/zio/interop/Fs2ZioSpec.scala
+++ b/interop/jvm/src/test/scala/scalaz/zio/interop/Fs2ZioSpec.scala
@@ -9,7 +9,7 @@ import org.specs2.concurrent.ExecutionEnv
 import org.specs2.Specification
 import org.specs2.specification.AroundTimeout
 
-class ZioWithFs2Spec(implicit ee: ExecutionEnv) extends Specification with AroundTimeout {
+class ZioWithFs2Spec(implicit ee: ExecutionEnv) extends Specification with AroundTimeout with RTS {
 
   def is = s2"""
   A simple fs2 join must


### PR DESCRIPTION
Copypasted from `scalaz.interop.scalaz72`, Added `MonadError`, `Alternative`, `Bifunctor` for non-Throwable `IO`

Also, `scalaz.interop.catz` object no longer inherits `RTS`