### PR TITLE
Convert sealed trait to sealed abstract class. Mark all classes Serializable

### DIFF
--- a/core/jvm/src/main/scala/scalaz/zio/App.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/App.scala
@@ -27,7 +27,7 @@ import scala.concurrent.duration.Duration
  */
 trait App extends RTS {
 
-  sealed trait ExitStatus
+  sealed abstract class ExitStatus
   object ExitStatus {
     case class ExitNow(code: Int)                         extends ExitStatus
     case class ExitWhenDone(code: Int, timeout: Duration) extends ExitStatus

--- a/core/jvm/src/main/scala/scalaz/zio/App.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/App.scala
@@ -28,7 +28,7 @@ import scala.concurrent.duration.Duration
 trait App extends RTS {
 
   sealed abstract class ExitStatus extends Serializable with Product
-  object ExitStatus {
+  object ExitStatus extends Serializable {
     case class ExitNow(code: Int)                         extends ExitStatus
     case class ExitWhenDone(code: Int, timeout: Duration) extends ExitStatus
     case object DoNotExit                                 extends ExitStatus

--- a/core/jvm/src/main/scala/scalaz/zio/App.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/App.scala
@@ -27,7 +27,7 @@ import scala.concurrent.duration.Duration
  */
 trait App extends RTS {
 
-  sealed abstract class ExitStatus
+  sealed abstract class ExitStatus extends Serializable with Product
   object ExitStatus {
     case class ExitNow(code: Int)                         extends ExitStatus
     case class ExitWhenDone(code: Int, timeout: Duration) extends ExitStatus

--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -111,7 +111,7 @@ trait RTS {
 
 private object RTS {
 
-  sealed trait RaceState
+  sealed abstract class RaceState
   object RaceState {
     case object Started     extends RaceState
     case object FirstFailed extends RaceState
@@ -1059,7 +1059,7 @@ private object RTS {
       observers.reverse.foreach(k => rts.submit(k(ExitResult.Completed(v))))
   }
 
-  sealed trait FiberStatus[E, A] {
+  sealed abstract class FiberStatus[E, A] {
 
     /** causes passed in when explicitly interrupting the fiber */
     def terminationCauses: Option[List[Throwable]]

--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -111,7 +111,7 @@ trait RTS {
 
 private object RTS {
 
-  sealed abstract class RaceState
+  sealed abstract class RaceState extends Serializable with Product
   object RaceState {
     case object Started     extends RaceState
     case object FirstFailed extends RaceState
@@ -1059,7 +1059,7 @@ private object RTS {
       observers.reverse.foreach(k => rts.submit(k(ExitResult.Completed(v))))
   }
 
-  sealed abstract class FiberStatus[E, A] {
+  sealed abstract class FiberStatus[E, A] extends Serializable with Product {
 
     /** causes passed in when explicitly interrupting the fiber */
     def terminationCauses: Option[List[Throwable]]

--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -112,7 +112,7 @@ trait RTS {
 private object RTS {
 
   sealed abstract class RaceState extends Serializable with Product
-  object RaceState {
+  object RaceState extends Serializable {
     case object Started     extends RaceState
     case object FirstFailed extends RaceState
     case object Finished    extends RaceState
@@ -1067,7 +1067,7 @@ private object RTS {
     /** errors resulting from exceptions thrown during the execution of the fiber */
     def defects: List[Throwable]
   }
-  object FiberStatus {
+  object FiberStatus extends Serializable {
     final case class Executing[E, A](
       terminationCauses: Option[List[Throwable]],
       defects: List[Throwable],

--- a/core/jvm/src/test/scala/scalaz/zio/SerializableSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/SerializableSpec.scala
@@ -17,12 +17,22 @@ class SerializableSpec extends AbstractRTSSpec {
     ios.readObject().asInstanceOf[T]
   }
 
+  def serializeAndBack[T](a: T): IO[_, T] =
+    for {
+      obj       <- IO.sync(serializeToBytes(a))
+      returnObj <- IO.sync(getObjFromBytes[T](obj))
+    } yield returnObj
+
   def is =
     "SerializableSpec".title ^ s2"""
     Test all classes are Serializable
     verify that
       Semaphore is serializable $e1
       Clock is serializable $e2
+      Queue is serializable $e3
+      Ref is serializable $e4
+      IO is serializable $e5
+      KleisliIO is serializable $e6
     """
 
   def e1 = {
@@ -31,8 +41,7 @@ class SerializableSpec extends AbstractRTSSpec {
       for {
         semaphore   <- Semaphore(n)
         count       <- semaphore.count
-        bytes       <- IO.sync(serializeToBytes(semaphore))
-        returnSem   <- IO.sync(getObjFromBytes[Semaphore](bytes))
+        returnSem   <- serializeAndBack(semaphore)
         returnCount <- returnSem.count
       } yield returnCount must_=== count
     )
@@ -43,10 +52,53 @@ class SerializableSpec extends AbstractRTSSpec {
     unsafeRun(
       for {
         time1       <- live.nanoTime
-        bytes       <- IO.sync(serializeToBytes(live))
-        returnClock <- IO.sync(getObjFromBytes[Clock](bytes))
+        returnClock <- serializeAndBack(live)
         time2       <- returnClock.nanoTime
       } yield (time1 < time2) must beTrue
+    )
+  }
+
+  def e3 = unsafeRun(
+    for {
+      queue       <- Queue.bounded[Int](100)
+      _           <- queue.offer(10)
+      returnQueue <- serializeAndBack(queue)
+      v1          <- returnQueue.take
+      _           <- returnQueue.offer(20)
+      v2          <- returnQueue.take
+    } yield (v1 must_=== 10) and (v2 must_=== 20)
+  )
+
+  def e4 = {
+    val current = "This is some value"
+    unsafeRun(
+      for {
+        ref       <- Ref(current)
+        returnRef <- serializeAndBack(ref)
+        value     <- returnRef.get
+      } yield value must_=== current
+    )
+  }
+
+  def e5 = {
+    val list = List("1", "2", "3")
+    val io   = IO.point(list)
+    unsafeRun(
+      for {
+        returnIO <- serializeAndBack(io)
+        result   <- returnIO
+      } yield result must_=== list
+    )
+  }
+
+  def e6 = {
+    import KleisliIO._
+    val v = lift[Int, Int](_ + 1)
+    unsafeRun(
+      for {
+        returnKleisli <- serializeAndBack(v)
+        computeV      <- returnKleisli.run(9)
+      } yield computeV must_=== 10
     )
   }
 }

--- a/core/jvm/src/test/scala/scalaz/zio/SerializableSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/SerializableSpec.scala
@@ -1,0 +1,52 @@
+package scalaz.zio
+
+import java.io._
+
+class SerializableSpec extends AbstractRTSSpec {
+
+  def serializeToBytes[T](a: T): Array[Byte] = {
+    val bf  = new ByteArrayOutputStream()
+    val oos = new ObjectOutputStream(bf)
+    oos.writeObject(a)
+    oos.close()
+    bf.toByteArray
+  }
+
+  def getObjFromBytes[T](bytes: Array[Byte]): T = {
+    val ios = new ObjectInputStream(new ByteArrayInputStream(bytes))
+    ios.readObject().asInstanceOf[T]
+  }
+
+  def is =
+    "SerializableSpec".title ^ s2"""
+    Test all classes are Serializable
+    verify that
+      Semaphore is serializable $e1
+      Clock is serializable $e2
+    """
+
+  def e1 = {
+    val n = 20L
+    unsafeRun(
+      for {
+        semaphore   <- Semaphore(n)
+        count       <- semaphore.count
+        bytes       <- IO.sync(serializeToBytes(semaphore))
+        returnSem   <- IO.sync(getObjFromBytes[Semaphore](bytes))
+        returnCount <- returnSem.count
+      } yield returnCount must_=== count
+    )
+  }
+
+  def e2 = {
+    val live = Clock.Live
+    unsafeRun(
+      for {
+        time1       <- live.nanoTime
+        bytes       <- IO.sync(serializeToBytes(live))
+        returnClock <- IO.sync(getObjFromBytes[Clock](bytes))
+        time2       <- returnClock.nanoTime
+      } yield (time1 < time2) must beTrue
+    )
+  }
+}

--- a/core/jvm/src/test/scala/scalaz/zio/SerializableSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/SerializableSpec.scala
@@ -4,24 +4,26 @@ import java.io._
 
 class SerializableSpec extends AbstractRTSSpec {
 
-  def serializeToBytes[T](a: T): Array[Byte] = {
-    val bf  = new ByteArrayOutputStream()
-    val oos = new ObjectOutputStream(bf)
-    oos.writeObject(a)
-    oos.close()
-    bf.toByteArray
-  }
+  def serializeAndBack[T](a: T): IO[_, T] = {
 
-  def getObjFromBytes[T](bytes: Array[Byte]): T = {
-    val ios = new ObjectInputStream(new ByteArrayInputStream(bytes))
-    ios.readObject().asInstanceOf[T]
-  }
+    def serializeToBytes[T](a: T): Array[Byte] = {
+      val bf  = new ByteArrayOutputStream()
+      val oos = new ObjectOutputStream(bf)
+      oos.writeObject(a)
+      oos.close()
+      bf.toByteArray
+    }
 
-  def serializeAndBack[T](a: T): IO[_, T] =
+    def getObjFromBytes[T](bytes: Array[Byte]): T = {
+      val ios = new ObjectInputStream(new ByteArrayInputStream(bytes))
+      ios.readObject().asInstanceOf[T]
+    }
+
     for {
       obj       <- IO.sync(serializeToBytes(a))
       returnObj <- IO.sync(getObjFromBytes[T](obj))
     } yield returnObj
+  }
 
   def is =
     "SerializableSpec".title ^ s2"""

--- a/core/shared/src/main/scala/scalaz/zio/Async.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Async.scala
@@ -11,7 +11,7 @@ package scalaz.zio
  * which represents an interruptible asynchronous action where the canceler has the
  * form `Throwable => IO[Nothing, Unit]`
  */
-sealed abstract class Async[+E, +A] extends Serializable { self =>
+sealed abstract class Async[+E, +A] extends Product with Serializable { self =>
   def fold[E1, B](
     f: A => ExitResult[E1, B],
     g: (E, List[Throwable]) => ExitResult[E1, B],

--- a/core/shared/src/main/scala/scalaz/zio/Async.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Async.scala
@@ -11,7 +11,7 @@ package scalaz.zio
  * which represents an interruptible asynchronous action where the canceler has the
  * form `Throwable => IO[Nothing, Unit]`
  */
-sealed abstract class Async[+E, +A] { self =>
+sealed abstract class Async[+E, +A] extends Serializable { self =>
   def fold[E1, B](
     f: A => ExitResult[E1, B],
     g: (E, List[Throwable]) => ExitResult[E1, B],

--- a/core/shared/src/main/scala/scalaz/zio/Async.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Async.scala
@@ -24,7 +24,7 @@ sealed abstract class Async[+E, +A] extends Product with Serializable { self =>
     }
 }
 
-object Async {
+object Async extends Serializable {
 
   val NoOpCanceler: Canceler         = () => ()
   val NoOpPureCanceler: PureCanceler = () => IO.unit

--- a/core/shared/src/main/scala/scalaz/zio/Clock.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Clock.scala
@@ -4,7 +4,7 @@ package scalaz.zio
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration._
 
-trait Clock {
+trait Clock extends Serializable {
   def currentTime(unit: TimeUnit): IO[Nothing, Long]
   val nanoTime: IO[Nothing, Long]
   def sleep(length: Long, unit: TimeUnit): IO[Nothing, Unit]

--- a/core/shared/src/main/scala/scalaz/zio/ExitResult.scala
+++ b/core/shared/src/main/scala/scalaz/zio/ExitResult.scala
@@ -6,7 +6,7 @@ package scalaz.zio
  * completed with a value, failed because of an uncaught `E`, or terminated
  * due to interruption or runtime error.
  */
-sealed abstract class ExitResult[+E, +A] extends Serializable { self =>
+sealed abstract class ExitResult[+E, +A] extends Product with Serializable { self =>
   import ExitResult._
 
   final def succeeded: Boolean = self match {

--- a/core/shared/src/main/scala/scalaz/zio/ExitResult.scala
+++ b/core/shared/src/main/scala/scalaz/zio/ExitResult.scala
@@ -6,7 +6,7 @@ package scalaz.zio
  * completed with a value, failed because of an uncaught `E`, or terminated
  * due to interruption or runtime error.
  */
-sealed trait ExitResult[+E, +A] { self =>
+sealed abstract class ExitResult[+E, +A] extends Serializable { self =>
   import ExitResult._
 
   final def succeeded: Boolean = self match {

--- a/core/shared/src/main/scala/scalaz/zio/ExitResult.scala
+++ b/core/shared/src/main/scala/scalaz/zio/ExitResult.scala
@@ -47,7 +47,7 @@ sealed abstract class ExitResult[+E, +A] extends Product with Serializable { sel
     case _                          => ts
   }
 }
-object ExitResult {
+object ExitResult extends Serializable {
   final case class Completed[E, A](value: A) extends ExitResult[E, A]
 
   /**

--- a/core/shared/src/main/scala/scalaz/zio/Fiber.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Fiber.scala
@@ -21,7 +21,7 @@ package scalaz.zio
  * } yield a
  * }}}
  */
-trait Fiber[+E, +A] extends Serializable { self =>
+trait Fiber[+E, +A] { self =>
 
   /**
    * Observes the fiber, which suspends the observing fiber until the result of the

--- a/core/shared/src/main/scala/scalaz/zio/Fiber.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Fiber.scala
@@ -21,7 +21,7 @@ package scalaz.zio
  * } yield a
  * }}}
  */
-trait Fiber[+E, +A] { self =>
+trait Fiber[+E, +A] extends Serializable { self =>
 
   /**
    * Observes the fiber, which suspends the observing fiber until the result of the

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -647,7 +647,7 @@ sealed abstract class IO[+E, +A] extends Serializable { self =>
   def tag: Int
 }
 
-object IO {
+object IO extends Serializable {
 
   @inline
   private final def nowLeft[E, A]: E => IO[Nothing, Either[E, A]] =

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -42,7 +42,7 @@ import scala.concurrent.ExecutionContext
  * values, see the default interpreter in `RTS` or the safe main function in
  * `App`.
  */
-sealed abstract class IO[+E, +A] { self =>
+sealed abstract class IO[+E, +A] extends Serializable { self =>
 
   /**
    * Maps an `IO[E, A]` into an `IO[E, B]` by applying the specified `A => B` function

--- a/core/shared/src/main/scala/scalaz/zio/KleisliIO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/KleisliIO.scala
@@ -184,7 +184,7 @@ sealed abstract class KleisliIO[+E, -A, +B] extends Serializable { self =>
   final def asEffect[A1 <: A]: KleisliIO[E, A1, A1] = self.first >>> KleisliIO._2
 }
 
-object KleisliIO {
+object KleisliIO extends Serializable {
   private class KleisliIOError[E](error: E) extends Throwable {
     final def unsafeCoerce[E2] = error.asInstanceOf[E2]
   }

--- a/core/shared/src/main/scala/scalaz/zio/KleisliIO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/KleisliIO.scala
@@ -69,7 +69,7 @@ package scalaz.zio
  * In both of these examples, the `KleisliIO` program is faster because it is
  * able to perform fusion of effectful functions.
  */
-sealed trait KleisliIO[+E, -A, +B] { self =>
+sealed abstract class KleisliIO[+E, -A, +B] extends Serializable { self =>
 
   /**
    * Applies the effectful function with the specified value, returning the

--- a/core/shared/src/main/scala/scalaz/zio/Managed.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Managed.scala
@@ -1,6 +1,6 @@
 package scalaz.zio
 
-sealed abstract class Managed[+E, +R] { self =>
+sealed abstract class Managed[+E, +R] extends Serializable { self =>
   def use[E1 >: E, A](f: R => IO[E1, A]): IO[E1, A]
 
   final def use_[E1 >: E, A](f: IO[E1, A]): IO[E1, A] =

--- a/core/shared/src/main/scala/scalaz/zio/Promise.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Promise.scala
@@ -179,7 +179,7 @@ object Promise {
     } yield b
 
   private[zio] object internal {
-    sealed trait State[E, A]
+    sealed abstract class State[E, A] extends Serializable
     final case class Pending[E, A](joiners: List[Callback[E, A]]) extends State[E, A]
     final case class Done[E, A](value: ExitResult[E, A])          extends State[E, A]
   }

--- a/core/shared/src/main/scala/scalaz/zio/Promise.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Promise.scala
@@ -179,7 +179,7 @@ object Promise {
     } yield b
 
   private[zio] object internal {
-    sealed abstract class State[E, A] extends Serializable
+    sealed abstract class State[E, A]                             extends Serializable
     final case class Pending[E, A](joiners: List[Callback[E, A]]) extends State[E, A]
     final case class Done[E, A](value: ExitResult[E, A])          extends State[E, A]
   }

--- a/core/shared/src/main/scala/scalaz/zio/Promise.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Promise.scala
@@ -179,7 +179,7 @@ object Promise {
     } yield b
 
   private[zio] object internal {
-    sealed abstract class State[E, A]                             extends Serializable
+    sealed abstract class State[E, A]                             extends Serializable with Product
     final case class Pending[E, A](joiners: List[Callback[E, A]]) extends State[E, A]
     final case class Done[E, A](value: ExitResult[E, A])          extends State[E, A]
   }

--- a/core/shared/src/main/scala/scalaz/zio/Queue.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Queue.scala
@@ -17,7 +17,7 @@ import Queue.internal._
  * 2. Benchmark to see how slow this implementation is and if there are any
  *    easy ways to improve performance.
  */
-class Queue[A] private (capacity: Int, ref: Ref[State[A]]) {
+class Queue[A] private (capacity: Int, ref: Ref[State[A]]) extends Serializable {
 
   /**
    * Retrieves the size of the queue, which is equal to the number of elements
@@ -146,7 +146,7 @@ object Queue {
   final def unbounded[A]: IO[Nothing, Queue[A]] = bounded(Int.MaxValue)
 
   private[zio] object internal {
-    sealed trait State[A] {
+    sealed abstract class State[A] {
       def size: Int
     }
     final case class Deficit[A](takers: IQueue[Promise[Nothing, A]]) extends State[A] {

--- a/core/shared/src/main/scala/scalaz/zio/Queue.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Queue.scala
@@ -146,7 +146,7 @@ object Queue {
   final def unbounded[A]: IO[Nothing, Queue[A]] = bounded(Int.MaxValue)
 
   private[zio] object internal {
-    sealed abstract class State[A] {
+    sealed abstract class State[A] extends Product with Serializable {
       def size: Int
     }
     final case class Deficit[A](takers: IQueue[Promise[Nothing, A]]) extends State[A] {

--- a/core/shared/src/main/scala/scalaz/zio/Ref.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Ref.scala
@@ -90,7 +90,7 @@ final class Ref[A] private (private val value: AtomicReference[A]) extends AnyVa
     IO.sync(value.compareAndSet(prev, next))
 }
 
-object Ref {
+object Ref extends Serializable {
 
   /**
    * Creates a new `Ref` with the specified value.

--- a/core/shared/src/main/scala/scalaz/zio/Ref.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Ref.scala
@@ -16,7 +16,7 @@ import java.util.concurrent.atomic.AtomicReference
  * } yield ()
  * }}}
  */
-final class Ref[A] private (private val value: AtomicReference[A]) extends AnyVal {
+final class Ref[A] private (private val value: AtomicReference[A]) extends AnyVal with Serializable {
 
   /**
    * Reads the value from the `Ref`.

--- a/core/shared/src/main/scala/scalaz/zio/Schedule.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Schedule.scala
@@ -22,7 +22,7 @@ import scala.concurrent.duration.Duration
  * Thanks to (1), `Schedule[A, B]` forms an applicative functor on the output
  * value `B`, allowing rich composition of different schedules.
  */
-trait Schedule[-A, +B] { self =>
+trait Schedule[-A, +B] extends Serializable { self =>
 
   /**
    * The internal state type of the schedule.

--- a/core/shared/src/main/scala/scalaz/zio/Schedule.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Schedule.scala
@@ -403,7 +403,7 @@ trait Schedule[-A, +B] extends Serializable { self =>
   final def compose[C](that: Schedule[C, A]): Schedule[C, B] = self <<< that
 }
 
-object Schedule {
+object Schedule extends Serializable {
   sealed case class Decision[+A, +B](cont: Boolean, delay: Duration, state: A, finish: () => B) { self =>
     final def bimap[C, D](f: A => C, g: B => D): Decision[C, D] = copy(state = f(state), finish = () => g(finish()))
     final def leftMap[C](f: A => C): Decision[C, B]             = copy(state = f(state))

--- a/core/shared/src/main/scala/scalaz/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Semaphore.scala
@@ -9,7 +9,7 @@ import scalaz.zio.ExitResult.Terminated
 import scala.annotation.tailrec
 import scala.collection.immutable.{ Queue => IQueue }
 
-final class Semaphore private (private val state: Ref[State]) {
+final class Semaphore private (private val state: Ref[State]) extends Serializable {
 
   def count: IO[Nothing, Long] = state.get.map(count_)
 

--- a/core/shared/src/main/scala/scalaz/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Semaphore.scala
@@ -114,7 +114,7 @@ final class Semaphore private (private val state: Ref[State]) extends Serializab
 
 }
 
-object Semaphore {
+object Semaphore extends Serializable {
   def apply(permits: Long): IO[Nothing, Semaphore] = Ref[State](Right(permits)).map(new Semaphore(_))
 }
 


### PR DESCRIPTION
solves #286 
@jdegoes for part 3, do you want to add type bounds to IO methods ?

```final def parWith[E1 >: E, B, C](that: IO[E1, B])(f: (A, B) => C): IO[E1, C]```

to

```final def parWith[E1 >: E, B <: Serializable, C <: Serializable](that: IO[E1, B])(f: (A, B) => C): IO[E1, C]```