### PR TITLE
Add method poll in Promise

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/PromiseSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/PromiseSpec.scala
@@ -17,6 +17,11 @@ class PromiseSpec extends AbstractRTSSpec {
           `done` to complete that promise with a terminated result.              $e6
           `interrupt` and interrupt all other fibers.                            $e7
 
+        Peek must return immediately:
+          None if the promise is not done yet. $e8
+          Some(value) if it is completed successfuly with value. $e9
+          the failure if it is failed. $e10
+
      """
 
   def e1 =
@@ -78,5 +83,31 @@ class PromiseSpec extends AbstractRTSSpec {
         p <- Promise.make[Exception, Int]
         s <- p.interrupt
       } yield s must beTrue
+    )
+
+  def e8 =
+    unsafeRun(
+      for {
+        p      <- Promise.make[String, Int]
+        option <- p.peek
+      } yield option must beNone
+    )
+
+  def e9 =
+    unsafeRun(
+      for {
+        p      <- Promise.make[String, Int]
+        _      <- p.complete(12)
+        option <- p.peek
+      } yield option must beSome(12)
+    )
+
+  def e10 =
+    unsafeRun(
+      for {
+        p             <- Promise.make[String, Int]
+        _             <- p.error("Failure")
+        attemptResult <- p.peek.attempt
+      } yield attemptResult must beLeft("Failure")
     )
 }

--- a/core/shared/src/main/scala/scalaz/zio/Promise.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Promise.scala
@@ -54,20 +54,14 @@ class Promise[E, A] private (private val state: AtomicReference[State[E, A]]) ex
     })
 
   /**
-   * Retrieves the value of the promise, inside an Option,
-   * if it is immediately available
-   * Otherwise completes  immediately with None
+   * Retrieves immediately the ExitResult of this promise if done
+   * and fails immediately with Unit otherwise
    */
-  final def peek: IO[E, Option[A]] =
-    IO.async0[E, Option[A]](_ => {
-      val currentState = state.get
-      Async.now[E, Option[A]](
-        currentState match {
-          case Pending(_)       => ExitResult.Completed(None)
-          case Done(exitResult) => exitResult.map(Some(_))
-        }
-      )
-    })
+  final def poll: IO[Unit, ExitResult[E, A]] =
+    IO.sync(state.get).flatMap {
+      case Pending(_)       => IO.fail(())
+      case Done(exitResult) => IO.now(exitResult)
+    }
 
   /**
    * Completes the promise with the specified value.
@@ -171,7 +165,7 @@ object Promise {
     for {
       pRef <- Ref[Option[(C, Promise[E, B])]](None)
       b <- (for {
-            p <- ref.modify { (a: A) =>
+            p <- ref.modify { a: A =>
                   val p = Promise.unsafeMake[E, B]
 
                   val (io, a2) = acquire(p, a)


### PR DESCRIPTION
Add `def peek: IO[E, Option[A]]` in class Promise. It behaves like get, excepts that it trades returning an option for not blocking. 

I write that after in #236, I  tried to do without it and have a confusing, even if possibly correct (not sure yet) implementation using interrupt just to check whether a Promise was completed. : 

Questions: 

- Is the feature desirable in `Promise`, or does it go against the intent of the class ? 
- Is the name `peek` ok? Other ideas: `getOption`, `getNow`, `nowOption`...
- The implementation uses `async0` while it always returns immediately. This is a bit strange. However it looked like the convenient way to go from an `ExitResult` to an `IO`. Is there a better way? 
- Does it need more testing? 