### PR TITLE
Fix inference problem for catchSome

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -175,7 +175,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec with AroundTime
   def testSandboxWithCatchSomeOfTerminate =
     unsafeRun(
       IO.sync[List[Throwable]](throw ExampleError)
-        .sandboxWith(_.catchSome[Either[List[Throwable], Nothing], List[Throwable]] { case Left(ts) => IO.now(ts) })
+        .sandboxWith(_.catchSome { case Left(ts) => IO.now(ts) })
     ) must_=== List(ExampleError)
 
   def testSandboxedTerminate =

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -373,8 +373,8 @@ sealed abstract class IO[+E, +A] { self =>
    * }
    * }}}
    */
-  final def catchSome[E1 >: E, A1 >: A](pf: PartialFunction[E1, IO[E1, A1]]): IO[E1, A1] = {
-    def tryRescue(t: E1): IO[E1, A1] = pf.applyOrElse(t, (_: E1) => IO.fail(t))
+  final def catchSome[E1 >: E, A1 >: A](pf: PartialFunction[E, IO[E1, A1]]): IO[E1, A1] = {
+    def tryRescue(t: E): IO[E1, A1] = pf.applyOrElse(t, (_: E) => IO.fail[E1](t))
 
     self.redeem[E1, A1](tryRescue, IO.now)
   }


### PR DESCRIPTION
No need to allow the catch partial function to have a an argument type `E1` more general than the error type `E`, because contravariance on the argument of PartialFunction will allow that anyway. Removing parametricity makes type inference  work. Type parameter `E1 >: E` is still required for returned error, because of covariance `IO[+E, ...]`  (and nice anyway), but not for the argument. 

Without the fix, if the explicit type parameters are removed in the test as done here, we get the same error message as reported in issue 164. 

fixes #164

Note: when omitting  the explicit `[E1`] in `IO.fail[E1](t)` in `tryRescue` – or when writing the more precise `E`, which should be the inferred type, the scala compiler or sbt crashes with an OutOfMemoryError: Metaspace. Please tell me if it is a known bug. Otherwise, I will try to investigate/report