### PR TITLE
Use shrinkable threadpool with bounded max # of threads by default

### DIFF
--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -72,7 +72,7 @@ trait RTS {
    *
    * FIXME: Replace this entirely with the new scheme.
    */
-  final val YieldMaxOpCount = 1048576
+  final val YieldMaxOpCount = 1024
 
   lazy val scheduledExecutor = newDefaultScheduledExecutor()
 

--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -1104,21 +1104,23 @@ private object RTS {
       }
 
   final def newDefaultThreadPool(): ExecutorService = {
-    val corePoolSize    = 0
-    val maximumPoolSize = Int.MaxValue
-    val keepAliveTime   = 60000L
-    val timeUnit        = TimeUnit.MILLISECONDS
-    val workQueue       = new SynchronousQueue[Runnable]()
-    val threadFactory   = new NamedThreadFactory("zio", true)
+    val corePoolSize  = Runtime.getRuntime.availableProcessors() * 2
+    val keepAliveTime = 1000L
+    val timeUnit      = TimeUnit.MILLISECONDS
+    val workQueue     = new LinkedBlockingQueue[Runnable]()
+    val threadFactory = new NamedThreadFactory("zio", true)
 
-    new ThreadPoolExecutor(
+    val threadPool = new ThreadPoolExecutor(
       corePoolSize,
-      maximumPoolSize,
+      corePoolSize,
       keepAliveTime,
       timeUnit,
       workQueue,
       threadFactory
     )
+    threadPool.allowCoreThreadTimeOut(true)
+
+    threadPool
   }
 
   final def newDefaultScheduledExecutor(): ScheduledExecutorService =

--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -72,7 +72,7 @@ trait RTS {
    *
    * FIXME: Replace this entirely with the new scheme.
    */
-  final val YieldMaxOpCount = 1024
+  val YieldMaxOpCount = 1024
 
   lazy val scheduledExecutor = newDefaultScheduledExecutor()
 


### PR DESCRIPTION
This is a follow up to https://github.com/scalaz/scalaz-zio/issues/294 and https://github.com/scalaz/scalaz-zio/pull/295

I'm not fully on-board with the change in #295. If the new behaviour is desired, please let me know. Otherwise, my concerns are:
1. Using unbounded threadpool as the default seems a bit risky. **Depending on the workload the # of threads can grow to 100s** and with a `keepAliveTimeout` of 60s it'll take a *long* time for a threadpool to shrink and thus lots of unnecessary context switches.
2. Allowing a threadpool to kill all working threads **can lead to increased processing latency** for spiky load since spinning up a thread can take 10s of ms.

If we just need a threadpool that can dynamically change its size **from 0 to N** depending on the load, it can be achieved using a regular bounded threadpool with `allowCoreThreadTimeOut` + `LinkedBoundedQueue` (this PR).

Here's a comparison of how threadpools behaves (code for the test app https://gist.github.com/artempyanykh/23672b174975477200f1ca07569f81c0).

**Unbounded dynamic ThreadPool**
Quickly grows from 6 to 44 threads to accommodate all submitted tasks, and then take quite a while to shrink.
```
Available CPUs: 8
Thread pool size: 0
Start queueing load (> poolSize)
Cycle 1 thread count = 6, queue size: 0, task count: 0 out of 0 completed
Cycle 2 thread count = 25, queue size: 0, task count: 0 out of 19 completed
Cycle 3 thread count = 44, queue size: 0, task count: 1 out of 38 completed
Cycle 4 thread count = 44, queue size: 0, task count: 19 out of 57 completed
Cycle 5 thread count = 44, queue size: 0, task count: 38 out of 76 completed
Cycle 6 thread count = 44, queue size: 0, task count: 57 out of 94 completed
Cycle 7 thread count = 44, queue size: 0, task count: 76 out of 100 completed
Cycle 8 thread count = 44, queue size: 0, task count: 95 out of 100 completed
Start light load (< poolSize)
Cycle 9 thread count = 44, queue size: 0, task count: 100 out of 101 completed
Cycle 10 thread count = 44, queue size: 0, task count: 100 out of 101 completed
Cycle 11 thread count = 44, queue size: 0, task count: 101 out of 102 completed
Cycle 12 thread count = 44, queue size: 0, task count: 101 out of 102 completed
Cycle 13 thread count = 44, queue size: 0, task count: 102 out of 103 completed
Cycle 14 thread count = 44, queue size: 0, task count: 102 out of 103 completed
Cycle 15 thread count = 44, queue size: 0, task count: 103 out of 104 completed
Cycle 16 thread count = 44, queue size: 0, task count: 103 out of 104 completed
Cycle 17 thread count = 44, queue size: 0, task count: 104 out of 105 completed
Cycle 18 thread count = 44, queue size: 0, task count: 104 out of 105 completed
Cycle 19 thread count = 44, queue size: 0, task count: 105 out of 105 completed
Cycle 20 thread count = 44, queue size: 0, task count: 105 out of 105 completed
... 47 seconds later the pool starts to shrink
Cycle 67 thread count = 26, queue size: 0, task count: 105 out of 105 completed
Cycle 68 thread count = 8, queue size: 0, task count: 105 out of 105 completed
Cycle 69 thread count = 8, queue size: 0, task count: 105 out of 105 completed
Cycle 70 thread count = 8, queue size: 0, task count: 105 out of 105 completed
Cycle 71 thread count = 8, queue size: 0, task count: 105 out of 105 completed
Cycle 72 thread count = 8, queue size: 0, task count: 105 out of 105 completed
Cycle 73 thread count = 8, queue size: 0, task count: 105 out of 105 completed
Cycle 74 thread count = 8, queue size: 0, task count: 105 out of 105 completed
Cycle 75 thread count = 7, queue size: 0, task count: 105 out of 105 completed
Cycle 76 thread count = 7, queue size: 0, task count: 105 out of 105 completed
Cycle 77 thread count = 7, queue size: 0, task count: 105 out of 105 completed
Cycle 78 thread count = 7, queue size: 0, task count: 105 out of 105 completed
Cycle 79 thread count = 6, queue size: 0, task count: 105 out of 105 completed
```

**Bounded dynamic ThreadPool with a queue**
Grows to configured max # of threads, excess tasks are queued, shrinks quickly after all tasks are completed.
```
Available CPUs: 8
Thread pool size: 16
Start queueing load (> poolSize)
Cycle 1 thread count = 6, queue size: 0, task count: 0 out of 0 completed
Cycle 2 thread count = 22, queue size: 3, task count: 0 out of 19 completed
Cycle 3 thread count = 22, queue size: 21, task count: 1 out of 38 completed
Cycle 4 thread count = 22, queue size: 24, task count: 16 out of 56 completed
Cycle 5 thread count = 22, queue size: 42, task count: 17 out of 75 completed
Cycle 6 thread count = 22, queue size: 46, task count: 32 out of 94 completed
Cycle 7 thread count = 22, queue size: 51, task count: 33 out of 100 completed
Cycle 8 thread count = 22, queue size: 36, task count: 48 out of 100 completed
Cycle 9 thread count = 22, queue size: 35, task count: 49 out of 100 completed
Cycle 10 thread count = 22, queue size: 20, task count: 64 out of 100 completed
Cycle 11 thread count = 22, queue size: 19, task count: 65 out of 100 completed
Cycle 12 thread count = 22, queue size: 4, task count: 80 out of 100 completed
Cycle 13 thread count = 22, queue size: 3, task count: 81 out of 100 completed
Cycle 14 thread count = 22, queue size: 0, task count: 96 out of 100 completed
Cycle 15 thread count = 10, queue size: 0, task count: 97 out of 100 completed
Start light load (< poolSize)
Cycle 16 thread count = 10, queue size: 0, task count: 100 out of 101 completed
Cycle 17 thread count = 7, queue size: 0, task count: 100 out of 101 completed
Cycle 18 thread count = 8, queue size: 0, task count: 101 out of 102 completed
Cycle 19 thread count = 7, queue size: 0, task count: 101 out of 102 completed
Cycle 20 thread count = 8, queue size: 0, task count: 102 out of 103 completed
Cycle 21 thread count = 7, queue size: 0, task count: 102 out of 103 completed
Cycle 22 thread count = 8, queue size: 0, task count: 103 out of 104 completed
Cycle 23 thread count = 7, queue size: 0, task count: 103 out of 104 completed
Cycle 24 thread count = 8, queue size: 0, task count: 104 out of 105 completed
Cycle 25 thread count = 7, queue size: 0, task count: 104 out of 105 completed
Cycle 26 thread count = 7, queue size: 0, task count: 105 out of 105 completed
Cycle 27 thread count = 6, queue size: 0, task count: 105 out of 105 completed
Cycle 28 thread count = 6, queue size: 0, task count: 105 out of 105 completed
```