### PR TITLE
More general type signature for putStr and putStrLn

### DIFF
--- a/core/jvm/src/main/scala/scalaz/zio/console/package.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/console/package.scala
@@ -4,25 +4,25 @@ package scalaz.zio
 import java.io.IOException
 
 package object console {
-  private val ioException: PartialFunction[Throwable, IOException] = {
-    case e: IOException => e
-  }
 
   /**
    * Prints text to the console.
    */
-  def putStr(line: String): IO[IOException, Unit] =
-    IO.syncCatch(scala.Console.print(line))(ioException)
+  def putStr(line: String): IO[Nothing, Unit] =
+    IO.sync(scala.Console.print(line))
 
   /**
    * Prints a line of text to the console, including a newline character.
    */
-  def putStrLn(line: String): IO[IOException, Unit] =
-    IO.syncCatch(scala.Console.println(line))(ioException)
+  def putStrLn(line: String): IO[Nothing, Unit] =
+    IO.sync(scala.Console.println(line))
 
   /**
    * Retrieves a line of input from the console.
    */
   def getStrLn: IO[IOException, String] =
-    IO.syncCatch(scala.io.StdIn.readLine())(ioException)
+    IO.syncCatch(scala.io.StdIn.readLine()) {
+      case e: IOException => e
+    }
+
 }


### PR DESCRIPTION
I noticed that the underlying actions for `putStr` and `putStrLn` don't actually throw an `IOException`. I don't know if it the original intention was to preserve parity, but putting this out there anyway. Makes for simpler `App`s when I'm testing :)