### PR TITLE
Ignore Redeem error handlers when interrupting

### DIFF
--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -231,7 +231,7 @@ private object RTS {
      * action that produces a list (possibly empty) of errors during finalization.
      * If needed, catch exceptions and apply redeem error handling.
      */
-    final def unwindStack: IO[Nothing, Option[Cause[Nothing]]] = {
+    final def unwindStack(catchError: Boolean): IO[Nothing, Option[Cause[Nothing]]] = {
       var errorHandler: Any => IO[Any, Any]              = null
       var finalizer: IO[Nothing, Option[Cause[Nothing]]] = null
 
@@ -239,7 +239,7 @@ private object RTS {
       // finalizers.
       while ((errorHandler eq null) && !stack.isEmpty) {
         stack.pop() match {
-          case a: IO.Redeem[_, _, _, _] =>
+          case a: IO.Redeem[_, _, _, _] if catchError =>
             errorHandler = a.err.asInstanceOf[Any => IO[Any, Any]]
           case f0: Finalizer =>
             val f: IO[Nothing, Option[Cause[Nothing]]] =
@@ -475,7 +475,7 @@ private object RTS {
                   case IO.Tags.Fail =>
                     val io = curIo.asInstanceOf[IO.Fail[E]]
 
-                    val finalizer = unwindStack
+                    val finalizer = unwindStack(true)
 
                     if (stack.isEmpty) {
                       // Error not caught, stack is empty:
@@ -824,7 +824,7 @@ private object RTS {
                 }
             }
 
-            val finalizer = unwindStack
+            val finalizer = unwindStack(false)
 
             if (finalizer ne null) {
               fork(finalizer.flatMap {

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -89,6 +89,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec with AroundTime
     bracket0 use is interruptible           $testBracket0UseIsInterruptible
     bracket release called on interrupt     $testBracketReleaseOnInterrupt
     bracket0 release called on interrupt    $testBracket0ReleaseOnInterrupt
+    redeem + interrupt + ensuring           $testRedeemInterruptEnsuring
     supervise fibers                        ${upTo(1.second)(testSupervise)}
     race of fail with success               ${upTo(1.second)(testRaceChoosesWinner)}
     race of fail with fail                  ${upTo(1.second)(testRaceChoosesFailure)}
@@ -539,6 +540,17 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec with AroundTime
       } yield ()
 
     unsafeRun(io.timeout0(42)(_ => 0)(1.second)) must_=== 0
+  }
+
+  def testRedeemInterruptEnsuring = {
+    val io = for {
+      p1  <- Promise.make[Nothing, Boolean]
+      f1  <- IO.never.catchAll(IO.fail).ensuring(p1.complete(true).void).fork
+      _   <- f1.interrupt
+      res <- p1.get
+    } yield res
+
+    unsafeRun(io) must_=== true
   }
 
   def testAsyncPureIsInterruptible = {

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -89,7 +89,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec with AroundTime
     bracket0 use is interruptible           $testBracket0UseIsInterruptible
     bracket release called on interrupt     $testBracketReleaseOnInterrupt
     bracket0 release called on interrupt    $testBracket0ReleaseOnInterrupt
-    redeem + interrupt + ensuring           $testRedeemInterruptEnsuring
+    redeem + ensuring + interrupt           $testRedeemEnsuringInterrupt
     supervise fibers                        ${upTo(1.second)(testSupervise)}
     race of fail with success               ${upTo(1.second)(testRaceChoosesWinner)}
     race of fail with fail                  ${upTo(1.second)(testRaceChoosesFailure)}
@@ -542,7 +542,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec with AroundTime
     unsafeRun(io.timeout0(42)(_ => 0)(1.second)) must_=== 0
   }
 
-  def testRedeemInterruptEnsuring = {
+  def testRedeemEnsuringInterrupt = {
     val io = for {
       p1  <- Promise.make[Nothing, Boolean]
       f1  <- IO.never.catchAll(IO.fail).ensuring(p1.complete(true).void).fork


### PR DESCRIPTION
Fix the second issue described in https://github.com/scalaz/scalaz-zio/pull/267#issuecomment-437719622

I added a simplified test reproducing @kaishh 's issue as well.