### PR TITLE
Conditional snapshot resolver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
   )
   .enablePlugins(BuildInfoPlugin)
   .settings(
-    buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
+    buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion, isSnapshot),
     buildInfoPackage := "scalaz.zio",
     buildInfoObject := "BuildInfo"
   )

--- a/microsite/src/main/tut/index.md
+++ b/microsite/src/main/tut/index.md
@@ -20,7 +20,7 @@ Pragmatic. The composable, orthogonal primitives necessary to build real world s
 Include ZIO in your project by adding the following to your `build.sbt`:
 
 ```tut:evaluated
-println(s"""resolvers += Resolver.sonatypeRepo("snapshots")""")
+if (scalaz.zio.BuildInfo.isSnapshot) println(s"""resolvers += Resolver.sonatypeRepo("snapshots")""")
 println(s"""libraryDependencies += "org.scalaz" %% "scalaz-zio" % "${scalaz.zio.BuildInfo.version}"""")
 ```
 


### PR DESCRIPTION
Add `isSnapshot` to our `BuildInfo` object.
We can then use that to show/hide the snapshot resolver on the microsite