### PR TITLE
Make `use` interruptible in `IO.bracket0`

### DIFF
--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -1041,12 +1041,11 @@ private object RTS {
       }
     }
 
-    private final def tryObserve0: Option[ExitResult[E, A]] = {
+    private final def tryObserve0: Option[ExitResult[E, A]] =
       status.get match {
         case Done(r) => Some(r)
-        case _ => None
+        case _       => None
       }
-    }
 
     private final def purgeObservers(v: ExitResult[E, A], observers: List[Callback[Nothing, ExitResult[E, A]]]): Unit =
       // To preserve fair scheduling, we submit all resumptions on the thread

--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -754,6 +754,8 @@ private object RTS {
 
     final def observe: IO[Nothing, ExitResult[E, A]] = IO.async0(observe0)
 
+    final def tryObserve: IO[Nothing, Option[ExitResult[E, A]]] = IO.sync(tryObserve0)
+
     final def enterSupervision: IO[E, Unit] = IO.sync {
       supervising += 1
 
@@ -1036,6 +1038,13 @@ private object RTS {
           else Async.later[Nothing, ExitResult[E, A]]
 
         case Done(v) => Async.now(ExitResult.Completed(v))
+      }
+    }
+
+    private final def tryObserve0: Option[ExitResult[E, A]] = {
+      status.get match {
+        case Done(r) => Some(r)
+        case _ => None
       }
     }
 

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -80,6 +80,8 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec with AroundTime
     interrupt of never                      ${upTo(1.second)(testNeverIsInterruptible)}
     bracket is uninterruptible              ${testBracketAcquireIsUninterruptible}
     bracket0 is uninterruptible             ${testBracket0AcquireIsUninterruptible}
+    bracket use is interruptible            $testBracketUseIsInterruptible
+    bracket0 use is interruptible           $testBracket0UseIsInterruptible
     supervise fibers                        ${upTo(1.second)(testSupervise)}
     race of fail with success               ${upTo(1.second)(testRaceChoosesWinner)}
     race of fail with fail                  ${upTo(1.second)(testRaceChoosesFailure)}
@@ -470,6 +472,24 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec with AroundTime
         res   <- fiber.interrupt.timeout(42)(_ => 0)(1.second)
       } yield res
     unsafeRun(io) must_=== 42
