### PR TITLE
Human-friendly root project name

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,8 @@ import sbtcrossproject.CrossPlugin.autoImport.crossProject
 import Scalaz._
 import xerial.sbt.Sonatype._
 
+name := "scalaz-zio"
+
 inThisBuild(
   List(
     organization := "org.scalaz",


### PR DESCRIPTION
Root project name set to scalaz-zio to make it more human-friendly when you open project with IDEs

Without this patch all the projects with unset root name looks like "root" in IDEA which is very confusing when you have 5-10 of em.