### PR TITLE
Add `Resolver.sonatypeRepo("snapshots")` to Getting started doc.

### DIFF
--- a/microsite/src/main/tut/index.md
+++ b/microsite/src/main/tut/index.md
@@ -20,6 +20,7 @@ Pragmatic. The composable, orthogonal primitives necessary to build real world s
 Include ZIO in your project by adding the following to your `build.sbt`:
 
 ```tut:evaluated
+println(s"""resolvers += Resolver.sonatypeRepo("snapshots")""")
 println(s"""libraryDependencies += "org.scalaz" %% "scalaz-zio" % "${scalaz.zio.BuildInfo.version}"""")
 ```
 


### PR DESCRIPTION
`Getting started` section in microsite documentation was missing a necessary sonatype snapshot resolver. 

