### PR TITLE
Introduce RefM, which is like Ref but can handle effectful atomic updates

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/RefSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RefSpec.scala
@@ -8,13 +8,6 @@ class RefSpec extends AbstractRTSSpec {
       `write` puts the new value correctly.                                                    $e2
       `modify` changes the value and returns the updated value.                                $e3
       `modifyFold` changes the value and returns another value computed from the modification. $e4
-      `writeLater` puts a new value.                                                           $e5
-      `tryWrite` returns
-         true and puts a new value to Ref.                                                     $e6
-         false and abort if there is a concurrent modification of the value by other fibers.   $e7
-      `compareAndSet` returns
-        true if the previous value and the current value have the same reference.              $e8
-        false if the previous value and the current value have a different reference.          $e9
     """
 
   val (current, update) = ("value", "new value")
@@ -52,61 +45,4 @@ class RefSpec extends AbstractRTSSpec {
         value <- ref.get
       } yield (r must beTheSameAs("hello")) and (value must beTheSameAs(update))
     )
-
-  def e5 =
-    unsafeRun(
-      for {
-        ref   <- Ref(current)
-        _     <- ref.setLater(update)
-        value <- ref.get
-      } yield value must beTheSameAs(update)
-    )
-
-  def e6 =
-    unsafeRun(
-      for {
-        ref     <- Ref(current)
-        success <- ref.trySet(update)
-        value   <- ref.get
-      } yield (success must beTrue) and (value must beTheSameAs(update))
-    )
-
-  def e7 = {
-
-    def tryWriteUntilFalse(ref: Ref[Int], update: Int): IO[Nothing, Boolean] =
-      ref
-        .trySet(update)
-        .flatMap(success => if (!success) IO.point[Boolean](success) else tryWriteUntilFalse(ref, update))
-
-    unsafeRun(
-      for {
-        ref     <- Ref(0)
-        f1      <- ref.set(1).forever.fork
-        f2      <- ref.set(2).forever.fork
-        success <- tryWriteUntilFalse(ref, 3)
-        value   <- ref.get
-        _       <- f1.zipWith(f2)((_, _) => ()).interrupt
-      } yield (success must beFalse) and (value must be_!=(3))
-    )
-
-  }
-
-  def e8 =
-    unsafeRun(
-      for {
-        ref     <- Ref(current)
-        success <- ref.compareAndSet(current, update)
-        value   <- ref.get
-      } yield (success must beTrue) and (value must beTheSameAs(update))
-    )
-
-  def e9 =
-    unsafeRun(
-      for {
-        ref     <- Ref(current)
-        success <- ref.compareAndSet(update, current)
-        value   <- ref.get
-      } yield (success must beFalse) and (value must beTheSameAs(current))
-    )
-
 }

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -339,9 +339,10 @@ sealed abstract class IO[+E, +A] { self =>
     )(_ => self)
 
   /**
-   * Runs the specified action if this action is interrupted.
+   * Runs the specified action if this action is terminated, either because of
+   * a defect or because of interruption.
    */
-  final def onInterrupt(cleanup: List[Throwable] => IO[Nothing, Unit]): IO[E, A] =
+  final def onTermination(cleanup: List[Throwable] => IO[Nothing, Unit]): IO[E, A] =
     IO.bracket0(IO.unit)(
       (_, eb: ExitResult[E, A]) =>
         eb match {

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -346,9 +346,8 @@ sealed abstract class IO[+E, +A] { self =>
     IO.bracket0(IO.unit)(
       (_, eb: ExitResult[E, A]) =>
         eb match {
-          case ExitResult.Completed(_)   => IO.unit
-          case ExitResult.Failed(_, _)   => IO.unit
           case ExitResult.Terminated(ts) => cleanup(ts)
+          case _                         => IO.unit
         }
     )(_ => self)
 

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -325,8 +325,8 @@ sealed abstract class IO[+E, +A] { self =>
     Managed[E, A](this)(release)
 
   /**
-   * Runs the cleanup action if this action errors, providing the error to the
-   * cleanup action if it exists. The cleanup action will not be interrupted.
+   * Runs the specified action if this action errors, providing the error to the
+   * action if it exists. The provided action will not be interrupted.
    */
   final def onError(cleanup: ExitResult[E, Nothing] => IO[Nothing, Unit]): IO[E, A] =
     IO.bracket0(IO.unit)(
@@ -335,6 +335,19 @@ sealed abstract class IO[+E, +A] { self =>
           case ExitResult.Completed(_)   => IO.unit
           case ExitResult.Failed(e, ts)  => cleanup(ExitResult.Failed(e, ts))
           case ExitResult.Terminated(ts) => cleanup(ExitResult.Terminated(ts))
+        }
+    )(_ => self)
+
+  /**
+   * Runs the specified action if this action is interrupted.
+   */
+  final def onInterrupt(cleanup: List[Throwable] => IO[Nothing, Unit]): IO[E, A] =
+    IO.bracket0(IO.unit)(
+      (_, eb: ExitResult[E, A]) =>
+        eb match {
+          case ExitResult.Completed(_)   => IO.unit
+          case ExitResult.Failed(_, _)   => IO.unit
+          case ExitResult.Terminated(ts) => cleanup(ts)
         }
     )(_ => self)
 

--- a/core/shared/src/main/scala/scalaz/zio/Ref.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Ref.scala
@@ -36,12 +36,6 @@ final class Ref[A] private (private val value: AtomicReference[A]) extends AnyVa
   final def setLater(a: A): IO[Nothing, Unit] = IO.sync(value.lazySet(a))
 
   /**
-   * Attempts to write a new value to the `Ref`, but aborts immediately under
-   * concurrent modification of the value by other fibers.
-   */
-  final def trySet(a: A): IO[Nothing, Boolean] = IO.sync(value.compareAndSet(value.get, a))
-
-  /**
    * Atomically modifies the `Ref` with the specified function. This is not
    * implemented in terms of `modify` purely for performance reasons.
    */
@@ -81,13 +75,6 @@ final class Ref[A] private (private val value: AtomicReference[A]) extends AnyVa
 
     b
   }
-
-  /**
-   * Compares and sets the value of the `Ref` if and only if it is `eq` to the
-   * specified value. Returns whether or not the ref was modified.
-   */
-  final def compareAndSet(prev: A, next: A): IO[Nothing, Boolean] =
-    IO.sync(value.compareAndSet(prev, next))
 }
 
 object Ref {

--- a/core/shared/src/main/scala/scalaz/zio/RefM.scala
+++ b/core/shared/src/main/scala/scalaz/zio/RefM.scala
@@ -58,7 +58,7 @@ final class RefM[A] private (private val value: Ref[A], private val queue: Queue
     } yield b
 }
 
-object RefM {
+object RefM extends Serializable {
   private[RefM] final case class Bundle[A, B](
     var interrupted: Option[List[Throwable]] = None,
     update: A => IO[Nothing, (B, A)],
@@ -74,11 +74,7 @@ object RefM {
   /**
    * Creates a new `RefM` with the specified value.
    */
-  final def apply[A](
-    a: A,
-    n: Int = 1000,
-    onDefect: List[Throwable] => IO[Nothing, Unit] = _ => IO.unit
-  ): IO[Nothing, RefM[A]] =
+  final def apply[A](a: A, n: Int = 1000, onDefect: List[Throwable] => IO[Nothing, Unit] = _ => IO.unit): IO[Nothing, RefM[A]] =
     for {
       ref   <- Ref(a)
       queue <- Queue.bounded[Bundle[A, _]](n)

--- a/core/shared/src/main/scala/scalaz/zio/RefM.scala
+++ b/core/shared/src/main/scala/scalaz/zio/RefM.scala
@@ -1,0 +1,83 @@
+// Copyright (C) 2017-2018 John A. De Goes. All rights reserved.
+package scalaz.zio
+
+/**
+ * A mutable atomic reference for the `IO` monad. This is the `IO` equivalent of
+ * a volatile `var`, augmented with atomic effectful operations, which make it
+ * useful as a reasonably efficient (if low-level) concurrency primitive.
+ *
+ * Unlike `Ref`, `RefM` allows effects in atomic operations, which makes the
+ * structure slower but more powerful than `Ref`.
+ *
+ * {{{
+ * for {
+ *   ref <- RefM(2)
+ *   v   <- ref.update(_ + putStrLn("Hello World!").attempt.void *> IO.now(3))
+ *   _   <- putStrLn("Value = " + v) // Value = 5
+ * } yield ()
+ * }}}
+ */
+final class RefM[A] private (private val value: Ref[A], private val queue: Queue[RefM.Bundle[A, _]])
+    extends Serializable {
+
+  /**
+   * Reads the value from the `Ref`.
+   */
+  final def get: IO[Nothing, A] = value.get
+
+  /**
+   * Writes a new value to the `Ref`, with a guarantee of immediate
+   * consistency (at some cost to performance).
+   */
+  final def set(a: A): IO[Nothing, Unit] = value.set(a)
+
+  /**
+   * Writes a new value to the `Ref` without providing a guarantee of
+   * immediate consistency.
+   */
+  final def setLater(a: A): IO[Nothing, Unit] = value.setLater(a)
+
+  /**
+   * Atomically modifies the `RefM` with the specified function, returning the
+   * value immediately after modification.
+   */
+  final def update(f: A => IO[Nothing, A]): IO[Nothing, A] =
+    modify(a => f(a).map(a => (a, a)))
+
+  /**
+   * Atomically modifies the `RefM` with the specified function, which computes
+   * a return value for the modification. This is a more powerful version of
+   * `update`.
+   */
+  final def modify[B](f: A => IO[Nothing, (B, A)]): IO[Nothing, B] =
+    for {
+      promise <- Promise.make[Nothing, B]
+      bundle  = RefM.Bundle(None, f, promise)
+      _       <- queue.offer(bundle)
+      b       <- promise.get.onInterrupt(ts => IO.sync(bundle.interrupted = Some(ts)))
+    } yield b
+}
+
+object RefM {
+  private[RefM] final case class Bundle[A, B](
+    var interrupted: Option[List[Throwable]] = None,
+    update: A => IO[Nothing, (B, A)],
+    promise: Promise[Nothing, B]
+  ) {
+    final def run(a: A): IO[List[Throwable], A] =
+      interrupted match {
+        case Some(ts) => IO.fail(ts)
+        case None     => update(a).flatMap(t => promise.complete(t._1).map(_ => t._2))
+      }
+  }
+
+  /**
+   * Creates a new `RefM` with the specified value.
+   */
+  final def apply[A](a: A, n: Int = 1000): IO[Nothing, RefM[A]] =
+    for {
+      ref   <- Ref(a)
+      queue <- Queue.bounded[Bundle[A, _]](n)
+      _     <- queue.take.flatMap(b => ref.get.flatMap(a => b.run(a).redeem(_ => IO.unit, ref.set))).forever.fork
+    } yield new RefM[A](ref, queue)
+}

--- a/core/shared/src/main/scala/scalaz/zio/RefM.scala
+++ b/core/shared/src/main/scala/scalaz/zio/RefM.scala
@@ -74,7 +74,11 @@ object RefM extends Serializable {
   /**
    * Creates a new `RefM` with the specified value.
    */
-  final def apply[A](a: A, n: Int = 1000, onDefect: List[Throwable] => IO[Nothing, Unit] = _ => IO.unit): IO[Nothing, RefM[A]] =
+  final def apply[A](
+    a: A,
+    n: Int = 1000,
+    onDefect: List[Throwable] => IO[Nothing, Unit] = _ => IO.unit
+  ): IO[Nothing, RefM[A]] =
     for {
       ref   <- Ref(a)
       queue <- Queue.bounded[Bundle[A, _]](n)

--- a/core/shared/src/main/scala/scalaz/zio/RefM.scala
+++ b/core/shared/src/main/scala/scalaz/zio/RefM.scala
@@ -53,8 +53,10 @@ final class RefM[A] private (value: Ref[A], queue: Queue[RefM.Bundle[A, _]]) ext
       promise <- Promise.make[Nothing, B]
       ref     <- Ref[Option[List[Throwable]]](None)
       bundle  = RefM.Bundle(ref, f, promise)
-      _       <- queue.offer(bundle)
-      b       <- promise.get.onTermination(ts => bundle.interrupted.set(Some(ts)))
+      b <- (for {
+            _ <- queue.offer(bundle)
+            b <- promise.get
+          } yield b).onTermination(ts => bundle.interrupted.set(Some(ts)))
     } yield b
 }
 


### PR DESCRIPTION
I've found myself reinventing this over many different projects. Better to live in ZIO.

It's a version of `Ref` whose `update` and `modify` methods accept effectful update/modify functions.

The API is otherwise identical. I also pared down the `Ref` API, deleting useless methods.