### PR TITLE
cats.Parallel instance for Task/ParIO[Throwable, ?]

### DIFF
--- a/interop/jvm/src/main/scala/scalaz/zio/interop/catsjvm.scala
+++ b/interop/jvm/src/main/scala/scalaz/zio/interop/catsjvm.scala
@@ -20,13 +20,16 @@ abstract class CatsInstances extends CatsInstances1 {
   implicit val taskEffectInstances: Effect[Task] with SemigroupK[Task] =
     new CatsEffect
 
-  implicit val catsParallelInstance: Parallel[Task, ParIO[Throwable, ?]] =
-    new CatsParallel[Throwable](taskEffectInstances)
+  implicit val taskParallelInstance: Parallel[Task, ParIO[Throwable, ?]] =
+    implicitly
 }
 
 sealed abstract class CatsInstances1 extends CatsInstances2 {
   implicit def ioMonoidInstances[E: Monoid]: MonadError[IO[E, ?], E] with Bifunctor[IO] with Alternative[IO[E, ?]] =
     new CatsAlternative[E] with CatsBifunctor
+
+  implicit def parallelInstance[E](implicit M: Monad[IO[E, ?]]): Parallel[IO[E, ?], ParIO[E, ?]] =
+    new CatsParallel[E](M)
 }
 
 sealed abstract class CatsInstances2 {

--- a/interop/jvm/src/main/scala/scalaz/zio/interop/catsjvm.scala
+++ b/interop/jvm/src/main/scala/scalaz/zio/interop/catsjvm.scala
@@ -1,7 +1,6 @@
 package scalaz.zio
 package interop
 
-import cats.Parallel
 import cats.effect.{ Effect, ExitCase }
 import cats.syntax.functor._
 import cats.{ effect, _ }
@@ -16,7 +15,6 @@ abstract class CatsPlatform extends CatsInstances {
 }
 
 abstract class CatsInstances extends CatsInstances1 {
-
   implicit val taskEffectInstances: Effect[Task] with SemigroupK[Task] =
     new CatsEffect
 

--- a/interop/jvm/src/main/scala/scalaz/zio/interop/catsjvm.scala
+++ b/interop/jvm/src/main/scala/scalaz/zio/interop/catsjvm.scala
@@ -15,7 +15,7 @@ abstract class CatsInstances extends CatsInstances1 {
   implicit val taskEffectInstances: Effect[Task] with SemigroupK[Task] =
     new CatsEffect
 
-  implicit val taskParallelInstance: Parallel[Task, ParTask] =
+  implicit val taskParallelInstance: Parallel[Task, Task.Par] =
     parallelInstance(taskEffectInstances)
 }
 

--- a/interop/jvm/src/main/scala/scalaz/zio/interop/catsjvm.scala
+++ b/interop/jvm/src/main/scala/scalaz/zio/interop/catsjvm.scala
@@ -19,7 +19,7 @@ abstract class CatsInstances extends CatsInstances1 {
     new CatsEffect
 
   implicit val taskParallelInstance: Parallel[Task, ParIO[Throwable, ?]] =
-    implicitly
+    parallelInstance(taskEffectInstances)
 }
 
 sealed abstract class CatsInstances1 extends CatsInstances2 {

--- a/interop/jvm/src/test/scala/scalaz/zio/interop/scalaz72Spec.scala
+++ b/interop/jvm/src/test/scala/scalaz/zio/interop/scalaz72Spec.scala
@@ -19,7 +19,7 @@ class scalaz72Spec extends AbstractRTSSpec with ScalaCheck with GenIO {
       MonadPlus              ${monadPlus.laws[IO[Int, ?]]}
       MonadPlus (Monoid)     ${monadPlus.laws[IO[Option[Unit], ?]]}
       MonadError             ${monadError.laws[IO[Int, ?], Int]}
-      Applicative (Parallel) ${applicative.laws[ParIO[Int, ?]]}
+      Applicative (Parallel) ${applicative.laws[scalaz72.ParIO[Int, ?]]}
   """
 
   implicit def ioEqual[E: Equal, A: Equal]: Equal[IO[E, A]] =
@@ -31,9 +31,9 @@ class scalaz72Spec extends AbstractRTSSpec with ScalaCheck with GenIO {
   implicit def ioArbitrary[E: Arbitrary: Cogen, A: Arbitrary: Cogen]: Arbitrary[IO[E, A]] =
     Arbitrary(genIO[E, A])
 
-  implicit def ioParEqual[E: Equal, A: Equal]: Equal[ParIO[E, A]] =
-    ioEqual[E, A].contramap(Par.unwrap)
+  implicit def ioParEqual[E: Equal, A: Equal]: Equal[scalaz72.ParIO[E, A]] =
+    ioEqual[E, A].contramap(Tag.unwrap)
 
-  implicit def ioParArbitrary[E: Arbitrary: Cogen, A: Arbitrary: Cogen]: Arbitrary[ParIO[E, A]] =
-    Arbitrary(genIO[E, A].map(Par.apply))
+  implicit def ioParArbitrary[E: Arbitrary: Cogen, A: Arbitrary: Cogen]: Arbitrary[scalaz72.ParIO[E, A]] =
+    Arbitrary(genIO[E, A].map(Tag.apply))
 }

--- a/interop/jvm/src/test/scala/scalaz/zio/interop/scalaz72Spec.scala
+++ b/interop/jvm/src/test/scala/scalaz/zio/interop/scalaz72Spec.scala
@@ -32,8 +32,8 @@ class scalaz72Spec extends AbstractRTSSpec with ScalaCheck with GenIO {
     Arbitrary(genIO[E, A])
 
   implicit def ioParEqual[E: Equal, A: Equal]: Equal[ParIO[E, A]] =
-    ioEqual[E, A].contramap(Tag.unwrap)
+    ioEqual[E, A].contramap(Par.unwrap)
 
   implicit def ioParArbitrary[E: Arbitrary: Cogen, A: Arbitrary: Cogen]: Arbitrary[ParIO[E, A]] =
-    Arbitrary(genIO[E, A].map(Tag.apply))
+    Arbitrary(genIO[E, A].map(Par.apply))
 }

--- a/interop/shared/src/main/scala/scalaz/zio/interop/IONewtype.scala
+++ b/interop/shared/src/main/scala/scalaz/zio/interop/IONewtype.scala
@@ -1,0 +1,17 @@
+package scalaz.zio
+package interop
+
+private[interop] trait IONewtype {
+  type Base
+  trait Tag extends Any
+
+  type T[+E, +A] <: Base with Tag
+
+  def apply[E, A](io: IO[E, A]): T[E, A] =
+    io.asInstanceOf[T[E, A]]
+
+  def unwrap[E, A](t: T[E, A]): IO[E, A] =
+    t.asInstanceOf[IO[E, A]]
+}
+
+private[interop] object Par extends IONewtype

--- a/interop/shared/src/main/scala/scalaz/zio/interop/package.scala
+++ b/interop/shared/src/main/scala/scalaz/zio/interop/package.scala
@@ -2,9 +2,8 @@ package scalaz.zio
 
 package object interop {
 
-  type Task[A]       = IO[Throwable, A]
-  type ParIO[+E, +A] = Par.T[E, A]
-  type ParTask[+A]   = Par.T[Throwable, A]
+  type Task[A]     = IO[Throwable, A]
+  type ParIO[E, A] = Par.T[E, A]
 
   implicit final class AutoCloseableOps(private val a: AutoCloseable) extends AnyVal {
 

--- a/interop/shared/src/main/scala/scalaz/zio/interop/package.scala
+++ b/interop/shared/src/main/scala/scalaz/zio/interop/package.scala
@@ -2,7 +2,9 @@ package scalaz.zio
 
 package object interop {
 
-  type Task[A] = IO[Throwable, A]
+  type Task[A]       = IO[Throwable, A]
+  type ParIO[+E, +A] = Par.T[E, A]
+  type ParTask[+A]   = Par.T[Throwable, A]
 
   implicit final class AutoCloseableOps(private val a: AutoCloseable) extends AnyVal {
 

--- a/interop/shared/src/main/scala/scalaz/zio/interop/scalaz72.scala
+++ b/interop/shared/src/main/scala/scalaz/zio/interop/scalaz72.scala
@@ -2,12 +2,7 @@ package scalaz
 package zio
 package interop
 
-import Tags.Parallel
-import scalaz72.ParIO
-
-object scalaz72 extends IOInstances with Scalaz72Platform {
-  type ParIO[E, A] = IO[E, A] @@ Parallel
-}
+object scalaz72 extends IOInstances with Scalaz72Platform
 
 abstract class IOInstances extends IOInstances1 {
 
@@ -65,18 +60,18 @@ private trait IOBifunctor extends Bifunctor[IO] {
 }
 
 private class IOParApplicative[E] extends Applicative[ParIO[E, ?]] {
-  override def point[A](a: => A): ParIO[E, A] = Tag(IO.point(a))
+  override def point[A](a: => A): ParIO[E, A] = Par(IO.point(a))
   override def ap[A, B](fa: => ParIO[E, A])(f: => ParIO[E, A => B]): ParIO[E, B] = {
-    lazy val fa0: IO[E, A] = Tag.unwrap(fa)
-    Tag(Tag.unwrap(f).flatMap(x => fa0.map(x)))
+    lazy val fa0: IO[E, A] = Par.unwrap(fa)
+    Par(Par.unwrap(f).flatMap(x => fa0.map(x)))
   }
 
   override def map[A, B](fa: ParIO[E, A])(f: A => B): ParIO[E, B] =
-    Tag(Tag.unwrap(fa).map(f))
+    Par(Par.unwrap(fa).map(f))
 
   override def apply2[A, B, C](
     fa: => ParIO[E, A],
     fb: => ParIO[E, B]
   )(f: (A, B) => C): ParIO[E, C] =
-    Tag(Tag.unwrap(fa).par(Tag.unwrap(fb)).map(f.tupled))
+    Par(Par.unwrap(fa).par(Par.unwrap(fb)).map(f.tupled))
 }

--- a/interop/shared/src/main/scala/scalaz/zio/interop/task.scala
+++ b/interop/shared/src/main/scala/scalaz/zio/interop/task.scala
@@ -4,11 +4,9 @@ package interop
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration.Duration
 import scala.util.{ Failure, Success }
-import scalaz.@@
-import scalaz.Tags.Parallel
 
 object Task {
-  type Par[A] = Task[A] @@ Parallel
+  type Par[A] = Par.T[Throwable, A]
 
   final def apply[A](effect: => A): Task[A] = IO.syncThrowable(effect)
 


### PR DESCRIPTION
~~Quickly~~ create a `cats.Parallel` instance for `Task`/`Task.Par`.
~~Can we promote `ParIO` and `ParTask` (ie. `ParIO[Throwable, ?]`) to be a thing?~~

- Added `IONewtype` to workout the problem with Scalaz not in classpath [see](https://github.com/scalaz/scalaz-zio/pull/336#discussion_r230555520)
- `scalaz72.ParIO` is no more. Instead, a newtype `type ParIO[E, A] = IONewtype.T[E, A]`
- `Task.Par[A]` is no longer `Task[A] @@ Tags.Parallel`. Instead, a  newtype `IONewtype.T[Throwable, ?]`