### PR TITLE
New App run signature and default ExecutionContext

### DIFF
--- a/microsite/src/main/tut/usage/main.md
+++ b/microsite/src/main/tut/usage/main.md
@@ -17,7 +17,7 @@ import java.io.IOException
 object MyApp extends App {
 
   def run(args: List[String]): IO[Nothing, ExitStatus] =
-    myAppLogic.attempt.map(_.fold(_ => 1, _ => 0)).map(ExitStatus.ExitNow(_))
+    myAppLogic.attempt.map(_.fold(_ => 1, _ => 0)).map(ExitStatus(_))
 
   def myAppLogic: IO[IOException, Unit] =
     for {


### PR DESCRIPTION
Addresses #305 . These changes were factored out of another PR I made in order to discuss them with more focus.

Changes:
- Remove `ExitStatus` functionality because its functionality is both redundant as it can be expressed in terms of `IO` and unsound because of its `ExitWhenDone` constructor. 
- Replace the default `ExecutorService` pool with a more general `ExecutionContext`

TODO:
- [ ] Update documentation

`ExitWhenDone` is designed both to wait for the RTS thread pools to complete all of its currently executing `Runnable` and to halt processing any additional `Runnable`s. There is no guarantee that remaining `Fiber`s will complete, because the shutdown mechanism operates on `Runnable`s. If a `Fiber` encounters an asynchronous boundary that reschedules to the pool, that task will never be invoked. Long-running and non-terminating tasks would not be immediately terminated either, so the app would have to wait for the timeout to complete.

If we remove the `ExitWhenDone` constructor, we can relax our constraint of an `ExecutorService` in `RTS` and use a more general `ExecutionContext` that doesn't capture shutdown behavior.

This is more subjective, but the functionality the two remaining constructors, `ExitNow` and `DoNotExit`, can be expressed in terms of `IO` combinators. `ExitNow` is the equivalent to allowing the main thread to reach its end. `DoNotExit` is equivalent to inserting an `IO.never` in the tree. A user must code the conditions under which the `App` terminates now. These semantics are offered by other language runtimes such as Go and Haskell.

In any case, there were concerns brought up in #305 and #315 about whether the main fiber should be explicit in the way it terminates or not. I'd like to hear more opinions about this.