### PR TITLE
Don't supervise finalizers

### DIFF
--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -246,7 +246,7 @@ private object RTS {
           case a: IO.Redeem[_, _, _, _] =>
             errorHandler = a.err.asInstanceOf[Any => IO[Any, Any]]
           case f0: Finalizer =>
-            val f: IO[Nothing, Option[List[Throwable]]] = f0.finalizer.run.map(collectDefect)
+            val f: IO[Nothing, Option[List[Throwable]]] = fork(f0.finalizer, _ => IO.unit).observe.map(collectDefect)
             if (finalizer eq null) finalizer = f
             else finalizer = finalizer.seqWith(f)(zipFailures)
           case _ =>
@@ -279,7 +279,7 @@ private object RTS {
         // (reverse chronological).
         stack.pop() match {
           case f0: Finalizer =>
-            val f: IO[Nothing, Option[List[Throwable]]] = f0.finalizer.run.map(collectDefect)
+            val f: IO[Nothing, Option[List[Throwable]]] = fork(f0.finalizer, _ => IO.unit).observe.map(collectDefect)
             if (finalizer eq null) finalizer = f
             else finalizer = finalizer.seqWith(f)(zipFailures)
           case _ =>
@@ -586,7 +586,7 @@ private object RTS {
               this.noInterrupt += 1
 
               // At this point, all causes of interruption have been accumulated
-              // in the fiber status and will be read during evalution of this
+              // in the fiber status and will be read during evaluation of this
               // action:
               curIo = IO.terminate
             }

--- a/core/jvm/src/test/scala/scalaz/zio/KleisliIOSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/KleisliIOSpec.scala
@@ -120,8 +120,8 @@ class KleisliIOSpec extends AbstractRTSSpec {
   def e13 =
     unsafeRun(
       for {
-        v1 <- test(lift[Array[Int], Boolean](_.sum > 10)).run(Array(1, 2, 5))
-        v2 <- test(lift[Array[Int], Boolean](_.sum > 10)).run(Array(1, 2, 5, 6))
+        v1 <- KleisliIO.test(lift[Array[Int], Boolean](_.sum > 10)).run(Array(1, 2, 5))
+        v2 <- KleisliIO.test(lift[Array[Int], Boolean](_.sum > 10)).run(Array(1, 2, 5, 6))
       } yield (v1 must beRight(Array(1, 2, 5))) and (v2 must beLeft(Array(1, 2, 5, 6)))
     )
 

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -34,7 +34,9 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec with AroundTime
     catchSome . sandboxWith . terminate     $testSandboxWithCatchSomeOfTerminate
     catch sandboxed terminate               $testSandboxedTerminate
     uncaught fail                           $testEvalOfUncaughtFail
+    uncaught fail supervised                $testEvalOfUncaughtFailSupervised
     uncaught sync effect error              $testEvalOfUncaughtThrownSyncEffect
+    uncaught supervised sync effect error   $testEvalOfUncaughtThrownSupervisedSyncEffect
     deep uncaught sync effect error         $testEvalOfDeepUncaughtThrownSyncEffect
     deep uncaught fail                      $testEvalOfDeepUncaughtFail
     catch multiple causes                   $testEvalOfMultipleFail
@@ -198,8 +200,14 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec with AroundTime
   def testEvalOfUncaughtFail =
     unsafeRun(IO.fail[Throwable](ExampleError).as[Any]) must (throwA(UnhandledError(ExampleError)))
 
+  def testEvalOfUncaughtFailSupervised =
+    unsafeRun(IO.fail[Throwable](ExampleError).supervised.as[Any]) must (throwA(UnhandledError(ExampleError)))
+
   def testEvalOfUncaughtThrownSyncEffect =
     unsafeRun(IO.sync[Int](throw ExampleError)) must (throwA(ExampleError))
+
+  def testEvalOfUncaughtThrownSupervisedSyncEffect =
+    unsafeRun(IO.sync[Int](throw ExampleError).supervised) must (throwA(ExampleError))
 
   def testEvalOfDeepUncaughtThrownSyncEffect =
     unsafeRun(deepErrorEffect(100)) must (throwA(UnhandledError(ExampleError)))


### PR DESCRIPTION
Closes #288 

During supervision, finalizers run in separate fibers, so that defects in them can be captured. However, they shouldn't be supervised themselves! We can avoid that forking directly rather than going through the whole `IO.Fork` route.