### PR TITLE
Minor improvement to `FiberContext.runSync`

### DIFF
--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -204,9 +204,9 @@ private object RTS {
           result.set(v)
 
         case _ =>
-          while (result.get eq null) {
-            result.synchronized {
-              if (result.get eq null) result.wait()
+          result.synchronized {
+            while (result.get eq null) {
+              result.wait()
             }
           }
       }


### PR DESCRIPTION
This is probably not going to change much but [`Object.wait`](https://docs.oracle.com/javase/7/docs/api/java/lang/Object.html#wait(long)) deals with synchronization claims.