### PR TITLE
Add a Managed data type for composing bracketed resources

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/ManagedSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/ManagedSpec.scala
@@ -1,0 +1,30 @@
+package scalaz.zio
+
+import org.specs2.ScalaCheck
+import scala.collection.mutable
+
+class ManagedSpec extends AbstractRTSSpec with GenIO with ScalaCheck {
+  def is = "ManagedSpec".title ^ s2"""
+  Invokes cleanups in reverse order of acquisition. $invokesCleanupsInReverse
+  """
+
+  def invokesCleanupsInReverse = {
+    val effects = new mutable.ListBuffer[Int]
+    def res(x: Int) =
+      Managed.mk(IO.sync { effects += x; () })(_ => IO.sync { effects += x; () })
+
+    val (first, second, third) = (res(1), res(2), res(3))
+
+    val composed = for {
+      _ <- first
+      _ <- second
+      _ <- third
+    } yield ()
+
+    val program = composed.use(_ => IO.unit)
+
+    unsafeRun(program)
+
+    effects must be_===(List(1, 2, 3, 3, 2, 1))
+  }
+}

--- a/core/jvm/src/test/scala/scalaz/zio/ManagedSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/ManagedSpec.scala
@@ -11,7 +11,7 @@ class ManagedSpec extends AbstractRTSSpec with GenIO with ScalaCheck {
   def invokesCleanupsInReverse = {
     val effects = new mutable.ListBuffer[Int]
     def res(x: Int) =
-      Managed.mk(IO.sync { effects += x; () })(_ => IO.sync { effects += x; () })
+      Managed(IO.sync { effects += x; () })(_ => IO.sync { effects += x; () })
 
     val (first, second, third) = (res(1), res(2), res(3))
 

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -321,7 +321,7 @@ sealed abstract class IO[+E, +A] { self =>
     )(use)
 
   final def managed(release: A => IO[Nothing, Unit]): Managed[E, A] =
-    Managed.mk[E, A](this)(release)
+    Managed[E, A](this)(release)
 
   /**
    * Runs the cleanup action if this action errors, providing the error to the

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -320,6 +320,9 @@ sealed abstract class IO[+E, +A] { self =>
       }
     )(use)
 
+  final def managed(release: A => IO[Nothing, Unit]): Managed[E, A] =
+    Managed.mk[E, A](this)(release)
+
   /**
    * Runs the cleanup action if this action errors, providing the error to the
    * cleanup action if it exists. The cleanup action will not be interrupted.

--- a/core/shared/src/main/scala/scalaz/zio/Managed.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Managed.scala
@@ -1,0 +1,82 @@
+package scalaz.zio
+
+sealed abstract class Managed[+E, +R] { self =>
+  def use[E1 >: E, A](f: R => IO[E1, A]): IO[E1, A]
+
+  def use_[E1 >: E, A](f: IO[E1, A]): IO[E1, A] =
+    use(_ => f)
+
+  def map[R1](f0: R => R1): Managed[E, R1] =
+    new Managed[E, R1] {
+      def use[E1 >: E, A](f: R1 => IO[E1, A]): IO[E1, A] =
+        self.use(r => f(f0(r)))
+    }
+
+  def flatMap[E1 >: E, R1](f0: R => Managed[E1, R1]) =
+    new Managed[E1, R1] {
+      def use[E2 >: E1, A](f: R1 => IO[E2, A]): IO[E2, A] =
+        self.use { r =>
+          f0(r).use { r1 =>
+            f(r1)
+          }
+        }
+    }
+
+  def *>[E1 >: E, R1](ff: Managed[E1, R1]): Managed[E1, R1] =
+    flatMap(_ => ff)
+
+  def <*[E1 >: E, R1](ff: Managed[E1, R1]): Managed[E1, R] =
+    flatMap(r => ff.map(_ => r))
+
+  def seqWith[E1 >: E, R1, R2](ff: Managed[E1, R1])(f: (R, R1) => R2): Managed[E1, R2] =
+    flatMap(r => ff.map(r1 => f(r, r1)))
+
+  def seq[E1 >: E, R1](ff: Managed[E1, R1]): Managed[E1, (R, R1)] =
+    seqWith(ff)((_, _))
+}
+
+object Managed {
+
+  /**
+   * Lifts an IO[E, R] into Managed[E, R] with a release action.
+   */
+  def mk[E, R](acquire: IO[E, R])(release: R => IO[Nothing, Unit]) =
+    new Managed[E, R] {
+      def use[E1 >: E, A](f: R => IO[E1, A]): IO[E1, A] =
+        acquire.bracket[E1, A](release)(f)
+    }
+
+  /**
+   * Lifts an IO[E, R] into Managed[E, R] with no release action. Use
+   * with care.
+   */
+  def liftIO[E, R](fa: IO[E, R]) =
+    new Managed[E, R] {
+      def use[E1 >: E, A](f: R => IO[E1, A]): IO[E1, A] =
+        fa.flatMap(f)
+    }
+
+  /**
+   * Lifts a strict, pure value into a Managed.
+   */
+  def now[R](r: R): Managed[Nothing, R] =
+    new Managed[Nothing, R] {
+      def use[E, A](f: R => IO[E, A]): IO[E, A] = f(r)
+    }
+
+  /**
+   * Lifts a by-name, pure value into a Managed.
+   */
+  def point[R](r: => R): Managed[Nothing, R] =
+    new Managed[Nothing, R] {
+      def use[E, A](f: R => IO[E, A]): IO[E, A] = f(r)
+    }
+
+  def traverse[E, R, A](as: Iterable[A])(f: A => Managed[E, R]): Managed[E, List[R]] =
+    as.foldRight[Managed[E, List[R]]](now(Nil)) { (a, m) =>
+      f(a).seqWith(m)(_ :: _)
+    }
+
+  def sequence[E, R, A](ms: Iterable[Managed[E, R]]): Managed[E, List[R]] =
+    traverse(ms)(identity)
+}


### PR DESCRIPTION
Composing brackets is not very ergonomic, resulting in lots of nesting. This data type helps in composing bracketed resources. Basically a partially applied bracket.

I had originally ported this from http://hackage.haskell.org/package/managed as https://github.com/iravid/managedt. Happy to bike-shed on the name, add additional combinators, test coverage, etc.

Resolves #254.