### PR TITLE
Enhance `interop` package for `Future`

### DIFF
--- a/interop/jvm/src/test/scala/scalaz/zio/interop/futureSpec.scala
+++ b/interop/jvm/src/test/scala/scalaz/zio/interop/futureSpec.scala
@@ -29,7 +29,7 @@ class futureSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec {
     catch exceptions thrown by lazy block                $catchBlockExceptionFiber
     return an `IO` that fails if `Future` fails          $propagateExceptionFromFutureFiber
     return an `IO` that produces the value from `Future` $produceValueFromFutureFiber
-  `Future.toIO` must
+  `Future.unsafeToIO` must
     convert a completed `Future` to an IO                $convertCompletedFutureToIO
     convert a failed Future to an failed IO              $convertFailedFutureToIO
   `Future.toFiber` must
@@ -139,7 +139,7 @@ class futureSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec {
 
   val convertCompletedFutureToIO = {
     def future: Future[Int] = Future.successful(42)
-    unsafeRun(future.toIO) must_=== 42
+    unsafeRun(future.unsafeToIO) must_=== 42
   }
 
   val convertCompletedFutureToFiber = {
@@ -149,7 +149,7 @@ class futureSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec {
 
   val convertFailedFutureToIO = {
     def future: Future[Int] = Future.failed(new Exception("fast failing"))
-    unsafeRun(future.toIO) must throwA[Exception](message = "fast failing")
+    unsafeRun(future.unsafeToIO) must throwA[Exception](message = "fast failing")
   }
 
   val convertFailedFutureToFiber = {

--- a/interop/shared/src/main/scala/scalaz/zio/interop/future.scala
+++ b/interop/shared/src/main/scala/scalaz/zio/interop/future.scala
@@ -48,7 +48,7 @@ object future {
   }
 
   class FutureOps[A](private val delayedFuture: () => Future[A]) extends AnyVal {
-    def unsafeToIO(implicit ec: ExecutionContext): IO[Throwable, A]       = IOObjOps(IO).fromFuture(delayedFuture)(ec)
+    def unsafeToIO(implicit ec: ExecutionContext): IO[Throwable, A] = IOObjOps(IO).fromFuture(delayedFuture)(ec)
     def toFiber(implicit ec: ExecutionContext): Fiber[Throwable, A] = FiberObjOps(Fiber).fromFuture(delayedFuture())(ec)
   }
 

--- a/interop/shared/src/main/scala/scalaz/zio/interop/future.scala
+++ b/interop/shared/src/main/scala/scalaz/zio/interop/future.scala
@@ -46,4 +46,9 @@ object future {
     def toFutureE(f: E => Throwable): IO[Nothing, Future[A]] = io.leftMap(f).toFuture
   }
 
+  implicit class FutureOps[A](private val future: Future[A]) extends AnyVal {
+    def toIO(implicit ec: ExecutionContext): IO[Throwable, A]       = IOObjOps(IO).fromFuture(() => future)(ec)
+    def toFiber(implicit ec: ExecutionContext): Fiber[Throwable, A] = FiberObjOps(Fiber).fromFuture(future)(ec)
+  }
+
 }

--- a/interop/shared/src/main/scala/scalaz/zio/interop/future.scala
+++ b/interop/shared/src/main/scala/scalaz/zio/interop/future.scala
@@ -48,7 +48,7 @@ object future {
   }
 
   class FutureOps[A](private val delayedFuture: () => Future[A]) extends AnyVal {
-    def toIO(implicit ec: ExecutionContext): IO[Throwable, A]       = IOObjOps(IO).fromFuture(delayedFuture)(ec)
+    def unsafeToIO(implicit ec: ExecutionContext): IO[Throwable, A]       = IOObjOps(IO).fromFuture(delayedFuture)(ec)
     def toFiber(implicit ec: ExecutionContext): Fiber[Throwable, A] = FiberObjOps(Fiber).fromFuture(delayedFuture())(ec)
   }
 


### PR DESCRIPTION
- Add syntax (implicit) on Future to convert to IO or Fiber
- Add test for `Future.toIO` for a resolved `future`and a failed `future`
- Add test for `Future.toFiber` for a resolved `future`and a failed `future`
Link to #327