### PR TITLE
Introduce `IO#to`

### DIFF
--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -695,9 +695,6 @@ sealed abstract class IO[+E, +A] extends Serializable { self =>
       case IO.Tags.Sleep =>
         val io = self.asInstanceOf[IO.Sleep]
         p.complete(().asInstanceOf[A]).delay(io.duration)
-      case IO.Tags.Fail =>
-        val io = self.asInstanceOf[IO.Fail[E]]
-        p.error(io.error)
       case IO.Tags.Terminate =>
         val io = self.asInstanceOf[IO.Terminate]
         p.interrupt0(io.causes)

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -682,25 +682,7 @@ sealed abstract class IO[+E, +A] extends Serializable { self =>
    * Keep or break a promise based on the result of this action.
    */
   final def to[E1 >: E, A1 >: A](p: Promise[E1, A1]): IO[Nothing, Boolean] =
-    (self.tag: @switch) match {
-      case IO.Tags.Point =>
-        val io = self.asInstanceOf[IO.Point[A]]
-        p.complete(io.value())
-      case IO.Tags.Strict =>
-        val io = self.asInstanceOf[IO.Strict[A]]
-        p.complete(io.value)
-      case IO.Tags.SyncEffect =>
-        val io = self.asInstanceOf[IO.SyncEffect[A]]
-        p.complete(io.effect())
-      case IO.Tags.Sleep =>
-        val io = self.asInstanceOf[IO.Sleep]
-        p.complete(().asInstanceOf[A]).delay(io.duration)
-      case IO.Tags.Terminate =>
-        val io = self.asInstanceOf[IO.Terminate]
-        p.interrupt0(io.causes)
-      case _ =>
-        self.run.flatMap(p.done(_))
-    }
+    self.run.flatMap(p.done(_))
 
   /**
    * An integer that identifies the term in the `IO` sum type to which this

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -191,7 +191,7 @@ sealed abstract class IO[+E, +A] extends Serializable { self =>
     )(res: ExitResult[E0, A]): IO[Nothing, _] =
       race
         .modify(r => r.won(res.succeeded) -> r.next(res.succeeded))
-        .flatMap(IO.when(_)(f(winner, loser).run.flatMap(done.done(_)).void))
+        .flatMap(IO.when(_)(f(winner, loser).to(done).void))
 
     (for {
       done  <- Promise.make[E2, C]
@@ -681,9 +681,9 @@ sealed abstract class IO[+E, +A] extends Serializable { self =>
   /**
    * Keep or break a promise based on the result of this action.
    */
-  final def to[E1 >: E, A1 >: A](p: Promise[E1, A1]): IO[E1, Boolean] =
+  final def to[E1 >: E, A1 >: A](p: Promise[E1, A1]): IO[Nothing, Boolean] =
     (self.tag: @switch) match {
-      case IO.Tags.Point => 
+      case IO.Tags.Point =>
         val io = self.asInstanceOf[IO.Point[A]]
         p.complete(io.value())
       case IO.Tags.Strict =>

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -665,6 +665,33 @@ sealed abstract class IO[+E, +A] extends Serializable { self =>
   final def as[A1 >: A]: IO[E, A1] = self.asInstanceOf[IO[E, A1]]
 
   /**
+   * Keep or break a promise based on the result of this action.
+   */
+  final def to[E1 >: E, A1 >: A](p: Promise[E1, A1]): IO[E1, Boolean] =
+    (self.tag: @switch) match {
+      case IO.Tags.Point => 
+        val io = self.asInstanceOf[IO.Point[A]]
+        p.complete(io.value())
+      case IO.Tags.Strict =>
+        val io = self.asInstanceOf[IO.Strict[A]]
+        p.complete(io.value)
+      case IO.Tags.SyncEffect =>
+        val io = self.asInstanceOf[IO.SyncEffect[A]]
+        p.complete(io.effect())
+      case IO.Tags.Sleep =>
+        val io = self.asInstanceOf[IO.Sleep]
+        p.complete(().asInstanceOf[A]).delay(io.duration)
+      case IO.Tags.Fail =>
+        val io = self.asInstanceOf[IO.Fail[E]]
+        p.error(io.error)
+      case IO.Tags.Terminate =>
+        val io = self.asInstanceOf[IO.Terminate]
+        p.interrupt0(io.causes)
+      case _ =>
+        self.run.flatMap(p.done(_))
+    }
+
+  /**
    * An integer that identifies the term in the `IO` sum type to which this
    * instance belongs (e.g. `IO.Tags.Point`).
    */


### PR DESCRIPTION
A nice syntactic shortcut to fulfil or break a promise depending on the result of an action.