### PR TITLE
Optimize Queues: avoid most linear traversals

### DIFF
--- a/core/shared/src/main/scala/scalaz/zio/Queue.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Queue.scala
@@ -157,6 +157,7 @@ object Queue {
     }
 
     final def ifNotDone[E, A](promise: Promise[E, A], action: Promise[E, A] => IO[E, Unit]): IO[E, Unit] =
-      promise.interrupt.flatMap(wasNotSet => if (wasNotSet) action(promise) else IO.unit)
+      promise.poll.void <> action(promise)
+
   }
 }


### PR DESCRIPTION
In class Queue, do not try the O(n) removal of a promise from the takers/putters IQueues if the promise has been completed, because then, we know that it has already been efficiently popped from the queue, or was never there in the first place.

The finalizer follows an IO which ends in p.get (this is inPromise.bracket). So it will run either after the promise has been set, or after the fiber running that code has been interrupted.

There are two way the promise may be set:

-  immediately in the call to offer/take if the Queue is not full/notempty. In that case, the promise is never queued, so there is no need to try to remove it
-  Later, when a call to the other method makes completion possible, e.g the queue was full when offer was called, and so the promise was queued. Now a call to take brings it back below capacity. Then the promised is popped from the queued, and set. Again, no need to try to remove it, it is not there any longer.

Only when the promise is not set is there a reason to remove it. And the finalizer (release) is called in such circumstances only when the calling fiber has been interrupted. We check that we are in that case
by calling interrupt of the promise. It should return true only if it is not set. If it returns false, it's a quick and harmless no-op. If it returns true, it has the side effect of interrupting the fiber waiting on this promise. However, that can only be the fiber calling offer/take:  the promise is an implementation detail of those methods and not seen outside, it cannot have been shared. As we know that this fiber is already interrupted,  that should be a ok too. 