### PR TITLE
Stop caching JARs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,8 +77,6 @@ cache:
   - $HOME/.sbt/1.0/dependency
   - $HOME/.sbt/boot/scala*
   - $HOME/.sbt/launchers
-  - $HOME/.ivy2/cache
-  - $HOME/.coursier
   - $HOME/.rvm
 
 before_cache:


### PR DESCRIPTION
https://docs.travis-ci.com/user/caching/#things-not-to-cache

This should stop those cache corruptions that keep breaking our builds.