+  }
+
+  def testBracketUseIsInterruptible = {
+    val io =
+      for {
+        fiber <- IO.bracket[Nothing, Unit, Unit](IO.unit)(_ => IO.unit)(_ => IO.never).fork
+        res   <- fiber.interrupt.timeout(42)(_ => 0)(1.second)
+      } yield res
+    unsafeRun(io) must_=== 0
+  }
+
+  def testBracket0UseIsInterruptible = {
+    val io =
+      for {
+        fiber <- IO.bracket0[Nothing, Unit, Unit](IO.unit)((_, _) => IO.unit)(_ => IO.never).fork
+        res   <- fiber.interrupt.timeout(42)(_ => 0)(1.second)
+      } yield res
+    unsafeRun(io) must_=== 0
   }
 
   def testSupervise = {

--- a/core/shared/src/main/scala/scalaz/zio/Fiber.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Fiber.scala
@@ -24,11 +24,14 @@ package scalaz.zio
 trait Fiber[+E, +A] { self =>
 
   /**
-   * Observes the fiber, which suspends the joining fiber until the result of the
+   * Observes the fiber, which suspends the observing fiber until the result of the
    * fiber has been determined.
    */
   def observe: IO[Nothing, ExitResult[E, A]]
 
+  /**
+   * Tentatively observes the fiber, but returns immediately if it is not already done.
+   */
   def tryObserve: IO[Nothing, Option[ExitResult[E, A]]]
 
   /**

--- a/core/shared/src/main/scala/scalaz/zio/Fiber.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Fiber.scala
@@ -29,6 +29,8 @@ trait Fiber[+E, +A] { self =>
    */
   def observe: IO[Nothing, ExitResult[E, A]]
 
+  def tryObserve: IO[Nothing, Option[ExitResult[E, A]]] = ???
+
   /**
    * Joins the fiber, which suspends the joining fiber until the result of the
    * fiber has been determined. Attempting to join a fiber that has errored will

--- a/core/shared/src/main/scala/scalaz/zio/Fiber.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Fiber.scala
@@ -74,30 +74,16 @@ trait Fiber[+E, +A] { self =>
   final def zipWith[E1 >: E, B, C](that: => Fiber[E1, B])(f: (A, B) => C): Fiber[E1, C] =
     new Fiber[E1, C] {
       def observe: IO[Nothing, ExitResult[E1, C]] =
-        self.observe.seqWith(that.observe)(combineExitResults)
+        self.observe.seqWith(that.observe)(_.zipWith(_)(f))
 
       def tryObserve: IO[Nothing, Option[ExitResult[E1, C]]] =
         self.tryObserve.seqWith(that.tryObserve) {
-          case (Some(ra), Some(rb)) => Some(combineExitResults(ra, rb))
+          case (Some(ra), Some(rb)) => Some(ra.zipWith(rb)(f))
           case _                    => None
         }
 
       def interrupt0(ts: List[Throwable]): IO[Nothing, Unit] =
         self.interrupt0(ts) *> that.interrupt0(ts)
-
-      private def combineExitResults: (ExitResult[E, A], ExitResult[E1, B]) => ExitResult[E1, C] = {
-        case (ExitResult.Completed(a), ExitResult.Completed(b))   => ExitResult.Completed(f(a, b))
-        case (ExitResult.Failed(e, ts), rb)                       => ExitResult.Failed(e, combine(ts, rb))
-        case (ExitResult.Terminated(ts), rb)                      => ExitResult.Terminated(combine(ts, rb))
-        case (ExitResult.Completed(_), ExitResult.Failed(e, ts))  => ExitResult.Failed(e, ts)
-        case (ExitResult.Completed(_), ExitResult.Terminated(ts)) => ExitResult.Terminated(ts)
-      }
-
-      private def combine(ts: List[Throwable], r: ExitResult[_, _]) = r match {
-        case ExitResult.Failed(_, ts2)  => ts ++ ts2
-        case ExitResult.Terminated(ts2) => ts ++ ts2
-        case _                          => ts
-      }
     }
 
   /**

--- a/core/shared/src/main/scala/scalaz/zio/Fiber.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Fiber.scala
@@ -77,14 +77,10 @@ trait Fiber[+E, +A] { self =>
         self.observe.seqWith(that.observe)(combineExitResults)
 
       def tryObserve: IO[Nothing, Option[ExitResult[E1, C]]] =
-        for {
-          optA <- self.tryObserve
-          optB <- that.tryObserve
-        } yield
-          (optA, optB) match {
-            case (Some(ra), Some(rb)) => Some(combineExitResults(ra, rb))
-            case _                    => None
-          }
+        self.tryObserve.seqWith(that.tryObserve) {
+          case (Some(ra), Some(rb)) => Some(combineExitResults(ra, rb))
+          case _                    => None
+        }
 
       def interrupt0(ts: List[Throwable]): IO[Nothing, Unit] =
         self.interrupt0(ts) *> that.interrupt0(ts)

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -1013,12 +1013,18 @@ object IO {
   final def bracket0[E, A, B](
     acquire: IO[E, A]
   )(release: (A, ExitResult[E, B]) => IO[Nothing, Unit])(use: A => IO[E, B]): IO[E, B] =
-    Ref[Option[A]](None).flatMap { m =>
-      for {
-        f <- acquire.flatMap(a => m.set(Some(a)) *> use(a).fork).uninterruptibly
-        b <- f.join.ensuring(m.get.flatMap(_.fold(IO.unit)(a => f.observe.flatMap(r => release(a, r)))))
-      } yield b
-    }.supervised
+    Ref[Option[(A, Fiber[E, B])]](None).flatMap { m =>
+      (for {
+        f <- acquire.flatMap(a => use(a).fork.flatMap(f => m.set(Some(a -> f)).const(f))).uninterruptibly
+        b <- f.join
+      } yield b).ensuring(m.get.flatMap(_.fold(IO.unit) {
+        case (a, f) =>
+          f.tryObserve.flatMap {
+            case Some(r) => release(a, r)
+            case None    => f.interrupt
+          }
+      }))
+    }
 
   /**
    * Acquires a resource, do some work with it, and then release that resource. `bracket`

--- a/interop/shared/src/main/scala/scalaz/zio/interop/future.scala
+++ b/interop/shared/src/main/scala/scalaz/zio/interop/future.scala
@@ -28,10 +28,9 @@ object future {
             }(ec)
         }
         def tryObserve: IO[Nothing, Option[ExitResult[Throwable, A]]] = IO.sync {
-          ftr.value match {
-            case Some(Success(a)) => Some(ExitResult.Completed(a))
-            case Some(Failure(t)) => Some(ExitResult.Failed(t))
-            case None             => None
+          ftr.value map {
+            case Success(a) => ExitResult.Completed(a)
+            case Failure(t) => ExitResult.Failed(t)
           }
         }
         def interrupt0(ts: List[Throwable]): IO[Nothing, Unit] = join.attempt.void

--- a/interop/shared/src/main/scala/scalaz/zio/interop/future.scala
+++ b/interop/shared/src/main/scala/scalaz/zio/interop/future.scala
@@ -27,6 +27,13 @@ object future {
               case Failure(t) => cb(ExitResult.Completed(ExitResult.Failed(t)))
             }(ec)
         }
+        def tryObserve: IO[Nothing, Option[ExitResult[Throwable, A]]] = IO.sync {
+          ftr.value match {
+            case Some(Success(a)) => Some(ExitResult.Completed(a))
+            case Some(Failure(t)) => Some(ExitResult.Failed(t))
+            case None             => None
+          }
+        }
         def interrupt0(ts: List[Throwable]): IO[Nothing, Unit] = join.attempt.void
       }
   }


### PR DESCRIPTION
Rewrites `IO.bracket0` following @jdegoes 's description [here](https://github.com/scalaz/scalaz-zio/pull/247#issuecomment-424509856).

> You need to fork inside the uninterruptible section, right after setting the ref containing the resource. Forking can't fail so it's safe to do that; you return the fiber from the uninterruptible section. Then outside the interruptible section, you join on the forked use. Finally, you return that value, all wrapped in ensuring to make sure that if acquire succeeds (hence, necessarily: the ref is set, and use is forked), there will be an exit value.

It's not quite there yet but I'm getting closer.