### PR TITLE
Implement FiberLocal

### DIFF
--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -375,6 +375,11 @@ private object RTS {
 
                         curIo = io.flatMapper(io2.effect())
 
+                      case IO.Tags.Descriptor =>
+                        val value = Fiber.Descriptor(fiberId)
+
+                        curIo = io.flatMapper(value)
+
                       case _ =>
                         // Fallback case. We couldn't evaluate the LHS so we have to
                         // use the stack:
@@ -594,7 +599,7 @@ private object RTS {
                     curIo = io.io
 
                   case IO.Tags.Descriptor =>
-                    val value = FiberDescriptor(fiberId)
+                    val value = Fiber.Descriptor(fiberId)
 
                     curIo = nextInstr[E](value, stack)
 

--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -592,7 +592,7 @@ private object RTS {
                     stack.push(new Finalizer(io.finalizer))
                     curIo = io.io
 
-                  case IO.Tags.FiberIdentity =>
+                  case IO.Tags.Descriptor =>
                     val value = fiberId
 
                     curIo = nextInstr[E](value, stack)

--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -595,7 +595,7 @@ private object RTS {
                     curIo = io.io
 
                   case IO.Tags.Descriptor =>
-                    val value = fiberId
+                    val value = FiberDescriptor(fiberId)
 
                     curIo = nextInstr[E](value, stack)
 

--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -118,7 +118,6 @@ trait RTS {
 
 private object RTS {
 
-
   /**
    * The global counter for assigning fiber identities on creation.
    */

--- a/core/jvm/src/test/scala/scalaz/zio/FiberLocalSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/FiberLocalSpec.scala
@@ -1,0 +1,62 @@
+package scalaz.zio
+
+class FiberLocalSpec extends AbstractRTSSpec {
+
+  def is =
+    "FiberLocalSpec".title ^ s2"""
+    Create a new FiberLocal and
+      retrieve fiber-local data that has been set          $e1
+      empty fiber-local data                               $e2
+      automatically sets and frees data                    $e3
+      fiber-local data cannot be accessed by other fibers  $e4
+      setting does not overwrite existing fiber-local data $e5
+    """
+
+  def e1 = unsafeRun(
+    for {
+      local <- FiberLocal.make[Int]
+      _     <- local.set(10)
+      v     <- local.get
+    } yield v must_=== Some(10)
+  )
+
+  def e2 = unsafeRun(
+    for {
+      local <- FiberLocal.make[Int]
+      _     <- local.set(10)
+      _     <- local.empty
+      v     <- local.get
+    } yield v must_=== None
+  )
+
+  def e3 = unsafeRun(
+    for {
+      local <- FiberLocal.make[Int]
+      v1    <- local.locally(10)(local.get)
+      v2    <- local.get
+    } yield (v1 must_=== Some(10)) and (v2 must_=== None)
+  )
+
+  def e4 = unsafeRun(
+    for {
+      local <- FiberLocal.make[Int]
+      p     <- Promise.make[Nothing, Unit]
+      _     <- (local.set(10) *> p.complete(())).fork
+      _     <- p.get
+      v     <- local.get
+    } yield (v must_=== None)
+  )
+
+  def e5 = unsafeRun(
+    for {
+      local <- FiberLocal.make[Int]
+      p     <- Promise.make[Nothing, Unit]
+      f     <- (local.set(10) *> p.get *> local.get).fork
+      _     <- local.set(20)
+      _     <- p.complete(())
+      v1    <- f.join
+      v2    <- local.get
+    } yield (v1 must_=== Some(10)) and (v2 must_== Some(20))
+  )
+
+}

--- a/core/shared/src/main/scala/scalaz/zio/Fiber.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Fiber.scala
@@ -117,6 +117,8 @@ trait Fiber[+E, +A] { self =>
 }
 
 object Fiber {
+  final case class Descriptor(id: FiberId)
+
   final def point[E, A](a: => A): Fiber[E, A] =
     new Fiber[E, A] {
       def observe: IO[Nothing, ExitResult[E, A]]             = IO.point(ExitResult.Completed(a))

--- a/core/shared/src/main/scala/scalaz/zio/FiberDescriptor.scala
+++ b/core/shared/src/main/scala/scalaz/zio/FiberDescriptor.scala
@@ -1,0 +1,3 @@
+package scalaz.zio
+
+final case class FiberDescriptor(id: FiberId)

--- a/core/shared/src/main/scala/scalaz/zio/FiberDescriptor.scala
+++ b/core/shared/src/main/scala/scalaz/zio/FiberDescriptor.scala
@@ -1,3 +1,0 @@
-package scalaz.zio
-
-final case class FiberDescriptor(id: FiberId)

--- a/core/shared/src/main/scala/scalaz/zio/FiberLocal.scala
+++ b/core/shared/src/main/scala/scalaz/zio/FiberLocal.scala
@@ -37,6 +37,8 @@ final class FiberLocal[A] private (private val state: Ref[State[A]]) extends Ser
 
   /**
    * Returns an `IO` that runs with `value` bound to the current fiber.
+   *
+   * Guarantees that fiber-local data is properly freed via `bracket`.
    */
   final def locally[E, B](value: A)(use: IO[E, B]): IO[E, B] =
     set(value).bracket(_ => empty)(_ => use)

--- a/core/shared/src/main/scala/scalaz/zio/FiberLocal.scala
+++ b/core/shared/src/main/scala/scalaz/zio/FiberLocal.scala
@@ -13,17 +13,17 @@ final class FiberLocal[A] private (private val state: Ref[State[A]]) extends Ser
    */
   final def get: IO[Nothing, Option[A]] =
     for {
-      fiberId <- IO.fiberIdentity
-      value   <- state.get
-    } yield value.get(fiberId)
+      descriptor <- IO.descriptor
+      value      <- state.get
+    } yield value.get(descriptor.id)
 
   /**
    * Sets the value associated with the current fiber.
    */
   final def set(value: A): IO[Nothing, Unit] =
     for {
-      fiberId <- IO.fiberIdentity
-      _       <- state.update(_ + (fiberId -> value))
+      descriptor <- IO.descriptor
+      _          <- state.update(_ + (descriptor.id -> value))
     } yield ()
 
   /**
@@ -31,8 +31,8 @@ final class FiberLocal[A] private (private val state: Ref[State[A]]) extends Ser
    */
   final def empty: IO[Nothing, Unit] =
     for {
-      fiberId <- IO.fiberIdentity
-      _       <- state.update(_ - fiberId)
+      descriptor <- IO.descriptor
+      _          <- state.update(_ - descriptor.id)
     } yield ()
 
   /**

--- a/core/shared/src/main/scala/scalaz/zio/FiberLocal.scala
+++ b/core/shared/src/main/scala/scalaz/zio/FiberLocal.scala
@@ -1,0 +1,59 @@
+package scalaz.zio
+
+import FiberLocal.internal._
+
+/**
+ * A container for fiber-local storage. It is the pure equivalent to Java's `ThreadLocal`
+ * on a fiber architecture.
+ */
+final class FiberLocal[A] private (private val state: Ref[State[A]]) extends Serializable {
+
+  /**
+   * Reads the value associated with the current fiber.
+   */
+  final def get: IO[Nothing, Option[A]] =
+    for {
+      fiberId <- IO.fiberIdentity
+      value   <- state.get
+    } yield value.get(fiberId)
+
+  /**
+   * Sets the value associated with the current fiber.
+   */
+  final def set(value: A): IO[Nothing, Unit] =
+    for {
+      fiberId <- IO.fiberIdentity
+      _       <- state.update(_ + (fiberId -> value))
+    } yield ()
+
+  /**
+   * Empties the value associated with the current fiber.
+   */
+  final def empty: IO[Nothing, Unit] =
+    for {
+      fiberId <- IO.fiberIdentity
+      _       <- state.update(_ - fiberId)
+    } yield ()
+
+  /**
+   * Returns an `IO` that runs with `value` bound to the current fiber.
+   */
+  final def locally[E, B](value: A)(use: IO[E, B]): IO[E, B] =
+    set(value).bracket(_ => empty)(_ => use)
+
+}
+
+object FiberLocal {
+
+  /**
+   * Creates a new `FiberLocal`.
+   */
+  final def make[A]: IO[Nothing, FiberLocal[A]] =
+    Ref[internal.State[A]](Map())
+      .map(state => new FiberLocal(state))
+
+  private[zio] object internal {
+    type State[A] = Map[FiberId, A]
+  }
+
+}

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -781,7 +781,7 @@ object IO extends Serializable {
     override def tag = Tags.Ensuring
   }
 
-  final class Descriptor private[IO] extends IO[Nothing, FiberDescriptor] {
+  final class Descriptor private[IO] extends IO[Nothing, Fiber.Descriptor] {
     override def tag = Tags.Descriptor
   }
 
@@ -1123,7 +1123,7 @@ object IO extends Serializable {
   /**
    * Returns information about the current fiber, such as its fiber identity.
    */
-  private[zio] final def descriptor: IO[Nothing, FiberDescriptor] =
+  private[zio] final def descriptor: IO[Nothing, Fiber.Descriptor] =
     new Descriptor
 
 }

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -694,7 +694,7 @@ object IO extends Serializable {
     final val Terminate       = 14
     final val Supervisor      = 15
     final val Ensuring        = 16
-    final val FiberIdentity   = 17
+    final val Descriptor      = 17
   }
   final class FlatMap[E, A0, A] private[IO] (val io: IO[E, A0], val flatMapper: A0 => IO[E, A]) extends IO[E, A] {
     override def tag = Tags.FlatMap
@@ -781,8 +781,8 @@ object IO extends Serializable {
     override def tag = Tags.Ensuring
   }
 
-  final class FiberIdentity private[IO] extends IO[Nothing, FiberId] {
-    override def tag = Tags.FiberIdentity
+  final class Descriptor private[IO] extends IO[Nothing, FiberDescriptor] {
+    override def tag = Tags.Descriptor
   }
 
   /**
@@ -1121,9 +1121,9 @@ object IO extends Serializable {
     in.foldLeft[IO[E, B]](IO.point[B](zero))((acc, a) => acc.par(a).map(f.tupled))
 
   /**
-   * Returns a value that uniquely identifies the current fiber.
+   * Returns information about the current fiber, such as its fiber identity.
    */
-  private[zio] final def fiberIdentity: IO[Nothing, FiberId] =
-    new FiberIdentity
+  private[zio] final def descriptor: IO[Nothing, FiberDescriptor] =
+    new Descriptor
 
 }

--- a/core/shared/src/main/scala/scalaz/zio/package.scala
+++ b/core/shared/src/main/scala/scalaz/zio/package.scala
@@ -6,4 +6,5 @@ package object zio {
   type Callback[E, A] = ExitResult[E, A] => Unit
   type Canceler       = () => Unit
   type PureCanceler   = () => IO[Nothing, Unit]
+  type FiberId        = Long
 }

--- a/core/shared/src/main/scala/scalaz/zio/package.scala
+++ b/core/shared/src/main/scala/scalaz/zio/package.scala
@@ -7,6 +7,4 @@ package object zio {
   type Canceler       = () => Unit
   type PureCanceler   = () => IO[Nothing, Unit]
   type FiberId        = Long
-
-  final case class FiberDescriptor(id: FiberId)
 }

--- a/core/shared/src/main/scala/scalaz/zio/package.scala
+++ b/core/shared/src/main/scala/scalaz/zio/package.scala
@@ -7,4 +7,6 @@ package object zio {
   type Canceler       = () => Unit
   type PureCanceler   = () => IO[Nothing, Unit]
   type FiberId        = Long
+
+  final case class FiberDescriptor(id: FiberId)
 }

--- a/microsite/src/main/resources/microsite/data/menu.yml
+++ b/microsite/src/main/resources/microsite/data/menu.yml
@@ -17,6 +17,8 @@ options:
       url: usage/bracket.html
     - title: Fibers
       url: usage/fibers.html
+    - title: FiberLocal
+      url: usage/fiberlocal.html
     - title: Promise
       url: usage/promise.html
     - title: Schedules

--- a/microsite/src/main/tut/usage/fiberlocal.md
+++ b/microsite/src/main/tut/usage/fiberlocal.md
@@ -1,0 +1,42 @@
+---
+layout: docs
+section: usage
+title:  "FiberLocal"
+---
+
+# FiberLocal
+
+A `FiberLocal[A]` is a container for fiber-local storage that enables you to bind a value of type `A` to a fiber. Fiber-local data can be accessed only by the fiber it is bound to, for as long as it remains bound, via a `FiberLocal` reference.
+
+`FiberLocal` is the pure equivalent of thread-local storage (e.g. Java's `ThreadLocal`) on a fiber architecture.
+
+```tut:silent
+import scalaz.zio._
+
+for {
+  local <- FiberLocal.make[Int]
+  _     <- local.set(10)
+  v     <- local.get
+  _     <- local.empty
+} yield v == Some(10)
+```
+
+## Operations
+
+The basic operations on a `FiberLocal` are `get`, `set` and `empty`.
+
+- `get` returns the current, possibly non-existent, fiber-bound `A` in an `Option[A]`
+- `set` binds an `A` to the current fiber
+- `empty` clears the current, fiber-bound `A` if it exists
+
+When binding data to a fiber manually, it is important to always unbind that data. Otherwise, you will start "leaking" memory because old fiber-local data will never be evicted. However, in the face of cancellation and failure, using `set` and `empty` with `flatMap` is insufficient.
+
+Instead of using `set` and `empty`, you should always use another method, `locally`, that automatically runs a specified `IO` with fiber-bound data, and guarantees that any bound data is unbound, avoiding possible leaks.
+
+```tut:silent
+for {
+  local <- FiberLocal.make[Int]
+  f     <- local.locally(10)(local.get).fork
+  v     <- f.join
+} yield v == Some(10)
+```


### PR DESCRIPTION
This PR provides an initial implementation for a type called `FiberLocal`, which is meant to be a pure equivalent to Java's `ThreadLocal` on a fiber architecture. While there are arguments for and against such a feature, I am proposing this as a proof-of-concept both to introduce additions needed to the core ZIO library and to discuss the merits of `FiberLocal`.

# Goals
- Introduce the notion of fiber identity to ZIO. This is the only necessary change to the core library to support `FiberLocal` and other types that may rely on fiber identity.
- Introduce the `FiberLocal` type. `FiberLocal` offers a form of concurrent storage that enables users to bind data to a fiber.

# Usage

```scala
for {
  localTraceId <- FiberLocal.make[String]
  _            <- localTraceId.set("14127")
  traceId      <- localTraceId.get
  _            <- traceId.fold(IO.unit)(putStrLn)
} yield ()
```

# TODO
[x] Write tests.
[x] Write documentation.
[x] Optimize code -- there are several `flatMap`s in the `FiberLocal` implementation that aren't strictly necessary.

# Questions
- What should happen at fork boundaries? Right now, a child fiber would not retain any fiber-local data from its parent fiber. Maybe we could introduce forking capabilities on `FiberLocal` that would propagate parent data to child fibers?
- `FiberLocal` uses `Ref` internally to hold data. Since the implementation is hidden from the user, we could also consider using `ConcurrentHashMap` (or even a pure equivalent) to improve concurrency.

# Discussion

In the larger software community, thread-local storage has played a role in addressing logging, tracing and many other cross-cutting concerns. However, on a fiber-based architecture, there is no guarantee that some computation will execute only on a single thread, therefore thread-local storage serves us no value.

For problems like passing a distributed trace ID throughout your application, the solution has been to pass a value all the way down your call stack wherever you need it. You could encode this need into a tagless final algebra and pop a `Kleisli` onto your growing monad stack, but there are several arguments against that.

Logging also loses much of its value in a fiber-based architecture. Since there is no guarantee that a fiber executes on a single given thread over its life time, the thread information that loggers print out aren't very meaningful anymore. Per-thread logging metadata isn't the best either; its not easy to distinguish logs from different logical computations that happen to occur on the same thread at some point in their lifetime.

However, with fiber identities, you could not only group together logs emitted by a given fiber, but you can distinguish them from logs emitted by *all other fibers* as well.

I have also seen thread-local storage used to "hide" the details of an underlying data source from business logic, although I don't believe this is a very compelling use case.