### PR TITLE
Observing fibers

### DIFF
--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -906,7 +906,7 @@ private object RTS {
         case ExitResult.Failed(e, _) => e
         case ExitResult.Terminated(ts) =>
           rts.submit(rts.unsafeRun(unhandled(ts)))
-          cb(ExitResult.Terminated(Errors.TerminatedFiber :: Nil))
+          cb(ExitResult.Terminated(ts))
       }.fold(identity, ExitResult.Failed(_, _), ExitResult.Terminated(_))
 
     @tailrec

--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -902,8 +902,8 @@ private object RTS {
 
     final def register(cb: Callback[E, A]): Async[E, A] =
       observe0 {
-        case ExitResult.Completed(r)    => cb(r)
-        case x: ExitResult.Failed[_, _] => x
+        case ExitResult.Completed(r) => cb(r)
+        case ExitResult.Failed(e, _) => e
         case ExitResult.Terminated(ts) =>
           rts.submit(rts.unsafeRun(unhandled(ts)))
           cb(ExitResult.Terminated(Errors.TerminatedFiber :: Nil))

--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -1041,7 +1041,7 @@ private object RTS {
 
     private final def purgeObservers(v: ExitResult[E, A], observers: List[Callback[Nothing, ExitResult[E, A]]]): Unit =
       // To preserve fair scheduling, we submit all resumptions on the thread
-      // pool in (rough) order of their submission.
+      // pool in order of their submission.
       observers.reverse.foreach(k => rts.submit(k(ExitResult.Completed(v))))
   }
 

--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -905,11 +905,7 @@ private object RTS {
         case ExitResult.Completed(r)   => cb(r)
         case ExitResult.Failed(e, ts)  => cb(ExitResult.Failed(e, ts))
         case ExitResult.Terminated(ts) => cb(ExitResult.Terminated(ts))
-      } match {
-        case Async.Now(v)          => Async.Now(v.fold(identity, ExitResult.Failed(_, _), ExitResult.Terminated(_)))
-        case Async.MaybeLater(c)   => Async.MaybeLater(c)
-        case Async.MaybeLaterIO(c) => Async.MaybeLaterIO(c)
-      }
+      }.fold(identity, ExitResult.Failed(_, _), ExitResult.Terminated(_))
 
     @tailrec
     final def done(v: ExitResult[E, A]): Unit = {

--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -902,8 +902,9 @@ private object RTS {
 
     final def register(cb: Callback[E, A]): Async[E, A] =
       observe0 {
-        case ExitResult.Completed(r) => cb(r)
-        case _                       =>
+        case ExitResult.Completed(r)   => cb(r)
+        case ExitResult.Failed(e, ts)  => cb(ExitResult.Failed(e, ts))
+        case ExitResult.Terminated(ts) => cb(ExitResult.Terminated(ts))
       } match {
         case Async.Now(v)          => Async.Now(v.fold(identity, ExitResult.Failed(_, _), ExitResult.Terminated(_)))
         case Async.MaybeLater(c)   => Async.MaybeLater(c)

--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -461,8 +461,8 @@ private object RTS {
                                 }
                               case ExitResult.Terminated(ts) =>
                                 curIo = IO.terminate0(ts)
-                              case ExitResult.Failed(e, _) =>
-                                curIo = IO.fail(e)
+                              case ExitResult.Failed(e, ts) =>
+                                curIo = IO.fail0(e, ts)
                             }
                           } else {
                             // Completion handled by interruptor:
@@ -653,7 +653,7 @@ private object RTS {
           if (io eq null) done(value.asInstanceOf[ExitResult[E, A]])
           else evaluate(io)
 
-        case ExitResult.Failed(t, _) => evaluate(IO.fail[E](t))
+        case ExitResult.Failed(t, ts) => evaluate(IO.fail0[E](t, ts))
 
         case ExitResult.Terminated(ts) => evaluate(IO.terminate0(ts))
       }

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -57,9 +57,6 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec with AroundTime
     bracket regression 1                    ${upTo(10.seconds)(testBracketRegression1)}
     interrupt waits for finalizer           $testInterruptWaitsForFinalizer
 
-  RTS exit handlers
-    exit handlers get called                $testExitHandlers
-
   RTS synchronous stack safety
     deep map of point                       $testDeepMapOfPoint
     deep map of now                         $testDeepMapOfNow
@@ -360,19 +357,6 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec with AroundTime
       _    <- s.interrupt
       test <- r.get
     } yield test must_=== true)
-
-  def testExitHandlers =
-    unsafeRun(for {
-      counter <- Ref(0)
-      f       <- IO.now(Fiber.point("hello"))
-      _       <- f.onComplete(_ => counter.update(_ + 1).void)
-      _       <- f.onComplete(_ => counter.update(_ + 1).void)
-      _       <- f.onComplete(_ => counter.update(_ + 1).void)
-      p       <- Promise.make[Nothing, String]
-      _       <- f.onComplete(r => p.done(r).void)
-      a       <- p.get
-      b       <- counter.get
-    } yield (a, b)) must_=== (("hello", 3))
 
   def testEvalOfDeepSyncEffect = {
     def incLeft(n: Int, ref: Ref[Int]): IO[Throwable, Int] =

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -78,6 +78,8 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec with AroundTime
     shallow fork/join identity              $testForkJoinIsId
     deep fork/join identity                 $testDeepForkJoinIsId
     interrupt of never                      ${upTo(1.second)(testNeverIsInterruptible)}
+    bracket is uninterruptible              ${testBracketAcquireIsUninterruptible}
+    bracket0 is uninterruptible             ${testBracket0AcquireIsUninterruptible}
     supervise fibers                        ${upTo(1.second)(testSupervise)}
     race of fail with success               ${upTo(1.second)(testRaceChoosesWinner)}
     race of fail with fail                  ${upTo(1.second)(testRaceChoosesFailure)}
@@ -449,6 +451,24 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec with AroundTime
         _     <- fiber.interrupt
       } yield 42
 
+    unsafeRun(io) must_=== 42
+  }
+
+  def testBracketAcquireIsUninterruptible = {
+    val io =
+      for {
+        fiber <- IO.bracket[Nothing, Unit, Unit](IO.never)(_ => IO.unit)(_ => IO.unit).fork
+        res   <- fiber.interrupt.timeout(42)(_ => 0)(1.second)
+      } yield res
+    unsafeRun(io) must_=== 42
+  }
+
+  def testBracket0AcquireIsUninterruptible = {
+    val io =
+      for {
+        fiber <- IO.bracket0[Nothing, Unit, Unit](IO.never)((_, _) => IO.unit)(_ => IO.unit).fork
+        res   <- fiber.interrupt.timeout(42)(_ => 0)(1.second)
+      } yield res
     unsafeRun(io) must_=== 42
   }
 

