### PR TITLE
Set scheduled executor threads to be daemon

### DIFF
--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -74,7 +74,7 @@ trait RTS {
    */
   final val YieldMaxOpCount = 1048576
 
-  lazy val scheduledExecutor = Executors.newScheduledThreadPool(1)
+  lazy val scheduledExecutor = newDefaultScheduledExecutor()
 
   final def submit[A](block: => A): Unit = {
     threadPool.submit(new Runnable {
@@ -1120,6 +1120,9 @@ private object RTS {
       threadFactory
     )
   }
+
+  final def newDefaultScheduledExecutor(): ScheduledExecutorService =
+    Executors.newScheduledThreadPool(1, new NamedThreadFactory("zio-timer", true))
 
   final class NamedThreadFactory(name: String, daemon: Boolean) extends ThreadFactory {
 


### PR DESCRIPTION
Somewhat of a continuation from #295 . I noticed that some asynchronous operations were still blocking the JVM exit, and the culprit was the internal thread pool for scheduled tasks. This change will make the threads on that pool daemonized.