### PR TITLE
Fix `IO.raceAll`

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -492,15 +492,15 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec with AroundTime
     unsafeRun(IO.fail(24).race(IO.never).timeout[Option[Int]](None)(Option.apply)(10.milliseconds)) must beNone
 
   def testRaceAllOfValues =
-    unsafeRun(IO.raceAll[Int, Int](List(IO.fail(42), IO.now(24))).attempt) must_=== Right(24)
+    unsafeRun(IO.raceAll[Int, Int](IO.fail(42), List(IO.now(24))).attempt) must_=== Right(24)
 
   def testRaceAllOfFailures =
-    unsafeRun(IO.raceAll[Int, Nothing](List(IO.fail(24).delay(10.milliseconds), IO.fail(24))).attempt) must_=== Left(
+    unsafeRun(IO.raceAll[Int, Nothing](IO.fail(24).delay(10.milliseconds), List(IO.fail(24))).attempt) must_=== Left(
       24
     )
 
   def testRaceAllOfFailuresOneSuccess =
-    unsafeRun(IO.raceAll[Int, Int](List(IO.fail(42), IO.now(24).delay(1.milliseconds))).attempt) must_=== Right(
+    unsafeRun(IO.raceAll[Int, Int](IO.fail(42), List(IO.now(24).delay(1.milliseconds))).attempt) must_=== Right(
       24
     )
 

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -1045,15 +1045,11 @@ object IO {
     parTraverse(as)(identity)
 
   /**
-   * Races an `Iterable[IO[E, A]]` against each other. If all of
-   * them fail, the last error is returned.
-   *
-   * _Note_: if the collection is empty, there is no action that can either
-   * succeed or fail. Therefore, the only possible output is an IO action
-   * that never terminates.
+   * Races an `IO[E, A]` against elements of a `Iterable[IO[E, A]]`. Yields
+   * either the first success or the last failure.
    */
-  final def raceAll[E, A](t: Iterable[IO[E, A]]): IO[E, A] =
-    t.foldLeft[IO[E, A]](IO.never)(_ race _)
+  final def raceAll[E, A](io: IO[E, A], ios: Iterable[IO[E, A]]): IO[E, A] =
+    ios.foldLeft[IO[E, A]](io)(_ race _)
 
   /**
    * Reduces an `Iterable[IO]` to a single IO, works in parallel.


### PR DESCRIPTION
Closes #206 