--- a/core/shared/src/main/scala/scalaz/zio/Async.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Async.scala
@@ -11,7 +11,15 @@ package scalaz.zio
  * which represents an interruptible asynchronous action where the canceler has the
  * form `Throwable => IO[Nothing, Unit]`
  */
-sealed abstract class Async[+E, +A]
+sealed abstract class Async[+E, +A] { self =>
+  def fold[E1, B](f: A => ExitResult[E1, B], g: (E, List[Throwable]) => ExitResult[E1, B], h: List[Throwable] => ExitResult[E1, B]): Async[E1, B] =
+    self match {
+      case Async.Now(r) => Async.Now(r.fold(f,g,h))
+      case Async.MaybeLater(c) => Async.MaybeLater(c)
+      case Async.MaybeLaterIO(c) => Async.MaybeLaterIO(c)
+    }
+}
+
 object Async {
 
   val NoOpCanceler: Canceler         = () => ()

--- a/core/shared/src/main/scala/scalaz/zio/Async.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Async.scala
@@ -12,10 +12,12 @@ package scalaz.zio
  * form `Throwable => IO[Nothing, Unit]`
  */
 sealed abstract class Async[+E, +A] { self =>
-  def fold[E1, B](f: A => ExitResult[E1, B], g: (E, List[Throwable]) => ExitResult[E1, B], h: List[Throwable] => ExitResult[E1, B]): Async[E1, B] =
+  def fold[E1, B](f: A => ExitResult[E1, B],
+                  g: (E, List[Throwable]) => ExitResult[E1, B],
+                  h: List[Throwable] => ExitResult[E1, B]): Async[E1, B] =
     self match {
-      case Async.Now(r) => Async.Now(r.fold(f,g,h))
-      case Async.MaybeLater(c) => Async.MaybeLater(c)
+      case Async.Now(r)          => Async.Now(r.fold(f, g, h))
+      case Async.MaybeLater(c)   => Async.MaybeLater(c)
       case Async.MaybeLaterIO(c) => Async.MaybeLaterIO(c)
     }
 }

--- a/core/shared/src/main/scala/scalaz/zio/Fiber.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Fiber.scala
@@ -120,8 +120,8 @@ trait Fiber[+E, +A] { self =>
 object Fiber {
   final def point[E, A](a: => A): Fiber[E, A] =
     new Fiber[E, A] {
-      def observe: IO[Nothing, ExitResult[E, A]]               = IO.point(ExitResult.Completed(a))
-      def interrupt0(ts: List[Throwable]): IO[Nothing, Unit]   = IO.unit
+      def observe: IO[Nothing, ExitResult[E, A]]             = IO.point(ExitResult.Completed(a))
+      def interrupt0(ts: List[Throwable]): IO[Nothing, Unit] = IO.unit
     }
 
   final def interruptAll(fs: Iterable[Fiber[_, _]]): IO[Nothing, Unit] =

--- a/core/shared/src/main/scala/scalaz/zio/Fiber.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Fiber.scala
@@ -36,7 +36,7 @@ trait Fiber[+E, +A] { self =>
    */
   final def join: IO[E, A] = observe.flatMap {
     case ExitResult.Completed(a)   => IO.now(a)
-    case ExitResult.Failed(e, _)   => IO.fail(e)
+    case ExitResult.Failed(e, ts)   => IO.fail0(e, ts)
     case ExitResult.Terminated(ts) => IO.terminate0(ts)
   }
 

--- a/core/shared/src/main/scala/scalaz/zio/Fiber.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Fiber.scala
@@ -62,17 +62,6 @@ trait Fiber[+E, +A] { self =>
   def interrupt0(ts: List[Throwable]): IO[Nothing, Unit]
 
   /**
-   * Add an exit handler for when the fiber terminates and receive information
-   * on whether the fiber terminated normally, with unhandled error, or with
-   * exception.
-   *
-   * The specified action will be invoked after the fiber has finished running
-   * (including all finalizers). If the specified action throws an exception,
-   * it will be reported to the parent fiber's unhandled error handler.
-   */
-  def onComplete(f: ExitResult[E, A] => IO[Nothing, Unit]): IO[Nothing, Unit]
-
-  /**
    * Zips this fiber with the specified fiber, combining their results using
    * the specified combiner function. Both joins and interruptions are performed
    * in sequential order from left to right.
@@ -90,19 +79,6 @@ trait Fiber[+E, +A] { self =>
 
       def interrupt0(ts: List[Throwable]): IO[Nothing, Unit] =
         self.interrupt0(ts) *> that.interrupt0(ts)
-
-      def onComplete(fc: ExitResult[E1, C] => IO[Nothing, Unit]): IO[Nothing, Unit] =
-        self.onComplete { ra: ExitResult[E, A] =>
-          that.onComplete { rb: ExitResult[E1, B] =>
-            (ra, rb) match {
-              case (ExitResult.Completed(a), ExitResult.Completed(b))   => fc(ExitResult.Completed(f(a, b)))
-              case (ExitResult.Failed(e, ts), rb)                       => fc(ExitResult.Failed(e, combine(ts, rb)))
-              case (ExitResult.Terminated(ts), rb)                      => fc(ExitResult.Terminated(combine(ts, rb)))
-              case (ExitResult.Completed(_), ExitResult.Failed(e, ts))  => fc(ExitResult.Failed(e, ts))
-              case (ExitResult.Completed(_), ExitResult.Terminated(ts)) => fc(ExitResult.Terminated(ts))
-            }
-          }
-        }
 
       private def combine(ts: List[Throwable], r: ExitResult[_, _]) = r match {
         case ExitResult.Failed(_, ts2)  => ts ++ ts2
@@ -138,11 +114,6 @@ trait Fiber[+E, +A] { self =>
       def observe: IO[Nothing, ExitResult[E, B]] = self.observe.map(_.map(f))
 
       def interrupt0(ts: List[Throwable]): IO[Nothing, Unit] = self.interrupt0(ts)
-
-      def onComplete(fb: ExitResult[E, B] => IO[Nothing, Unit]): IO[Nothing, Unit] =
-        self.onComplete { r: ExitResult[E, A] =>
-          fb(r.map(f))
-        }
     }
 }
 
@@ -151,7 +122,6 @@ object Fiber {
     new Fiber[E, A] {
       def observe: IO[Nothing, ExitResult[E, A]]               = IO.point(ExitResult.Completed(a))
       def interrupt0(ts: List[Throwable]): IO[Nothing, Unit]   = IO.unit
-      def onComplete(f: ExitResult[E, A] => IO[Nothing, Unit]) = f(ExitResult.Completed(a))
     }
 
   final def interruptAll(fs: Iterable[Fiber[_, _]]): IO[Nothing, Unit] =

--- a/core/shared/src/main/scala/scalaz/zio/Fiber.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Fiber.scala
@@ -31,12 +31,12 @@ trait Fiber[+E, +A] { self =>
 
   /**
    * Joins the fiber, which suspends the joining fiber until the result of the
-   * fiber has been determined. Attempting to join a fiber that has errored will 
+   * fiber has been determined. Attempting to join a fiber that has errored will
    * result in a catchable error, _if_ that error does not result from interruption.
    */
   final def join: IO[E, A] = observe.flatMap {
     case ExitResult.Completed(a)   => IO.now(a)
-    case ExitResult.Failed(e, ts)   => IO.fail0(e, ts)
+    case ExitResult.Failed(e, ts)  => IO.fail0(e, ts)
     case ExitResult.Terminated(ts) => IO.terminate0(ts)
   }
 

--- a/core/shared/src/main/scala/scalaz/zio/Fiber.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Fiber.scala
@@ -34,7 +34,7 @@ trait Fiber[+E, +A] { self =>
    * fiber has been determined. Attempting to join a fiber that has been or is
    * killed before producing its result will result in a catchable error.
    */
-  def join: IO[E, A] = observe.flatMap {
+  final def join: IO[E, A] = observe.flatMap {
     case ExitResult.Completed(a)   => IO.now(a)
     case ExitResult.Failed(e, _)   => IO.fail(e)
     case ExitResult.Terminated(ts) => IO.terminate0(ts)

--- a/core/shared/src/main/scala/scalaz/zio/Fiber.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Fiber.scala
@@ -31,8 +31,8 @@ trait Fiber[+E, +A] { self =>
 
   /**
    * Joins the fiber, which suspends the joining fiber until the result of the
-   * fiber has been determined. Attempting to join a fiber that has been or is
-   * killed before producing its result will result in a catchable error.
+   * fiber has been determined. Attempting to join a fiber that has errored will 
+   * result in a catchable error, _if_ that error does not result from interruption.
    */
   final def join: IO[E, A] = observe.flatMap {
     case ExitResult.Completed(a)   => IO.now(a)

--- a/core/shared/src/main/scala/scalaz/zio/Fiber.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Fiber.scala
@@ -128,5 +128,5 @@ object Fiber {
     fs.foldLeft(IO.unit)((io, f) => io *> f.interrupt)
 
   final def joinAll(fs: Iterable[Fiber[_, _]]): IO[Nothing, Unit] =
-    fs.foldLeft(IO.unit)((io, f) => io *> f.join.attempt.void)
+    fs.foldLeft(IO.unit)((io, f) => io *> f.observe.void)
 }

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -790,7 +790,7 @@ object IO {
   final def done[E, A](r: ExitResult[E, A]): IO[E, A] = r match {
     case ExitResult.Completed(b)   => now(b)
     case ExitResult.Terminated(ts) => terminate0(ts)
-    case ExitResult.Failed(e, ts)   => fail0(e, ts)
+    case ExitResult.Failed(e, ts)  => fail0(e, ts)
   }
 
   /**

--- a/interop/shared/src/main/scala/scalaz/zio/interop/future.scala
+++ b/interop/shared/src/main/scala/scalaz/zio/interop/future.scala
@@ -1,8 +1,7 @@
 package scalaz.zio
 package interop
 
-import scala.concurrent.duration.Duration
-import scala.concurrent.{ Await, ExecutionContext, Future }
+import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success }
 
 object future {
@@ -20,16 +19,15 @@ object future {
   implicit class FiberObjOps(private val fiberObj: Fiber.type) extends AnyVal {
     def fromFuture[A](_ftr: => Future[A])(ec: ExecutionContext): Fiber[Throwable, A] =
       new Fiber[Throwable, A] {
-        private lazy val ftr                                   = _ftr
-        def join: IO[Throwable, A]                             = IO.syncThrowable(Await.result(ftr, Duration.Inf))
-        def interrupt0(ts: List[Throwable]): IO[Nothing, Unit] = join.attempt.void
-        def onComplete(f: ExitResult[Throwable, A] => IO[Nothing, Unit]): IO[Nothing, Unit] =
-          IO.syncThrowable {
+        private lazy val ftr = _ftr
+        def observe: IO[Nothing, ExitResult[Throwable, A]] = IO.async {
+          cb: Callback[Nothing, ExitResult[Throwable, A]] =>
             ftr.onComplete {
-              case Success(a) => f(ExitResult.Completed(a))
-              case Failure(t) => f(ExitResult.Failed(t))
+              case Success(a) => cb(ExitResult.Completed(ExitResult.Completed(a)))
+              case Failure(t) => cb(ExitResult.Completed(ExitResult.Failed(t)))
             }(ec)
-          }.attempt.void
+        }
+        def interrupt0(ts: List[Throwable]): IO[Nothing, Unit] = join.attempt.void
       }
   }
 


### PR DESCRIPTION
Replaces `Fiber#onComplete` and generalises `Fiber#join` 🌟 

Technically we could get rid of `killers` in `FiberStatus` too, as they are just observers ignoring their argument. What do you think @jdegoes ?