### PR TITLE
Submit `Fiber#onComplete` on the thread pool

### DIFF
--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -1058,8 +1058,8 @@ private object RTS {
       // To preserve fair scheduling, we submit all resumptions on the thread
       // pool in (rough) order of their submission.
       killers.reverse.foreach(k => rts.submit(k(SuccessUnit)))
-      joiners.foreach(k => rts.submit(k(v)))
-      exitHandlers.foreach(k => rts.unsafeRunAsync(k(v))((_: ExitResult[Nothing, Unit]) => ()))
+      joiners.reverse.foreach(k => rts.submit(k(v)))
+      exitHandlers.reverse.foreach(k => rts.submit(rts.unsafeRunAsync(k(v))((_: ExitResult[Nothing, Unit]) => ())))
     }
   }
 

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -476,7 +476,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec with AroundTime
         fiber <- IO.bracket[Nothing, Unit, Unit](IO.never)(_ => IO.unit)(_ => IO.unit).fork
         res   <- fiber.interrupt.timeout(42)(_ => 0)(1.second)
       } yield res
-     unsafeRun(io) must_=== 42
+    unsafeRun(io) must_=== 42
   }
 
   def testBracket0AcquireIsUninterruptible = {
@@ -485,9 +485,8 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec with AroundTime
         fiber <- IO.bracket0[Nothing, Unit, Unit](IO.never)((_, _) => IO.unit)(_ => IO.unit).fork
         res   <- fiber.interrupt.timeout(42)(_ => 0)(1.second)
       } yield res
-     unsafeRun(io) must_=== 42
+    unsafeRun(io) must_=== 42
   }
-
 
   def testSupervise = {
     var counter = 0


### PR DESCRIPTION
Following discussion in https://github.com/scalaz/scalaz-zio/pull/247, I also copied the tests defined there. However that does not solve the underlying issue that causes thread starvation.

I think the reason is both `joiners` and `killers` are async IOs, whereas `exitHandlers` are not, and so there is no continuation to signal when the action has been evaluated. This is by design since `Fiber#onComplete` should merely register a handler without blocking.

If we zoom out, the execution order for an `IO[E, A]` is:
- evaluate it
- evaluate the finalizers
- run the joiners, killers and exit handlers roughly

I propose to change it as such:
- evaluate it
- evaluate exit handlers
- evaluate the finalizers
- run the joiners and killers