### PR TITLE
Use cats-effect-1.0.0, add Bracket[Task]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,7 +82,7 @@ lazy val interop = crossProject(JSPlatform, JVMPlatform)
   .settings(
     libraryDependencies ++= Seq(
       "org.scalaz"    %%% "scalaz-core"               % "7.2.+"  % Optional,
-      "org.typelevel" %%% "cats-effect"               % "0.10.1" % Optional,
+      "org.typelevel" %%% "cats-effect"               % "1.0.0"  % Optional,
       "org.scalaz"    %%% "scalaz-scalacheck-binding" % "7.2.+"  % Test,
       "co.fs2"        %%% "fs2-core"                  % "0.10.5" % Test
     ),
@@ -102,9 +102,9 @@ lazy val interopCatsLaws = project.module
   .settings(
     skip in publish := true,
     libraryDependencies ++= Seq(
-      "org.typelevel"              %% "cats-effect-laws"          % "0.10.1" % Test,
-      "org.typelevel"              %% "cats-testkit"              % "1.2.0"  % Test,
-      "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.8"  % Test
+      "org.typelevel"              %% "cats-effect-laws"          % "1.0.0" % Test,
+      "org.typelevel"              %% "cats-testkit"              % "1.3.1" % Test,
+      "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.8" % Test
     ),
     dependencyOverrides += "org.scalacheck" %% "scalacheck" % "1.13.5" % Test,
     scalacOptions in Test ++= Seq("-Yrangepos")
@@ -120,7 +120,7 @@ lazy val benchmarks = project.module
         "org.scala-lang" % "scala-reflect"  % scalaVersion.value,
         "org.scala-lang" % "scala-compiler" % scalaVersion.value % Provided,
         "io.monix"       %% "monix"         % "3.0.0-RC1",
-        "org.typelevel"  %% "cats-effect"   % "1.0.0-RC2"
+        "org.typelevel"  %% "cats-effect"   % "1.0.0"
       )
   )
 

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -461,8 +461,9 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec with AroundTime
   def testBracketAcquireIsUninterruptible = {
     val io =
       for {
-        fiber <- IO.bracket[Nothing, Unit, Unit](IO.never)(_ => IO.unit)(_ => IO.unit).fork
-        res   <- fiber.interrupt.timeout(42)(_ => 0)(1.second)
+        promise <- Promise.make[Nothing, Unit]
+        fiber <- IO.bracket[Nothing, Unit, Unit](promise.complete(()) *> IO.never)(_ => IO.unit)(_ => IO.unit).fork
+        res   <- promise.get *> fiber.interrupt.timeout(42)(_ => 0)(1.second)
       } yield res
     unsafeRun(io) must_=== 42
   }
@@ -470,8 +471,9 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec with AroundTime
   def testBracket0AcquireIsUninterruptible = {
     val io =
       for {
-        fiber <- IO.bracket0[Nothing, Unit, Unit](IO.never)((_, _) => IO.unit)(_ => IO.unit).fork
-        res   <- fiber.interrupt.timeout(42)(_ => 0)(1.second)
+        promise <- Promise.make[Nothing, Unit]
+        fiber <- IO.bracket0[Nothing, Unit, Unit](promise.complete(()) *> IO.never)((_, _) => IO.unit)(_ => IO.unit).fork
+        res   <- promise.get *> fiber.interrupt.timeout(42)(_ => 0)(1.second)
       } yield res
     unsafeRun(io) must_=== 42
   }

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -488,12 +488,13 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec with AroundTime
 
   def testAsyncIsInterruptible = {
     val io =
-      for {
-        fiber <- IO.async[Nothing, Nothing](_ => ()).fork
-        _     <- fiber.interrupt
-      } yield 42
+    for {
+      fiber <- IO.async[Nothing, Nothing](_ => ()).fork
+      _     <- fiber.interrupt
+    } yield 42
 
     unsafeRun(io) must_=== 42
+  }
 
   def testBracketUseIsInterruptible = {
     val io =

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -488,10 +488,10 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec with AroundTime
 
   def testAsyncIsInterruptible = {
     val io =
-    for {
-      fiber <- IO.async[Nothing, Nothing](_ => ()).fork
-      _     <- fiber.interrupt
-    } yield 42
+      for {
+        fiber <- IO.async[Nothing, Nothing](_ => ()).fork
+        _     <- fiber.interrupt
+      } yield 42
 
     unsafeRun(io) must_=== 42
   }

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -462,8 +462,8 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec with AroundTime
     val io =
       for {
         promise <- Promise.make[Nothing, Unit]
-        fiber <- IO.bracket[Nothing, Unit, Unit](promise.complete(()) *> IO.never)(_ => IO.unit)(_ => IO.unit).fork
-        res   <- promise.get *> fiber.interrupt.timeout(42)(_ => 0)(1.second)
+        fiber   <- IO.bracket[Nothing, Unit, Unit](promise.complete(()) *> IO.never)(_ => IO.unit)(_ => IO.unit).fork
+        res     <- promise.get *> fiber.interrupt.timeout(42)(_ => 0)(1.second)
       } yield res
     unsafeRun(io) must_=== 42
   }
