### PR TITLE
Issue #199: add test for IO.repeat

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/RepeatSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RepeatSpec.scala
@@ -33,7 +33,6 @@ class RepeatSpec extends AbstractRTSSpec with GenIO with ScalaCheck {
     repeated must_=== n
   }
 
-
   def repeat1 = {
     val n = 1
     val repeated = unsafeRun(repeat(n))

--- a/core/jvm/src/test/scala/scalaz/zio/RepeatSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RepeatSpec.scala
@@ -1,0 +1,48 @@
+package scalaz.zio
+
+import org.specs2.ScalaCheck
+
+class RepeatSpec extends AbstractRTSSpec with GenIO with ScalaCheck {
+  def is = "RepeatSpec".title ^ s2"""
+   Repeat on success according to a provided strategy
+      for a negatime number of time does nothing $repeatNeg
+      for 0 time does nothing $repeat0
+      for 1 time does the action one time $repeat1
+      for a given number of times $repeatN
+    """
+
+  val repeat: Int => IO[Nothing, Int] = (n: Int) => for {
+      ref <- Ref(0)
+      s   <- ref.update(_ + 1).repeat(Schedule.recurs(n))
+    } yield s
+
+  /*
+   * A repeat with a negative number of times should not execute the action at all
+   */
+  def repeatNeg = {
+    val repeated = unsafeRun(repeat(-5))
+    repeated must_=== 0
+  }
+
+  /*
+   * A repeat with 0 number of times should not execute the action at all
+   */
+  def repeat0 = {
+    val n = 0
+    val repeated = unsafeRun(repeat(n))
+    repeated must_=== n
+  }
+
+
+  def repeat1 = {
+    val n = 1
+    val repeated = unsafeRun(repeat(n))
+    repeated must_=== n
+  }
+
+  def repeatN = {
+    val n = 42
+    val repeated = unsafeRun(repeat(n))
+    repeated must_=== n
+  }
+}

--- a/core/shared/src/main/scala/scalaz/zio/Schedule.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Schedule.scala
@@ -586,8 +586,13 @@ object Schedule extends Serializable {
   /**
    * A schedule that recurs the specified number of times. Returns the number
    * of repetitions so far.
+   *
+   * If 0 of negative numbers are given, the operation is not done at all so
+   * that in (op: IO[E, A]).repeat(Schedule.recurs(0)) , op is not done at all.
    */
-  final def recurs(n: Int): Schedule[Any, Int] = forever.whileOutput(_ < n)
+  final def recurs(n: Int): Schedule[Any, Int] =
+    if(n < 1) Schedule[Int, Any, Int](IO.point(0), (_, _) => IO.now(Decision.done(Duration.Zero, 0, 0)))
+    else forever.whileOutput(_ < n)
 
   /**
    * A schedule that recurs forever without delay. Returns the elapsed time


### PR DESCRIPTION
Some very basic test for `IO.repeat`, but they raise a first question. The current implementation seems to execute the action at least once, even if the number of recurse in the repeat is 0 (or negative). So tests `repeatNeg` and `repeat0` are failing. 

So I'm not sure if I misunderstand `IO.repeat`, or `Schedule.recurs` (and in that case, perhaps a comment should be added) or if there is a problem with the implementation of one or the other. 