### PR TITLE
Fixes #366: consistance for repeat/retry with recurs/once

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/QueueSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/QueueSpec.scala
@@ -139,16 +139,16 @@ class QueueSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Abstrac
       values = Range.inclusive(1, 10).toList
       f      <- IO.forkAll(values.map(queue.offer))
       _      <- waitForSize(queue, 10)
-      l      <- queue.take.repeat(Schedule.recurs(10) *> Schedule.identity[Int].collect)
+      l      <- queue.take.repeat(Schedule.recurs(9) *> Schedule.identity[Int].collect)
       _      <- f.join
     } yield l must containTheSameElementsAs(values))
 
   def e5 =
     unsafeRun((for {
       queue        <- Queue.bounded[Int](10)
-      _            <- queue.offer(1).repeat(Schedule.recurs(10))
+      _            <- queue.offer(1).repeat(Schedule.recurs(9))
       refSuspended <- Ref[Boolean](true)
-      _            <- (queue.offer(2).repeat(Schedule.recurs(10)) *> refSuspended.set(false)).fork
+      _            <- (queue.offer(2).repeat(Schedule.recurs(9)) *> refSuspended.set(false)).fork
       isSuspended  <- refSuspended.get
     } yield isSuspended must beTrue).supervised)
 
@@ -160,7 +160,7 @@ class QueueSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Abstrac
         _      <- IO.forkAll(values.map(queue.offer))
         _      <- waitForSize(queue, 10)
         l <- queue.take
-              .repeat(Schedule.recurs(10) *> Schedule.identity[Int].collect)
+              .repeat(Schedule.recurs(9) *> Schedule.identity[Int].collect)
       } yield l must containTheSameElementsAs(values)
     )
 