@@ -472,8 +472,10 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec with AroundTime
     val io =
       for {
         promise <- Promise.make[Nothing, Unit]
-        fiber <- IO.bracket0[Nothing, Unit, Unit](promise.complete(()) *> IO.never)((_, _) => IO.unit)(_ => IO.unit).fork
-        res   <- promise.get *> fiber.interrupt.timeout(42)(_ => 0)(1.second)
+        fiber <- IO
+                  .bracket0[Nothing, Unit, Unit](promise.complete(()) *> IO.never)((_, _) => IO.unit)(_ => IO.unit)
+                  .fork
+        res <- promise.get *> fiber.interrupt.timeout(42)(_ => 0)(1.second)
       } yield res
     unsafeRun(io) must_=== 42
   }

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -1034,7 +1034,7 @@ object IO {
   final def bracket[E, A, B](
     acquire: IO[E, A]
   )(release: A => IO[Nothing, Unit])(use: A => IO[E, B]): IO[E, B] =
-    Ref[Option[A]](None).uninterruptibly.flatMap { m =>
+    Ref[Option[A]](None).flatMap { m =>
       (for {
         a <- acquire.flatMap(a => m.set(Some(a)).const(a)).uninterruptibly
         b <- use(a)

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -1013,7 +1013,7 @@ object IO {
   final def bracket0[E, A, B](
     acquire: IO[E, A]
   )(release: (A, ExitResult[E, B]) => IO[Nothing, Unit])(use: A => IO[E, B]): IO[E, B] =
-    Ref[Option[(A, ExitResult[E, B])]](None).flatMap { m =>
+    Ref[Option[(A, ExitResult[E, B])]](None).uninterruptibly.flatMap { m =>
       (for {
         r <- (for {
               a <- acquire
@@ -1033,7 +1033,7 @@ object IO {
   final def bracket[E, A, B](
     acquire: IO[E, A]
   )(release: A => IO[Nothing, Unit])(use: A => IO[E, B]): IO[E, B] =
-    Ref[Option[A]](None).flatMap { m =>
+    Ref[Option[A]](None).uninterruptibly.flatMap { m =>
       (for {
         a <- acquire.flatMap(a => m.set(Some(a)).const(a)).uninterruptibly
         b <- use(a)

--- a/interop-cats-laws/src/test/scala/scalaz/zio/interop/catzSpec.scala
+++ b/interop-cats-laws/src/test/scala/scalaz/zio/interop/catzSpec.scala
@@ -59,6 +59,7 @@ class catzSpec extends FunSuite with Matchers with Checkers with Discipline with
   checkAllAsync("Effect[Task]", implicit e => EffectTests[Task].effect[Int, Int, Int])
   checkAllAsync("MonadError[IO[Int, ?]]", implicit e => MonadErrorTests[IO[Int, ?], Int].monadError[Int, Int, Int])
   checkAllAsync("Alternative[IO[Int, ?]]", implicit e => AlternativeTests[IO[Int, ?]].alternative[Int, Int, Int])
+  checkAllAsync("Alternative[IO[Option[Unit], ?]]", implicit e => AlternativeTests[IO[Option[Unit], ?]].alternative[Int, Int, Int])
   checkAllAsync("SemigroupK[IO[Nothing, ?]]", implicit e => SemigroupKTests[IO[Nothing, ?]].semigroupK[Int])
   checkAllAsync("Bifunctor[IO]", implicit e => BifunctorTests[IO].bifunctor[Int, Int, Int, Int, Int, Int])
 

--- a/interop-cats-laws/src/test/scala/scalaz/zio/interop/catzSpec.scala
+++ b/interop-cats-laws/src/test/scala/scalaz/zio/interop/catzSpec.scala
@@ -4,7 +4,8 @@ package interop
 import java.io.{ ByteArrayOutputStream, PrintStream }
 
 import cats.Eq
-import cats.effect.laws.discipline.EffectTests
+import cats.effect.laws.discipline.{ EffectTests, Parameters }
+import cats.effect.laws.discipline.arbitrary._
 import cats.effect.laws.util.{ TestContext, TestInstances }
 import cats.implicits._
 import cats.laws.discipline.{ AlternativeTests, BifunctorTests, MonadErrorTests, SemigroupKTests }
@@ -66,6 +67,9 @@ class catzSpec extends FunSuite with Matchers with Checkers with Discipline with
       def eqv(io1: IO[E, A], io2: IO[E, A]): Boolean =
         unsafeRun(io1.attempt) === unsafeRun(io2.attempt)
     }
+
+  implicit def params: Parameters =
+    Parameters.default.copy(allowNonTerminationLaws = false)
 
   implicit def ioArbitrary[E, A: Arbitrary: Cogen]: Arbitrary[IO[E, A]] =
     Arbitrary(genSuccess[E, A])

--- a/interop-cats-laws/src/test/scala/scalaz/zio/interop/catzSpec.scala
+++ b/interop-cats-laws/src/test/scala/scalaz/zio/interop/catzSpec.scala
@@ -59,7 +59,8 @@ class catzSpec extends FunSuite with Matchers with Checkers with Discipline with
   checkAllAsync("Effect[Task]", implicit e => EffectTests[Task].effect[Int, Int, Int])
   checkAllAsync("MonadError[IO[Int, ?]]", implicit e => MonadErrorTests[IO[Int, ?], Int].monadError[Int, Int, Int])
   checkAllAsync("Alternative[IO[Int, ?]]", implicit e => AlternativeTests[IO[Int, ?]].alternative[Int, Int, Int])
-  checkAllAsync("Alternative[IO[Option[Unit], ?]]", implicit e => AlternativeTests[IO[Option[Unit], ?]].alternative[Int, Int, Int])
+  checkAllAsync("Alternative[IO[Option[Unit], ?]]",
+                implicit e => AlternativeTests[IO[Option[Unit], ?]].alternative[Int, Int, Int])
   checkAllAsync("SemigroupK[IO[Nothing, ?]]", implicit e => SemigroupKTests[IO[Nothing, ?]].semigroupK[Int])
   checkAllAsync("Bifunctor[IO]", implicit e => BifunctorTests[IO].bifunctor[Int, Int, Int, Int, Int, Int])
 

--- a/interop/jvm/src/main/scala/scalaz/zio/interop/catz.scala
+++ b/interop/jvm/src/main/scala/scalaz/zio/interop/catz.scala
@@ -72,6 +72,10 @@ private class CatsEffect extends CatsMonadError[Throwable] with Effect[Task] wit
       }
     )
 
+  override def bracket[A, B](acquire: Task[A])(use: A => Task[B])(
+    release: A => Task[Unit]
+  ): Task[B] = IO.bracket(acquire)(release(_).catchAll(IO.terminate(_)))(use)
+
   override def bracketCase[A, B](
     acquire: Task[A]
   )(use: A => Task[B])(release: (A, ExitCase[Throwable]) => Task[Unit]): Task[B] =

--- a/interop/jvm/src/main/scala/scalaz/zio/interop/catz.scala
+++ b/interop/jvm/src/main/scala/scalaz/zio/interop/catz.scala
@@ -85,6 +85,12 @@ private class CatsEffect extends CatsMonadError[Throwable] with Effect[Task] wit
       release(a, exitCase)
         .catchAll(IO.terminate(_))
     }(use)
+
+  override def uncancelable[A](fa: Task[A]): Task[A] =
+    fa.uninterruptibly
+
+  override def guarantee[A](fa: Task[A])(finalizer: Task[Unit]): Task[A] =
+    fa.ensuring(finalizer.catchAll(IO.terminate(_)))
 }
 
 private class CatsMonad[E] extends Monad[IO[E, ?]] {

--- a/interop/jvm/src/main/scala/scalaz/zio/interop/catz.scala
+++ b/interop/jvm/src/main/scala/scalaz/zio/interop/catz.scala
@@ -5,6 +5,8 @@ import cats.effect.{ Effect, ExitCase }
 import cats.syntax.functor._
 import cats.{ effect, _ }
 
+import scala.util.control.NonFatal
+
 object catz extends CatsInstances
 
 abstract class CatsInstances extends CatsInstances1 {
@@ -36,7 +38,7 @@ private class CatsEffect extends CatsMonadError[Throwable] with Effect[Task] wit
       unsafeRunAsync(fa) {
         cb.compose(cbZ2C).andThen(_.unsafeRunAsync(_ => ()))
       }
-    }.attempt.void
+    }.void
   }
 
   override def async[A](k: (Either[Throwable, A] => Unit) => Unit): Task[A] = {
@@ -66,7 +68,7 @@ private class CatsEffect extends CatsMonadError[Throwable] with Effect[Task] wit
       try {
         thunk
       } catch {
-        case t: Throwable => IO.fail(t)
+        case NonFatal(e) => IO.fail(e)
       }
     )
 

--- a/interop/jvm/src/main/scala/scalaz/zio/interop/catz.scala
+++ b/interop/jvm/src/main/scala/scalaz/zio/interop/catz.scala
@@ -1,18 +1,15 @@
 package scalaz.zio
 package interop
 
-import cats.effect
-import cats.effect.Effect
-import cats._
+import cats.effect.{ Effect, ExitCase }
 import cats.syntax.functor._
-
-import scala.util.control.NonFatal
+import cats.{ effect, _ }
 
 object catz extends CatsInstances
 
 abstract class CatsInstances extends CatsInstances1 {
   implicit val taskEffectInstances: Effect[Task] with SemigroupK[Task] =
-    new CatsEffect with CatsSemigroupK[Throwable]
+    new CatsEffect
 }
 
 sealed abstract class CatsInstances1 extends CatsInstances2 {
@@ -26,23 +23,23 @@ sealed abstract class CatsInstances2 {
 }
 
 private class CatsEffect extends CatsMonadError[Throwable] with Effect[Task] with CatsSemigroupK[Throwable] with RTS {
-  def runAsync[A](
+  override def runAsync[A](
     fa: Task[A]
-  )(cb: Either[Throwable, A] => effect.IO[Unit]): effect.IO[Unit] = {
+  )(cb: Either[Throwable, A] => effect.IO[Unit]): effect.SyncIO[Unit] = {
     val cbZ2C: ExitResult[Throwable, A] => Either[Throwable, A] = {
       case ExitResult.Completed(a)       => Right(a)
       case ExitResult.Failed(t, _)       => Left(t)
       case ExitResult.Terminated(Nil)    => Left(Errors.TerminatedFiber)
       case ExitResult.Terminated(t :: _) => Left(t)
     }
-    effect.IO {
+    effect.SyncIO {
       unsafeRunAsync(fa) {
         cb.compose(cbZ2C).andThen(_.unsafeRunAsync(_ => ()))
       }
     }.attempt.void
   }
 
-  def async[A](k: (Either[Throwable, A] => Unit) => Unit): Task[A] = {
+  override def async[A](k: (Either[Throwable, A] => Unit) => Unit): Task[A] = {
     val kk = k.compose[ExitResult[Throwable, A] => Unit] {
       _.compose[Either[Throwable, A]] {
         case Left(t)  => ExitResult.Failed(t)
@@ -53,13 +50,39 @@ private class CatsEffect extends CatsMonadError[Throwable] with Effect[Task] wit
     IO.async(kk)
   }
 
-  def suspend[A](thunk: => Task[A]): Task[A] = IO.suspend(
-    try {
-      thunk
-    } catch {
-      case NonFatal(e) => IO.fail(e)
+  override def asyncF[A](k: (Either[Throwable, A] => Unit) => Task[Unit]): Task[A] = {
+    val kk = k.compose[ExitResult[Throwable, A] => Unit] {
+      _.compose[Either[Throwable, A]] {
+        case Left(t)  => ExitResult.Failed(t)
+        case Right(r) => ExitResult.Completed(r)
+      }
     }
-  )
+
+    IO.asyncPure(kk)
+  }
+
+  override def suspend[A](thunk: => Task[A]): Task[A] =
+    IO.suspend(
+      try {
+        thunk
+      } catch {
+        case t: Throwable => IO.fail(t)
+      }
+    )
+
+  override def bracketCase[A, B](
+    acquire: Task[A]
+  )(use: A => Task[B])(release: (A, ExitCase[Throwable]) => Task[Unit]): Task[B] =
+    acquire.bracket0[Throwable, B] { (a, exitResult) =>
+      val exitCase = exitResult match {
+        case ExitResult.Completed(_)           => ExitCase.Completed
+        case ExitResult.Failed(error, defects) => ExitCase.Error(Errors.UnhandledError(error, defects))
+        case ExitResult.Terminated(Nil)        => ExitCase.Error(Errors.TerminatedFiber)
+        case ExitResult.Terminated(t :: _)     => ExitCase.Error(t)
+      }
+      release(a, exitCase)
+        .catchAll(IO.terminate(_))
+    }(use)
 }
 
 private class CatsMonad[E] extends Monad[IO[E, ?]] {

--- a/interop/jvm/src/main/scala/scalaz/zio/interop/catz.scala
+++ b/interop/jvm/src/main/scala/scalaz/zio/interop/catz.scala
@@ -128,3 +128,16 @@ trait CatsBifunctor extends Bifunctor[IO] {
   override def bimap[A, B, C, D](fab: IO[A, B])(f: A => C, g: B => D): IO[C, D] =
     fab.bimap(f, g)
 }
+
+import scalaz.zio._
+
+object App extends App {
+  // print + 1000 empty flatMaps
+  def worker(i: Int) =
+    (IO.sync(println(s"running $i")) *> IO.async((cb: Callback[Nothing, Unit]) => cb(ExitResult.Completed(())))).forever
+
+  override def run(args: List[String]): IO[Nothing, ExitStatus] =
+    IO.traverse(1 to 50)(worker(_).fork)
+      .flatMap(Fiber.joinAll(_))
+      .const(ExitStatus.ExitNow(0))
+}

--- a/interop/jvm/src/test/scala/scalaz/zio/interop/scalaz72Spec.scala
+++ b/interop/jvm/src/test/scala/scalaz/zio/interop/scalaz72Spec.scala
@@ -17,6 +17,7 @@ class scalaz72Spec extends AbstractRTSSpec with ScalaCheck with GenIO {
       BindRec                ${bindRec.laws[IO[Int, ?]]}
       Plus                   ${plus.laws[IO[Int, ?]]}
       MonadPlus              ${monadPlus.laws[IO[Int, ?]]}
+      MonadPlus (Monoid)     ${monadPlus.laws[IO[Option[Unit], ?]]}
       MonadError             ${monadError.laws[IO[Int, ?], Int]}
       Applicative (Parallel) ${applicative.laws[ParIO[Int, ?]]}
   """

--- a/interop/shared/src/main/scala/scalaz/zio/interop/task.scala
+++ b/interop/shared/src/main/scala/scalaz/zio/interop/task.scala
@@ -4,7 +4,6 @@ package interop
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration.Duration
 import scala.util.{ Failure, Success }
-
 import scalaz.@@
 import scalaz.Tags.Parallel
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.2.1


### PR DESCRIPTION
@alexandru @jdegoes 
There are several open questions:

1. "bracket release is called on Completed or Error" is still flaky. When in RC3 it succeeded ~70% of the time, now it passes in only about ~10% cases, rest of the time it deadlocks. A stub implementation of bracket passes laws 100% of the time, though:
  ```scala
  override def bracketCase[A, B](acquire: Task[A])(use: A => Task[B])(release: (A, ExitCase[Throwable]) => Task[Unit]): Task[B] =
    for {
      a <- acquire
      b <- use(a)
      _ <- release(a, cats.effect.ExitCase.Completed)
    } yield b
  ```
2. In ZIO bracket release can't throw, but in cats it can. IO.terminate is used to adapt in case release does throw. Technically, `Bracket` can be implemented for any `IO[E, A]`, not just for `Task`, using `.terminate(Error.UnhandledError(_))` in case of failures – would it make sense?
3. Trying to implement ConcurrentEffect in a different branch – [ContextShift.shift implementation](https://github.com/kaishh/scalaz-zio/commit/132e4f6141766e9f79361068c4b51c1945175bf0#diff-06348b7c032588d34466ade8627a8cb7R16) – is this sufficient? Should ZIO have an explicit .yield operator? Maybe a shift operator taking RTS instead of ExecutionContext? `rtsContextShift` – should it be an implicit as in above, or implicit conversion on RTS or extension method on RTS or a function on RTS?