### PR TITLE
Fix bracket0 release

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -513,12 +513,12 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec with AroundTime
   def testBracketReleaseOnInterrupt = {
     val io =
       for {
-        p1      <- Promise.make[Nothing, Unit]
-        p2      <- Promise.make[Nothing, Unit]
-        fiber   <- IO.bracket(IO.unit)(_ => p2.complete(()) *> IO.unit)(_ => p1.complete(()) *> IO.never).fork
-        _       <- p1.get
-        _       <- fiber.interrupt
-        _       <- p2.get
+        p1    <- Promise.make[Nothing, Unit]
+        p2    <- Promise.make[Nothing, Unit]
+        fiber <- IO.bracket(IO.unit)(_ => p2.complete(()) *> IO.unit)(_ => p1.complete(()) *> IO.never).fork
+        _     <- p1.get
+        _     <- fiber.interrupt
+        _     <- p2.get
       } yield ()
 
     unsafeRun(io.timeout0(42)(_ => 0)(1.second)) must_=== 0
@@ -527,12 +527,16 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec with AroundTime
   def testBracket0ReleaseOnInterrupt = {
     val io =
       for {
-        p1      <- Promise.make[Nothing, Unit]
-        p2      <- Promise.make[Nothing, Unit]
-        fiber   <- IO.bracket0[Nothing, Unit, Unit](IO.unit)((_, _) => p2.complete(()) *> IO.unit)(_ => p1.complete(()) *> IO.never).fork
-        _       <- p1.get
-        _       <- fiber.interrupt
-        _       <- p2.get
+        p1 <- Promise.make[Nothing, Unit]
+        p2 <- Promise.make[Nothing, Unit]
+        fiber <- IO
+                  .bracket0[Nothing, Unit, Unit](IO.unit)((_, _) => p2.complete(()) *> IO.unit)(
+                    _ => p1.complete(()) *> IO.never
+                  )
+                  .fork
+        _ <- p1.get
+        _ <- fiber.interrupt
+        _ <- p2.get
       } yield ()
 
     unsafeRun(io.timeout0(42)(_ => 0)(1.second)) must_=== 0

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -1104,8 +1104,8 @@ object IO extends Serializable {
       } yield b).ensuring(m.get.flatMap(_.fold(IO.unit) {
         case (a, f) =>
           f.tryObserve.flatMap {
-            case Some(exitResult) => release(a, exitResult)
-            case None             => f.interrupt *> f.observe.flatMap(release(a, _))
+            case Some(r) => release(a, r)
+            case None    => f.interrupt *> f.observe.flatMap(release(a, _))
           }
       }))
     }


### PR DESCRIPTION
Fixed #351 .

The implementation ended up being mostly similar to the one before:
```scala
f.tryObserve.flatMap {
  case Some(exitResult) => release(a, exitResult)
  case None             => f.interrupt *> f.observe.flatMap(release(a, _))
}
```

I kept the `tryObserve` in as an optimization for the happy path, so that the interrupt code path is only taken if the forked fiber is still running.

Also added tests to ensure that release is called on interruption.

@jdegoes @regiskuckaertz 