### PR TITLE
Cross-built artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,9 +45,9 @@ jobs:
       script: sbt ++$TRAVIS_SCALA_VERSION microsite/makeMicrosite
     - &release
       stage: release
-      name: "Release artifacts for 2.12"
+      name: "Release artifacts"
       before_script: export PGP_SECRET="$(<./project/zecret)"
-      script: sbt ++$TRAVIS_SCALA_VERSION ci-release
+      script: sbt ci-release || sbt sonatypeReleaseAll
     - &publishSite
       stage: publishMicrosite
       name: "Publish microsite"
@@ -64,9 +64,6 @@ jobs:
     - <<: *test
       scala: 2.11.12
       name: "Test for 2.11"
-    - <<: *release
-      scala: 2.11.12
-      name: "Release artifacts for 2.11"
 
 cache:
   directories:


### PR DESCRIPTION
As per https://github.com/olafurpg/sbt-ci-release#how-do-i-publish-cross-built-projects `ci-release` honors `crossScalaVersions`. Triggering it twice will fail the second time around because overwriting artifacts is not allowed.