### PR TITLE
Readme Sonatype badge link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Copyright (C) 2017-2018 John A. De Goes. All rights reserved.
 [Link-IsItMaintained]: http://isitmaintained.com/project/scalaz/scalaz-zio "Average time to resolve an issue"
 [Link-Scaladex]: https://index.scala-lang.org/search?q=dependencies:scalaz/scalaz-zio "Scaladex"
 [Link-SonatypeReleases]: https://oss.sonatype.org/content/repositories/releases/org/scalaz/scalaz-zio_2.12/ "Sonatype Releases"
-[Link-SonatypeSnapshots]: https://oss.sonatype.org/content/repositories/snapshots/org/scalaz/scalaz-zio_2.12/ "Sonatype Snapshots"
+[Link-SonatypeSnapshots]: https://oss.sonatype.org/content/repositories/staging/org/scalaz/scalaz-zio_2.12/ "Sonatype Snapshots"
 [Link-Travis]: https://travis-ci.org/scalaz/scalaz-zio "Travis CI"
 
 [Badge-Codecov]: https://codecov.io/gh/scalaz/scalaz-zio/coverage.svg?branch=master "Codecov"


### PR DESCRIPTION
points to `staging` repo instead of `snapshots`

Apparently we now don't publish to snapshot artefacts [`snapshots`](https://oss.sonatype.org/content/repositories/snapshots/org/scalaz/scalaz-zio_2.12/) but to [`staging`](https://oss.sonatype.org/content/repositories/staging/org/scalaz/scalaz-zio_2.12/)

**Is this intentional?**
could it be and unintended consequence of `sbt ci-release || sbt sonatypeReleaseAll` (instead of just `sbt ci-release`) for example?

if it's intentional and OK, this PR fixes a link on our README badge