--- a/core/jvm/src/test/scala/scalaz/zio/RepeatSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RepeatSpec.scala
@@ -70,20 +70,21 @@ class RepeatSpec extends AbstractRTSSpec with GenIO with ScalaCheck {
 
   def repeatFail = {
     // a method that increment ref and fail with the incremented value in error message
-    def incr(ref: Ref[Int]): IO[String, Int] = {
+    def incr(ref: Ref[Int]): IO[String, Int] =
       for {
-        i <- ref.update(_+1)
+        i <- ref.update(_ + 1)
         _ <- IO.fail(s"Error: $i")
       } yield i
-    }
 
-    val repeated = unsafeRun((for {
-      ref <- Ref(0)
-      _   <- incr(ref).repeat(Schedule.recurs(42))
-    } yield ()).redeem(
-      err => IO.now(err)
-    , _   => IO.now("it should not be a success at all")
-    ))
+    val repeated = unsafeRun(
+      (for {
+        ref <- Ref(0)
+        _   <- incr(ref).repeat(Schedule.recurs(42))
+      } yield ()).redeem(
+        err => IO.now(err),
+        _ => IO.now("it should not be a success at all")
+      )
+    )
 
     repeated must_=== "Error: 1"
   }

--- a/core/jvm/src/test/scala/scalaz/zio/RepeatSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RepeatSpec.scala
@@ -2,7 +2,7 @@ package scalaz.zio
 
 import org.specs2.ScalaCheck
 
-class RepeatSpec extends AbstractRTSSpec with GenIO with ScalaCheck {
+class RepeatSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends AbstractRTSSpec with GenIO with ScalaCheck {
   def is = "RepeatSpec".title ^ s2"""
    Repeat on success according to a provided strategy
       for 'recurs(a negative number)' repeats 0 additional time $repeatNeg
@@ -20,7 +20,7 @@ class RepeatSpec extends AbstractRTSSpec with GenIO with ScalaCheck {
     } yield s
 
   /*
-   * A repeat with a negative number of times should not execute the action at all
+   * A repeat with a negative number of times should not repeat the action at all
    */
   def repeatNeg = {
     val repeated = unsafeRun(repeat(-5))
@@ -28,7 +28,7 @@ class RepeatSpec extends AbstractRTSSpec with GenIO with ScalaCheck {
   }
 
   /*
-   * A repeat with 0 number of times should not execute the action at all
+   * A repeat with 0 number of times should not repeat the action at all
    */
   def repeat0 = {
     val n        = 0

--- a/core/jvm/src/test/scala/scalaz/zio/RepeatSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RepeatSpec.scala
@@ -1,0 +1,90 @@
+package scalaz.zio
+
+import org.specs2.ScalaCheck
+
+class RepeatSpec extends AbstractRTSSpec with GenIO with ScalaCheck {
+  def is = "RepeatSpec".title ^ s2"""
+   Repeat on success according to a provided strategy
+      for 'recurs(a negative number)' repeats 0 additional time $repeatNeg
+      for 'recurs(0)' does repeats 0 additional time $repeat0
+      for 'recurs(1)' does repeats 1 additional time $repeat1
+      for 'once' does repeats 1 additional time $once
+      for 'recurs(a positive given number)' repeats that additional number of time $repeatN
+   Repeat on failure does not actually repeat $repeatFail
+    """
+
+  val repeat: Int => IO[Nothing, Int] = (n: Int) =>
+    for {
+      ref <- Ref(0)
+      s   <- ref.update(_ + 1).repeat(Schedule.recurs(n))
+    } yield s
+
+  /*
+   * A repeat with a negative number of times should not execute the action at all
+   */
+  def repeatNeg = {
+    val repeated = unsafeRun(repeat(-5))
+    repeated must_=== 1
+  }
+
+  /*
+   * A repeat with 0 number of times should not execute the action at all
+   */
+  def repeat0 = {
+    val n        = 0
+    val repeated = unsafeRun(repeat(n))
+    repeated must_=== 1
+  }
+
+  def never = {
+    val repeated = unsafeRun(for {
+      ref <- Ref(0)
+      _   <- ref.update(_ + 1).repeat(Schedule.never)
+      res <- ref.get
+    } yield res)
+
+    repeated must_=== 1
+  }
+
+  def repeat1 = {
+    val n        = 1
+    val repeated = unsafeRun(repeat(n))
+    repeated must_=== n + 1
+  }
+
+  def once = {
+    val repeated = unsafeRun(for {
+      ref <- Ref(0)
+      _   <- ref.update(_ + 1).repeat(Schedule.once)
+      res <- ref.get
+    } yield res)
+
+    repeated must_=== 2
+  }
+
+  def repeatN = {
+    val n        = 42
+    val repeated = unsafeRun(repeat(n))
+    repeated must_=== n + 1
+  }
+
+  def repeatFail = {
+    // a method that increment ref and fail with the incremented value in error message
+    def incr(ref: Ref[Int]): IO[String, Int] = {
+      for {
+        i <- ref.update(_+1)
+        _ <- IO.fail(s"Error: $i")
+      } yield i
+    }
+
+    val repeated = unsafeRun((for {
+      ref <- Ref(0)
+      _   <- incr(ref).repeat(Schedule.recurs(42))
+    } yield ()).redeem(
+      err => IO.now(err)
+    , _   => IO.now("it should not be a success at all")
+    ))
+
+    repeated must_=== "Error: 1"
+  }
+}

--- a/core/jvm/src/test/scala/scalaz/zio/RetrySpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RetrySpec.scala
@@ -65,19 +65,20 @@ class RetrySpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Abstrac
     /*
      * A function that increments ref each time it is called.
      */
-    def incr(ref: Ref[Int]): IO[String, Int] = {
+    def incr(ref: Ref[Int]): IO[String, Int] =
       for {
         i <- ref.update(_ + 1)
         x <- IO.fail(s"Error: $i")
       } yield x
-    }
-    val retried = unsafeRun((for {
-      ref <- Ref(0)
-      i   <- incr(ref).retry(Schedule.recurs(0))
-    } yield i).redeem(
-      err => IO.now(err)
-    , _   => IO.now("it should not be a success")
-    ))
+    val retried = unsafeRun(
+      (for {
+        ref <- Ref(0)
+        i   <- incr(ref).retry(Schedule.recurs(0))
+      } yield i).redeem(
+        err => IO.now(err),
+        _ => IO.now("it should not be a success")
+      )
+    )
 
     retried must_=== "Error: 1"
   }

--- a/core/jvm/src/test/scala/scalaz/zio/RetrySpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RetrySpec.scala
@@ -6,13 +6,17 @@ import org.specs2.ScalaCheck
 class RetrySpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends AbstractRTSSpec with GenIO with ScalaCheck {
   def is = "RetrySpec".title ^ s2"""
    Retry on failure according to a provided strategy
+      retry 0 time for `once` when first time succeeds $notRetryOnSuccess
+      retry 0 time for `recurs(0)` $retryRecurs0
+      retry exactly one time for `once` when second time succeeds $retryOnceSuccess
+      retry exactly one time for `once` even if still in error $retryOnceFail
       for a given number of times $retryN
       for a given number of times with random jitter $retryNJittered
       fixed delay with error predicate $fixedWithErrorPredicate
       fixed delay with error predicate and random jitter $fixedWithErrorPredicateJittered
   Retry according to a provided strategy
     for up to 10 times $recurs10Retry
-    """
+  """
 
   def retryCollect[E, A, E1 >: E, S](
     io: IO[E, A],
@@ -37,15 +41,101 @@ class RetrySpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Abstrac
     retry.initial(clock).flatMap(s => loop(s, Nil)).map(x => (x._1, x._2.reverse))
   }
 
+  /*
+   * Retry `once` means that we try to exec `io`, get and error,
+   * try again to exec `io`, and whatever the output return it.
+   * The three following tests test retry when:
+   * - the first time succeeds (no retry)
+   * - the first time succeeds and the second fails (one retry, result success)
+   * - both first time and retry fail (one retry, result failure)
+   */
+  // no retry on success
+  def notRetryOnSuccess = {
+    val retried = unsafeRun(for {
+      ref <- Ref(0)
+      _   <- ref.update(_ + 1).retry(Schedule.once)
+      i   <- ref.get
+    } yield i)
+
+    retried must_=== 1
+  }
+
+  // 0 retry means one attempt execution in all
+  def retryRecurs0 = {
+    /*
+     * A function that increments ref each time it is called.
+     */
+    def incr(ref: Ref[Int]): IO[String, Int] = {
+      for {
+        i <- ref.update(_ + 1)
+        x <- IO.fail(s"Error: $i")
+      } yield x
+    }
+    val retried = unsafeRun((for {
+      ref <- Ref(0)
+      i   <- incr(ref).retry(Schedule.recurs(0))
+    } yield i).redeem(
+      err => IO.now(err)
+    , _   => IO.now("it should not be a success")
+    ))
+
+    retried must_=== "Error: 1"
+  }
+
+  // one retry on failure
+  def retryOnceSuccess = {
+    /*
+     * A function that increments ref each time it is called.
+     * It returns either a failure if ref value is 0 or less
+     * before increment, and the value in other cases.
+     */
+    def failOn0(ref: Ref[Int]): IO[String, Int] =
+      for {
+        i <- ref.update(_ + 1)
+        x <- if (i <= 1) IO.fail(s"Error: $i") else IO.now(i)
+      } yield x
+    val retried = unsafeRun(for {
+      ref <- Ref(0)
+      _   <- failOn0(ref).retry(Schedule.once)
+      r   <- ref.get
+    } yield r)
+
+    retried must_=== 2
+  }
+
+  // no more than one retry on retry `once`
+  def retryOnceFail = {
+    /*
+     * A function that increments ref each time it is called.
+     * It always fails, with the incremented value in error
+     */
+    def alwaysFail(ref: Ref[Int]): IO[String, Int] =
+      for {
+        i <- ref.update(_ + 1)
+        x <- IO.fail(s"Error: $i")
+      } yield x
+    val retried = unsafeRun(
+      (for {
+        ref <- Ref(0)
+        _   <- alwaysFail(ref).retry(Schedule.once)
+      } yield ()).redeem(
+        err => IO.now(err),
+        _ => IO.now("A failure was expected")
+      )
+    )
+
+    retried must_=== "Error: 2"
+  }
+
   def retryN = {
     val retried  = unsafeRun(retryCollect(IO.fail("Error"), Schedule.recurs(5)))
-    val expected = (Left("Error"), List(1, 2, 3, 4, 5).map((Duration.Zero, _)))
+    val expected = (Left("Error"), List(1, 2, 3, 4, 5, 6).map((Duration.Zero, _)))
     retried must_=== expected
   }
 
   def retryNJittered = {
     val retried  = unsafeRun(retryCollect(IO.fail("Error"), Schedule.recurs(5).jittered))
-    val expected = (Left("Error"), List(1, 2, 3, 4, 5).map((Duration.Zero, _)))
+    val expected = (Left("Error"), List(1, 2, 3, 4, 5, 6).map((Duration.Zero, _)))
     retried must_=== expected
   }
 

--- a/core/jvm/src/test/scala/scalaz/zio/RetrySpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RetrySpec.scala
@@ -43,10 +43,11 @@ class RetrySpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Abstrac
 
   /*
    * Retry `once` means that we try to exec `io`, get and error,
-   * try again to exec `io`, and whatever the output return it.
+   * try again to exec `io`, and whatever the output is, return that
+   * second result.
    * The three following tests test retry when:
    * - the first time succeeds (no retry)
-   * - the first time succeeds and the second fails (one retry, result success)
+   * - the first time fails and the second succeeds (one retry, result success)
    * - both first time and retry fail (one retry, result failure)
    */
   // no retry on success
@@ -60,7 +61,7 @@ class RetrySpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Abstrac
     retried must_=== 1
   }
 
-  // 0 retry means one attempt execution in all
+  // 0 retry means "one execution in all, no retry, whatever the output"
   def retryRecurs0 = {
     /*
      * A function that increments ref each time it is called.

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -477,8 +477,8 @@ sealed abstract class IO[+E, +A] extends Serializable { self =>
   /**
    * Repeats this action with the specified schedule until the schedule
    * completes, or until the first failure.
-   * Repeat are done in addition of the first execution so that
-   * `io.repeat(Schedule.once)` means "execute io and in case of success repeat io one time".
+   * Repeats are done in addition to the first execution so that
+   * `io.repeat(Schedule.once)` means "execute io and in case of success repeat io once".
    */
   final def repeat[B](schedule: Schedule[A, B], clock: Clock = Clock.Live): IO[E, B] =
     repeatOrElse[E, B](schedule, (e, _) => IO.fail(e), clock)
@@ -520,9 +520,9 @@ sealed abstract class IO[+E, +A] extends Serializable { self =>
 
   /**
    * Retries with the specified retry policy.
-   * A `retry` with a number of time specified (with `once` or `recurs` for example) means
-   * that the operation is tried one time and then retried the specified number of time, so
-   * that `io.retry(Schedule.once)` means "try io and in case of failure, try again one time".
+   * Retries are done following the failure of the original io (up to a fixed maximum with
+   * `once` or `recurs` for example), so that that `io.retry(Schedule.once)` means
+   * "execute io and in case of failure, try again once".
    */
   final def retry[E1 >: E, S](policy: Schedule[E1, S], clock: Clock = Clock.Live): IO[E1, A] =
     retryOrElse(policy, (e: E1, _: S) => IO.fail(e), clock)

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -477,6 +477,8 @@ sealed abstract class IO[+E, +A] extends Serializable { self =>
   /**
    * Repeats this action with the specified schedule until the schedule
    * completes, or until the first failure.
+   * Repeat are done in addition of the first execution so that
+   * `io.repeat(Schedule.once)` means "execute io and in case of success repeat io one time".
    */
   final def repeat[B](schedule: Schedule[A, B], clock: Clock = Clock.Live): IO[E, B] =
     repeatOrElse[E, B](schedule, (e, _) => IO.fail(e), clock)
@@ -518,6 +520,9 @@ sealed abstract class IO[+E, +A] extends Serializable { self =>
 
   /**
    * Retries with the specified retry policy.
+   * A `retry` with a number of time specified (with `once` or `recurs` for example) means
+   * that the operation is tried one time and then retried the specified number of time, so
+   * that `io.retry(Schedule.once)` means "try io and in case of failure, try again one time".
    */
   final def retry[E1 >: E, S](policy: Schedule[E1, S], clock: Clock = Clock.Live): IO[E1, A] =
     retryOrElse(policy, (e: E1, _: S) => IO.fail(e), clock)

--- a/core/shared/src/main/scala/scalaz/zio/Schedule.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Schedule.scala
@@ -552,7 +552,7 @@ object Schedule extends Serializable {
   /**
    * A schedule that executes once.
    */
-  final val once: Schedule[Any, Unit] = forever.whileOutput(_ => false).void
+  final val once: Schedule[Any, Unit] = recurs(1).void
 
   /**
    * A new schedule derived from the specified schedule which adds the delay
@@ -588,8 +588,11 @@ object Schedule extends Serializable {
   /**
    * A schedule that recurs the specified number of times. Returns the number
    * of repetitions so far.
+   *
+   * If 0 of negative numbers are given, the operation is not done at all so
+   * that in (op: IO[E, A]).repeat(Schedule.recurs(0)) , op is not done at all.
    */
-  final def recurs(n: Int): Schedule[Any, Int] = forever.whileOutput(_ < n)
+  final def recurs(n: Int): Schedule[Any, Int] = forever.whileOutput(_ <= n)
 
   /**
    * A schedule that recurs forever without delay. Returns the elapsed time

--- a/core/shared/src/main/scala/scalaz/zio/Schedule.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Schedule.scala
@@ -589,7 +589,7 @@ object Schedule extends Serializable {
    * A schedule that recurs the specified number of times. Returns the number
    * of repetitions so far.
    *
-   * If 0 of negative numbers are given, the operation is not done at all so
+   * If 0 or negative numbers are given, the operation is not done at all so
    * that in (op: IO[E, A]).repeat(Schedule.recurs(0)) , op is not done at all.
    */
   final def recurs(n: Int): Schedule[Any, Int] = forever.whileOutput(_ <= n)


### PR DESCRIPTION
This pull request change the semantic of `Schedule.once` and `Schedule.recurs` to mean "number of additionnal time" according to what is descrbed in https://github.com/scalaz/scalaz-zio/issues/366

The pull request also provides simple tests for both `repeat` and `retry` to ensure that the same semantic is used everywhere. 

