### PR TITLE
Add Scalaz Stream

### DIFF
--- a/benchmarks/src/main/scala/scalaz/zio/StreamBenchmarks.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/StreamBenchmarks.scala
@@ -174,7 +174,7 @@ class CSVStreamBenchmarks {
     val chunks = genCsvChunks.map(Chunk.fromArray(_))
     val stream = StreamChunk
       .fromChunks(chunks: _*)
-      .scan[Vector[Char], Chunk[CSV.Token]](Vector.empty[Char]) {
+      .mapAccum[Vector[Char], Chunk[CSV.Token]](Vector.empty[Char]) {
         case (acc, char) =>
           if (char == CSV.ColumnSep) {
             Vector.empty[Char] ->

--- a/benchmarks/src/main/scala/scalaz/zio/StreamBenchmarks.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/StreamBenchmarks.scala
@@ -1,0 +1,245 @@
+package scalaz.zio
+
+import java.util.concurrent.TimeUnit
+
+import scalaz.zio.stream._
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{ Source => AkkaSource, Sink => AkkaSink, Keep }
+import cats.effect.{ IO => CatsIO }
+import fs2.{ Stream => FS2Stream, Chunk => FS2Chunk }
+import org.openjdk.jmh.annotations._
+
+import IOBenchmarks._
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class StreamBenchmarks {
+  @Param(Array("10000"))
+  var chunkCount: Int = _
+
+  @Param(Array("5000"))
+  var chunkSize: Int = _
+
+  implicit val system = ActorSystem("benchmarks")
+  implicit val mat    = ActorMaterializer()
+  implicit val ec     = system.dispatcher
+
+  @TearDown
+  def shutdown(): Unit = {
+    system.terminate()
+    ()
+  }
+
+  @Benchmark
+  def akkaChunkFilterMapSum = {
+    val chunks = (1 to chunkCount).flatMap(i => Array.fill(chunkSize)(i))
+    val program = AkkaSource
+      .fromIterator(() => chunks.iterator)
+      .filter(_ % 2 == 0)
+      .map(_.toLong)
+      .toMat(AkkaSink.fold(0L)(_ + _))(Keep.right)
+
+    Await.result(program.run, Duration.Inf)
+  }
+
+  @Benchmark
+  def fs2ChunkFilterMapSum = {
+    val chunks = (1 to chunkCount).map(i => FS2Chunk.array(Array.fill(chunkSize)(i)))
+    val stream = FS2Stream(chunks: _*)
+      .flatMap(FS2Stream.chunk(_))
+      .filter(_ % 2 == 0)
+      .map(_.toLong)
+      .covary[CatsIO]
+      .compile
+      .fold(0L)(_ + _)
+    stream.unsafeRunSync
+  }
+
+  @Benchmark
+  def scalazChunkFilterMapSum = {
+    val chunks = (1 to chunkCount).map(i => Chunk.fromArray(Array.fill(chunkSize)(i)))
+    val stream = StreamChunk
+      .fromChunks(chunks: _*)
+      .filter(_ % 2 == 0)
+      .map(_.toLong)
+
+    val sink   = Sink.foldLeft(0L)((s, as: Chunk[Long]) => as.foldLeft(s)(_ + _))
+    val result = stream.run(sink)
+
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def scalazChunkChunkFilterMapSum = {
+    val chunks = Chunk.fromArray((1 to chunkCount).toArray).flatMap(i => Chunk.fromArray(Array.fill(chunkSize)(i)))
+    chunks
+      .filter(_ % 2 == 0)
+      .map(_.toLong)
+      .foldLeft(0L)(_ + _)
+  }
+}
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class CSVStreamBenchmarks {
+  @Param(Array("5000"))
+  var chunkSize: Int = _
+
+  @Param(Array("100"))
+  var rows: Int = _
+
+  @Param(Array("100"))
+  var cols: Int = _
+
+  var genCsvChunks: Array[Array[Char]] = _
+
+  implicit val system = ActorSystem("benchmarks")
+  implicit val mat    = ActorMaterializer()
+  implicit val ec     = system.dispatcher
+
+  @Setup
+  def setup(): Unit =
+    genCsvChunks = CSV.genChoppedCsv(rows, cols, chunkSize)
+
+  @TearDown
+  def shutdown(): Unit = {
+    system.terminate()
+    ()
+  }
+
+  @Benchmark
+  def akkaCsvTokenize() = {
+    val chunks = genCsvChunks
+
+    val program = AkkaSource
+      .fromIterator(() => chunks.flatten.iterator)
+      .scan((Vector.empty[Char], Vector.empty[CSV.Token])) {
+        case ((acc, _), char) =>
+          if (char == CSV.ColumnSep) {
+            Vector.empty[Char] ->
+              ((if (acc.length > 0)
+                  Vector(CSV.Column(acc.mkString))
+                else Vector.empty[CSV.Token]) ++
+                Vector(CSV.NewCol))
+          } else if (char == CSV.RowSep) {
+            Vector.empty[Char] ->
+              ((if (acc.length > 0)
+                  Vector(CSV.Column(acc.mkString))
+                else Vector.empty[CSV.Token]) ++
+                Vector(CSV.NewCol))
+          } else (acc :+ char) -> Vector.empty[CSV.Token]
+      }
+      .flatMapConcat(t => AkkaSource(t._2))
+      .toMat(AkkaSink.ignore)(Keep.right)
+
+    Await.result(program.run, Duration.Inf)
+  }
+
+  @Benchmark
+  def fs2CsvTokenize() = {
+    val chunks = genCsvChunks.map(FS2Chunk.array(_))
+    val stream = FS2Stream(chunks: _*)
+      .flatMap(FS2Stream.chunk(_))
+      .scan((Vector.empty[Char], Vector.empty[CSV.Token])) {
+        case ((acc, _), char) =>
+          if (char == CSV.ColumnSep) {
+            Vector.empty[Char] ->
+              ((if (acc.length > 0)
+                  Vector(CSV.Column(acc.mkString))
+                else Vector.empty[CSV.Token]) ++
+                Vector(CSV.NewCol))
+          } else if (char == CSV.RowSep) {
+            Vector.empty[Char] ->
+              ((if (acc.length > 0)
+                  Vector(CSV.Column(acc.mkString))
+                else Vector.empty[CSV.Token]) ++
+                Vector(CSV.NewCol))
+          } else (acc :+ char) -> Vector.empty[CSV.Token]
+      }
+      .flatMap(t => FS2Stream(t._2))
+      .covary[CatsIO]
+      .compile
+      .drain
+
+    stream.unsafeRunSync
+  }
+
+  @Benchmark
+  def scalazCsvTokenize() = {
+    val chunks = genCsvChunks.map(Chunk.fromArray(_))
+    val stream = StreamChunk
+      .fromChunks(chunks: _*)
+      .scan[Vector[Char], Chunk[CSV.Token]](Vector.empty[Char]) {
+        case (acc, char) =>
+          if (char == CSV.ColumnSep) {
+            Vector.empty[Char] ->
+              ((if (acc.length > 0)
+                  Chunk(CSV.Column(acc.mkString))
+                else Chunk.empty) ++
+                Chunk(CSV.NewCol))
+          } else if (char == CSV.RowSep) {
+            Vector.empty[Char] ->
+              ((if (acc.length > 0)
+                  Chunk(CSV.Column(acc.mkString))
+                else Chunk.empty) ++
+                Chunk(CSV.NewCol))
+          } else (acc :+ char) -> Chunk.empty
+      }
+      .mapConcat(identity(_))
+
+    unsafeRun(stream.run(Sink.drain))
+  }
+
+  // @Benchmark
+  // def scalazChunkCsvTokenize = {
+  //   // TODO
+  // }
+}
+
+object CSV {
+  sealed trait Token
+  case object NewCol               extends Token
+  case object NewRow               extends Token
+  case class Column(value: String) extends Token
+
+  val ColumnSep = ','
+  val RowSep    = '\n'
+
+  def alphanumeric(random: scala.util.Random, min: Int, max: Int): String = {
+    val n = random.nextInt(max - min + 1) + min
+
+    random.alphanumeric.take(n).mkString
+  }
+
+  def genCsv(cols: Int, rows: Int, min: Int = 5, max: Int = 100): String = {
+    val random: scala.util.Random = new scala.util.Random(rows * cols * (min + 1) * max)
+
+    val builder = new scala.collection.mutable.StringBuilder()
+
+    for {
+      _   <- (0 to rows).toList
+      col <- (0 to cols).toList
+    } {
+      if (col > 0) builder
+      builder ++= ColumnSep.toString
+
+      builder ++= alphanumeric(random, min, max)
+
+      if (col == cols - 1)
+        builder ++= RowSep.toString
+    }
+
+    builder.toString
+  }
+
+  def chop(n: Int, s: String): Array[Array[Char]] =
+    s.grouped(n).toArray.map(_.toArray)
+
+  def genChoppedCsv(rows: Int, cols: Int, chunkSize: Int): Array[Array[Char]] =
+    chop(chunkSize, genCsv(rows, cols))
+}

--- a/benchmarks/src/main/scala/scalaz/zio/StreamBenchmarks.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/StreamBenchmarks.scala
@@ -194,11 +194,6 @@ class CSVStreamBenchmarks {
 
     unsafeRun(stream.run(Sink.drain))
   }
-
-  // @Benchmark
-  // def scalazChunkCsvTokenize = {
-  //   // TODO
-  // }
 }
 
 object CSV {

--- a/build.sbt
+++ b/build.sbt
@@ -85,6 +85,7 @@ lazy val coreJVM = core.jvm
                                                |import scalaz._
                                                |import scalaz.zio._
                                                |import scalaz.zio.console._
+                                               |import scalaz.zio.stream._
                                                |object replRTS extends RTS {}
                                                |import replRTS._
                                                |implicit class RunSyntax[E, A](io: IO[E, A]){ def unsafeRun: A = replRTS.unsafeRun(io) }
@@ -168,11 +169,12 @@ lazy val benchmarks = project.module
     skip in publish := true,
     libraryDependencies ++=
       Seq(
-        "org.scala-lang" % "scala-reflect"  % scalaVersion.value,
-        "org.scala-lang" % "scala-compiler" % scalaVersion.value % Provided,
-        "io.monix"       %% "monix"         % "3.0.0-RC1",
-        "org.typelevel"  %% "cats-effect"   % "1.0.0",
-        "co.fs2"         %% "fs2-core"      % "1.0.0"
+        "org.scala-lang"    % "scala-reflect"  % scalaVersion.value,
+        "org.scala-lang"    % "scala-compiler" % scalaVersion.value % Provided,
+        "io.monix"          %% "monix"         % "3.0.0-RC1",
+        "org.typelevel"     %% "cats-effect"   % "1.0.0",
+        "co.fs2"            %% "fs2-core"      % "1.0.0",
+        "com.typesafe.akka" %% "akka-stream"   % "2.5.17"
       )
   )
 

--- a/core/jvm/src/test/scala/scalaz/zio/stream/ArbitraryChunk.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/stream/ArbitraryChunk.scala
@@ -1,0 +1,29 @@
+package scalaz.zio.stream
+
+import org.scalacheck.{Arbitrary, Gen}
+
+import scala.reflect.ClassTag
+
+object ArbitraryChunk {
+
+  implicit def arbChunk[T: ClassTag](implicit a: Arbitrary[T]): Arbitrary[Chunk[T]] =
+    Arbitrary {
+
+      val genEmpty = Gen.const(Chunk.empty)
+      val genSingleton = for (e <- Arbitrary.arbitrary[T]) yield Chunk.point(e)
+      val genArr: Gen[Chunk[T]] = for (e <- Arbitrary.arbitrary[Seq[T]]) yield Chunk.fromArray(e.toArray)
+      val genSimple = Gen.oneOf(genEmpty, genSingleton, genArr)
+
+      val genSlice = for {
+        arr <- genSimple
+        left <- Gen.choose[Int](0, arr.length)
+      } yield arr.take(left)
+
+      val genConcat: Gen[Chunk[T]] = for {
+        left <- genSimple
+        right <- genSimple
+      } yield left ++ right
+
+      Gen.oneOf(genEmpty, genSingleton, genSlice, genArr, genConcat)
+    }
+}

--- a/core/jvm/src/test/scala/scalaz/zio/stream/ArbitraryChunk.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/stream/ArbitraryChunk.scala
@@ -1,6 +1,6 @@
 package scalaz.zio.stream
 
-import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.{ Arbitrary, Gen }
 
 import scala.reflect.ClassTag
 
@@ -8,22 +8,22 @@ object ArbitraryChunk {
 
   implicit def arbChunk[T: ClassTag](implicit a: Arbitrary[T]): Arbitrary[Chunk[T]] =
     Arbitrary {
-
-      val genEmpty = Gen.const(Chunk.empty)
-      val genSingleton = for (e <- Arbitrary.arbitrary[T]) yield Chunk.point(e)
-      val genArr: Gen[Chunk[T]] = for (e <- Arbitrary.arbitrary[Seq[T]]) yield Chunk.fromArray(e.toArray)
-      val genSimple = Gen.oneOf(genEmpty, genSingleton, genArr)
-
-      val genSlice = for {
-        arr <- genSimple
-        left <- Gen.choose[Int](0, arr.length)
-      } yield arr.take(left)
-
-      val genConcat: Gen[Chunk[T]] = for {
-        left <- genSimple
-        right <- genSimple
-      } yield left ++ right
-
-      Gen.oneOf(genEmpty, genSingleton, genSlice, genArr, genConcat)
+      Gen.oneOf(
+        Gen.const(Chunk.empty),
+        Arbitrary.arbitrary[T].map(Chunk.point),
+        Arbitrary.arbitrary[Seq[T]].map(seqT => Chunk.fromArray(seqT.toArray)),
+        Gen.lzy {
+          for {
+            arr  <- arbChunk.arbitrary
+            left <- Gen.choose[Int](0, arr.length)
+          } yield arr.take(left)
+        },
+        Gen.lzy {
+          for {
+            left  <- arbChunk.arbitrary
+            right <- arbChunk.arbitrary
+          } yield left ++ right
+        }
+      )
     }
 }

--- a/core/jvm/src/test/scala/scalaz/zio/stream/ArbitraryStream.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/stream/ArbitraryStream.scala
@@ -1,6 +1,6 @@
 package scalaz.zio.stream
 
-import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.{ Arbitrary, Gen }
 import scalaz.zio.IO
 
 import scala.reflect.ClassTag
@@ -12,12 +12,13 @@ object ArbitraryStream {
       val failingStream: Gen[Stream[String, T]] =
         for {
           it <- Arbitrary.arbitrary[List[T]]
-          n <- Gen.choose(0, it.size)
-        } yield Stream.unfoldM((n, it)) {
-          case (_, Nil) | (0, _)=>
-            IO.fail("fail-case")
-          case (n, head :: rest) => IO.now(Some((head, (n - 1, rest))))
-        }
+          n  <- Gen.choose(0, it.size)
+        } yield
+          Stream.unfoldM((n, it)) {
+            case (_, Nil) | (0, _) =>
+              IO.fail("fail-case")
+            case (n, head :: rest) => IO.now(Some((head, (n - 1, rest))))
+          }
 
       val succeedingStream: Gen[Stream[String, T]] =
         for (it <- Arbitrary.arbitrary[Iterable[T]]) yield Stream.fromIterable(it)

--- a/core/jvm/src/test/scala/scalaz/zio/stream/ArbitraryStream.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/stream/ArbitraryStream.scala
@@ -1,0 +1,27 @@
+package scalaz.zio.stream
+
+import org.scalacheck.{Arbitrary, Gen}
+import scalaz.zio.IO
+
+import scala.reflect.ClassTag
+
+object ArbitraryStream {
+
+  implicit def arbStream[T: ClassTag](implicit a: Arbitrary[T]): Arbitrary[Stream[String, T]] =
+    Arbitrary {
+      val failingStream: Gen[Stream[String, T]] =
+        for {
+          it <- Arbitrary.arbitrary[List[T]]
+          n <- Gen.choose(0, it.size)
+        } yield Stream.unfoldM((n, it)) {
+          case (_, Nil) | (0, _)=>
+            IO.fail("fail-case")
+          case (n, head :: rest) => IO.now(Some((head, (n - 1, rest))))
+        }
+
+      val succeedingStream: Gen[Stream[String, T]] =
+        for (it <- Arbitrary.arbitrary[Iterable[T]]) yield Stream.fromIterable(it)
+
+      Gen.oneOf(failingStream, succeedingStream)
+    }
+}

--- a/core/jvm/src/test/scala/scalaz/zio/stream/ChunkSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/stream/ChunkSpec.scala
@@ -4,103 +4,90 @@ import org.specs2._
 import org.specs2.specification.core.SpecStructure
 
 class ChunkSpec extends Specification with ScalaCheck {
-  def is: SpecStructure = "ChunkSpec".title ^
-    s2"""
-  chunk apply $applyChunk
-  chunk length $chunkLength
-  chunk equality $chunkEquality
-  chunk equality prop $chunkEqualityProp
-  chunk inequality $chunkInequality
-  flatMap chunk $flatMapChunk
-  map chunk $mapChunk
-  materialize chunk $materializeChunk
-  foldLeft chunk $foldLeftChunk
-  filter chunk $filterChunk
-  drop chunk $dropChunk
-  drop singleton chunk $dropSingletonChunk
-  drop slice chunk $dropSliceChunk
-  take chunk $takeChunk
-  take singleton chunk $takeSingletonChunk
-  take slice chunk $takeSliceChunk
+  def is: SpecStructure =
+    "ChunkSpec".title ^
+      s2"""
+  chunk apply $apply
+  chunk length $length
+  chunk equality prop $equality
+  chunk inequality $inequality
+  flatMap chunk $flatMap
+  map chunk $map
+  materialize chunk $materialize
+  foldLeft chunk $foldLeft
+  filter chunk $filter
+  drop chunk $drop
+  take chunk $take
   dropWhile chunk $dropWhile
-  dropWhile singleton chunk $dropWhileSingleton
-  dropWhile slice chunk $dropWhileSlice
-  dropWhile array chunk $dropWhileArray
   takeWhile chunk $takeWhile
-  takeWhile singleton chunk $takeWhileSingleton
-  takeWhile slice chunk $takeWhileSlice
-  takeWhile array chunk $takeWhileArray
-  concat chunk $concatChunk
+  toArray $toArray
+  foreach $foreach
+  concat chunk $concat
   An Array-based chunk that is filtered empty and mapped must not throw NPEs. $nullArrayBug
   toArray on concat of a slice must work properly. $toArrayOnConcatOfSlice
   toArray on concat of empty and integers must work properly. $toArrayOnConcatOfEmptyAndInts
   Chunk.filter that results in an empty Chunk must use Chunk.empty $filterConstFalseResultsInEmptyChunk
-  Chunk.Slice toArray $sliceToArray
-  Chunk.Slice foreach $sliceForeach
-  Chunk.slice toArray $sliceToArray
     """
 
   import ArbitraryChunk._
   import org.scalacheck._
 
-  private def applyChunk = {
-    implicit val abStringGen: Gen[(Chunk[Int], Int)] = for {
+  private def apply = {
+    implicit val chunkGen: Gen[(Chunk[Int], Int)] = for {
       chunk <- Arbitrary.arbitrary[Chunk[Int]].filter(_.length > 0)
-      len <- Gen.chooseNum(0, chunk.length - 1)
+      len   <- Gen.chooseNum(0, chunk.length - 1)
     } yield (chunk, len)
 
     prop { t: (Chunk[Int], Int) =>
       t._1.apply(t._2) must_=== t._1.toSeq.apply(t._2)
-    }.setArbitrary(Arbitrary(abStringGen))
+    }.setArbitrary(Arbitrary(chunkGen))
   }
 
-  private def chunkLength =
-    prop { chunk: Chunk[Int] => chunk.length must_=== chunk.toSeq.length }
+  private def length =
+    prop { chunk: Chunk[Int] =>
+      chunk.length must_=== chunk.toSeq.length
+    }
 
-  private def chunkEqualityProp =
+  private def equality =
     prop((c1: Chunk[Int], c2: Chunk[Int]) => c1.equals(c2) must_=== c1.toSeq.equals(c2.toSeq))
 
-  private def chunkEquality =
-    Chunk(1, 2, 3, 4, 5) must_=== Chunk(1, 2, 3, 4, 5)
-
-  private def chunkInequality =
+  private def inequality =
     Chunk(1, 2, 3, 4, 5) must_!== Chunk(1, 2, 3, 4, 5, 6)
 
-  private def flatMapChunk =
+  private def flatMap =
     prop { (c: Chunk[Int], f: Int => Chunk[Int]) =>
       c.flatMap(f).toSeq must_=== c.toSeq.flatMap(f.andThen(_.toSeq))
     }
 
-  private def mapChunk =
+  private def map =
     prop { (c: Chunk[Int], f: Int => String) =>
       c.map(f).toSeq must_=== c.toSeq.map(f)
     }
 
-  private def materializeChunk =
-    prop { c: Chunk[Int] => c.materialize.toSeq must_=== c.toSeq }
+  private def materialize =
+    prop { c: Chunk[Int] =>
+      c.materialize.toSeq must_=== c.toSeq
+    }
 
-  private def foldLeftChunk =
+  private def foldLeft =
     prop { (s0: String, f: (String, Int) => String, c: Chunk[Int]) =>
       c.foldLeft(s0)(f) must_=== c.toArray.foldLeft(s0)(f)
     }
 
-  private def filterChunk =
-    prop { (chunk: Chunk[String], p: String => Boolean) => chunk.filter(p).toSeq must_=== chunk.toSeq.filter(p) }
-
-  private def dropChunk =
-    prop { (chunk: Chunk[Int], n: Int) => chunk.drop(n).toSeq must_=== chunk.toSeq.drop(n) }
-
-  private def dropSingletonChunk =
-    Chunk(1).drop(4) must_=== Chunk.empty
-
-  private def takeChunk =
-    prop {
-      (c: Chunk[Int], n: Int) =>
-        c.take(n).toSeq must_=== c.toSeq.take(n)
+  private def filter =
+    prop { (chunk: Chunk[String], p: String => Boolean) =>
+      chunk.filter(p).toSeq must_=== chunk.toSeq.filter(p)
     }
 
-  private def takeSingletonChunk =
-    Chunk(1).take(4) must_=== Chunk(1)
+  private def drop =
+    prop { (chunk: Chunk[Int], n: Int) =>
+      chunk.drop(n).toSeq must_=== chunk.toSeq.drop(n)
+    }
+
+  private def take =
+    prop { (c: Chunk[Int], n: Int) =>
+      c.take(n).toSeq must_=== c.toSeq.take(n)
+    }
 
   private def nullArrayBug = {
     val c = Chunk.fromArray(Array(1, 2, 3, 4, 5))
@@ -111,7 +98,7 @@ class ChunkSpec extends Specification with ScalaCheck {
     c.filter(_ => false).map(_ * 2).length must_=== 0
   }
 
-  private def concatChunk = prop { (c1: Chunk[Int], c2: Chunk[Int]) =>
+  private def concat = prop { (c1: Chunk[Int], c2: Chunk[Int]) =>
     (c1 ++ c2).toSeq must_=== (c1.toSeq ++ c2.toSeq)
   }
 
@@ -129,49 +116,26 @@ class ChunkSpec extends Specification with ScalaCheck {
   private def toArrayOnConcatOfEmptyAndInts =
     (Chunk.empty ++ Chunk.fromArray(Array(1, 2, 3))).toArray must_=== Array(1, 2, 3)
 
-  private def filterConstFalseResultsInEmptyChunk = Chunk.fromArray(Array(1, 2, 3)).filter(_ => false) must_=== Chunk.empty
+  private def filterConstFalseResultsInEmptyChunk =
+    Chunk.fromArray(Array(1, 2, 3)).filter(_ => false) must_=== Chunk.empty
 
   private def dropWhile =
-    prop {
-      (c: Chunk[Int], p: Int => Boolean) =>
-        c.dropWhile(p).toSeq must_=== c.toSeq.dropWhile(p)
+    prop { (c: Chunk[Int], p: Int => Boolean) =>
+      c.dropWhile(p).toSeq must_=== c.toSeq.dropWhile(p)
     }
 
   private def takeWhile = prop { (c: Chunk[Int], p: Int => Boolean) =>
-    c.takeWhile(p).toArray.toSeq must_=== c.toArray.toSeq.takeWhile(p)
+    c.takeWhile(p).toSeq must_=== c.toSeq.takeWhile(p)
   }
 
-  private def sliceToArray =
-    Chunk.fromArray(Array(1, 2, 3, 4)).dropWhile(_ < 3).toArray must_=== Array(3, 4)
+  private def toArray = prop { (c: Chunk[Int]) =>
+    c.toArray.toSeq must_=== c.toSeq
+  }
 
-  private def dropSliceChunk =
-    Chunk(1, 2, 3, 4, 5).dropWhile(_ < 3).drop(2) must_=== Chunk(5)
-
-  private def takeSliceChunk =
-    Chunk(1, 2, 3, 4, 5).dropWhile(_ < 3).take(2) must_=== Chunk(3, 4)
-
-  private def dropWhileSingleton =
-    Chunk(1).dropWhile(_ == 1) must_=== Chunk.empty
-
-  private def dropWhileSlice =
-    Chunk(1, 2, 3, 4, 5).dropWhile(_ == 1).dropWhile(_ < 4) must_=== Chunk(4, 5)
-
-  def dropWhileArray =
-    Chunk(1, 2, 3, 4, 5).dropWhile(_ <= 3) must_=== Chunk(4, 5)
-
-  def takeWhileSlice = Chunk(1, 2, 3, 4, 5).takeWhile(_ <= 4).takeWhile(_ <= 2) must_=== Chunk(1, 2)
-
-  def takeWhileArray = Chunk(1, 2, 3, 4, 5).takeWhile(_ <= 3) must_=== Chunk(1, 2, 3)
-
-  def sliceForeach = {
+  private def foreach = prop { (c: Chunk[Int]) =>
     var sum = 0
-
-    val c = Chunk(1, 1, 1, 1, 1).take(3)
     c.foreach(sum += _)
 
-    sum must_=== 3
+    sum must_=== c.toSeq.sum
   }
-
-  private def takeWhileSingleton =
-    Chunk(1).takeWhile(_ == 1) must_=== Chunk(1)
 }

--- a/core/jvm/src/test/scala/scalaz/zio/stream/ChunkSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/stream/ChunkSpec.scala
@@ -1,12 +1,20 @@
 package scalaz.zio.stream
 
 import org.specs2._
+import org.specs2.specification.core.SpecStructure
 
 class ChunkSpec extends Specification with ScalaCheck {
-  def is = "ChunkSpec".title ^ s2"""
+  def is: SpecStructure = "ChunkSpec".title ^
+    s2"""
+  chunk apply $applyChunk
+  chunk length $chunkLength
   chunk equality $chunkEquality
+  chunk equality prop $chunkEqualityProp
   chunk inequality $chunkInequality
   flatMap chunk $flatMapChunk
+  map chunk $mapChunk
+  materialize chunk $materializeChunk
+  foldLeft chunk $foldLeftChunk
   filter chunk $filterChunk
   drop chunk $dropChunk
   drop singleton chunk $dropSingletonChunk
@@ -22,48 +30,79 @@ class ChunkSpec extends Specification with ScalaCheck {
   takeWhile singleton chunk $takeWhileSingleton
   takeWhile slice chunk $takeWhileSlice
   takeWhile array chunk $takeWhileArray
+  concat chunk $concatChunk
   An Array-based chunk that is filtered empty and mapped must not throw NPEs. $nullArrayBug
   toArray on concat of a slice must work properly. $toArrayOnConcatOfSlice
   toArray on concat of empty and integers must work properly. $toArrayOnConcatOfEmptyAndInts
   Chunk.filter that results in an empty Chunk must use Chunk.empty $filterConstFalseResultsInEmptyChunk
   Chunk.Slice toArray $sliceToArray
   Chunk.Slice foreach $sliceForeach
-  """
+  Chunk.slice toArray $sliceToArray
+    """
 
-  def chunkEquality =
-    Chunk(1, 2, 3, 4, 5) must_===
-      Chunk(1, 2, 3, 4, 5)
+  import ArbitraryChunk._
+  import org.scalacheck._
 
-  def chunkInequality =
-    Chunk(1, 2, 3, 4, 5) must_!==
-      Chunk(1, 2, 3, 4, 5, 6)
+  private def applyChunk = {
+    implicit val abStringGen: Gen[(Chunk[Int], Int)] = for {
+      chunk <- Arbitrary.arbitrary[Chunk[Int]].filter(_.length > 0)
+      len <- Gen.chooseNum(0, chunk.length - 1)
+    } yield (chunk, len)
 
-  def flatMapChunk = {
-    val c = Chunk.fromArray(Array(1, 2, 3, 4, 5))
-
-    c.flatMap(i => Chunk(i, i)) must_===
-      Chunk(1, 1, 2, 2, 3, 3, 4, 4, 5, 5)
+    prop { t: (Chunk[Int], Int) =>
+      t._1.apply(t._2) must_=== t._1.toSeq.apply(t._2)
+    }.setArbitrary(Arbitrary(abStringGen))
   }
 
-  def filterChunk =
-    Chunk(1, 2, 3, 4, 5).filter(_ % 2 == 0) must_===
-      Chunk(2, 4)
+  private def chunkLength =
+    prop { chunk: Chunk[Int] => chunk.length must_=== chunk.toSeq.length }
 
-  def dropChunk =
-    Chunk(1, 2, 3, 4, 5).drop(4) must_===
-      Chunk(5)
+  private def chunkEqualityProp =
+    prop((c1: Chunk[Int], c2: Chunk[Int]) => c1.equals(c2) must_=== c1.toSeq.equals(c2.toSeq))
 
-  def dropSingletonChunk =
+  private def chunkEquality =
+    Chunk(1, 2, 3, 4, 5) must_=== Chunk(1, 2, 3, 4, 5)
+
+  private def chunkInequality =
+    Chunk(1, 2, 3, 4, 5) must_!== Chunk(1, 2, 3, 4, 5, 6)
+
+  private def flatMapChunk =
+    prop { (c: Chunk[Int], f: Int => Chunk[Int]) =>
+      c.flatMap(f).toSeq must_=== c.toSeq.flatMap(f.andThen(_.toSeq))
+    }
+
+  private def mapChunk =
+    prop { (c: Chunk[Int], f: Int => String) =>
+      c.map(f).toSeq must_=== c.toSeq.map(f)
+    }
+
+  private def materializeChunk =
+    prop { c: Chunk[Int] => c.materialize.toSeq must_=== c.toSeq }
+
+  private def foldLeftChunk =
+    prop { (s0: String, f: (String, Int) => String, c: Chunk[Int]) =>
+      c.foldLeft(s0)(f) must_=== c.toArray.foldLeft(s0)(f)
+    }
+
+  private def filterChunk =
+    prop { (chunk: Chunk[String], p: String => Boolean) => chunk.filter(p).toSeq must_=== chunk.toSeq.filter(p) }
+
+  private def dropChunk =
+    prop { (chunk: Chunk[Int], n: Int) => chunk.drop(n).toSeq must_=== chunk.toSeq.drop(n) }
+
+  private def dropSingletonChunk =
     Chunk(1).drop(4) must_=== Chunk.empty
 
-  def takeChunk =
-    Chunk(1, 2, 3, 4, 5).take(4) must_===
-      Chunk(1, 2, 3, 4)
+  private def takeChunk =
+    prop {
+      (c: Chunk[Int], n: Int) =>
+        c.take(n).toSeq must_=== c.toSeq.take(n)
+    }
 
-  def takeSingletonChunk =
+  private def takeSingletonChunk =
     Chunk(1).take(4) must_=== Chunk(1)
 
-  def nullArrayBug = {
+  private def nullArrayBug = {
     val c = Chunk.fromArray(Array(1, 2, 3, 4, 5))
 
     // foreach should not throw
@@ -72,7 +111,11 @@ class ChunkSpec extends Specification with ScalaCheck {
     c.filter(_ => false).map(_ * 2).length must_=== 0
   }
 
-  def toArrayOnConcatOfSlice = {
+  private def concatChunk = prop { (c1: Chunk[Int], c2: Chunk[Int]) =>
+    (c1 ++ c2).toSeq must_=== (c1.toSeq ++ c2.toSeq)
+  }
+
+  private def toArrayOnConcatOfSlice = {
     val onlyOdd: Int => Boolean = _ % 2 != 0
     val concat = Chunk(1, 1, 1).filter(onlyOdd) ++
       Chunk(2, 2, 2).filter(onlyOdd) ++
@@ -83,38 +126,38 @@ class ChunkSpec extends Specification with ScalaCheck {
     array must_=== Array(1, 1, 1, 3, 3, 3)
   }
 
-  def toArrayOnConcatOfEmptyAndInts =
+  private def toArrayOnConcatOfEmptyAndInts =
     (Chunk.empty ++ Chunk.fromArray(Array(1, 2, 3))).toArray must_=== Array(1, 2, 3)
 
-  def filterConstFalseResultsInEmptyChunk = Chunk.fromArray(Array(1, 2, 3)).filter(_ => false) must_=== Chunk.empty
+  private def filterConstFalseResultsInEmptyChunk = Chunk.fromArray(Array(1, 2, 3)).filter(_ => false) must_=== Chunk.empty
 
-  def dropWhile =
-    Chunk
-      .fromArray(Array(1, 2, 3, 4))
-      .dropWhile(_ < 3) must_=== Chunk(3, 4)
+  private def dropWhile =
+    prop {
+      (c: Chunk[Int], p: Int => Boolean) =>
+        c.dropWhile(p).toSeq must_=== c.toSeq.dropWhile(p)
+    }
 
-  def takeWhile = Chunk(1, 2, 3, 4).takeWhile(_ < 3) must_=== Chunk(1, 2)
+  private def takeWhile = prop { (c: Chunk[Int], p: Int => Boolean) =>
+    c.takeWhile(p).toArray.toSeq must_=== c.toArray.toSeq.takeWhile(p)
+  }
 
-  def sliceToArray =
+  private def sliceToArray =
     Chunk.fromArray(Array(1, 2, 3, 4)).dropWhile(_ < 3).toArray must_=== Array(3, 4)
 
-  def dropSliceChunk =
+  private def dropSliceChunk =
     Chunk(1, 2, 3, 4, 5).dropWhile(_ < 3).drop(2) must_=== Chunk(5)
 
-  def takeSliceChunk =
+  private def takeSliceChunk =
     Chunk(1, 2, 3, 4, 5).dropWhile(_ < 3).take(2) must_=== Chunk(3, 4)
 
-  def dropWhileSingleton =
+  private def dropWhileSingleton =
     Chunk(1).dropWhile(_ == 1) must_=== Chunk.empty
 
-  def dropWhileSlice =
+  private def dropWhileSlice =
     Chunk(1, 2, 3, 4, 5).dropWhile(_ == 1).dropWhile(_ < 4) must_=== Chunk(4, 5)
 
   def dropWhileArray =
     Chunk(1, 2, 3, 4, 5).dropWhile(_ <= 3) must_=== Chunk(4, 5)
-
-  def takeWhileSingleton =
-    Chunk(1).takeWhile(_ == 1) must_=== Chunk(1)
 
   def takeWhileSlice = Chunk(1, 2, 3, 4, 5).takeWhile(_ <= 4).takeWhile(_ <= 2) must_=== Chunk(1, 2)
 
@@ -128,4 +171,7 @@ class ChunkSpec extends Specification with ScalaCheck {
 
     sum must_=== 3
   }
+
+  private def takeWhileSingleton =
+    Chunk(1).takeWhile(_ == 1) must_=== Chunk(1)
 }

--- a/core/jvm/src/test/scala/scalaz/zio/stream/ChunkSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/stream/ChunkSpec.scala
@@ -1,0 +1,131 @@
+package scalaz.zio.stream
+
+import org.specs2._
+
+class ChunkSpec extends Specification with ScalaCheck {
+  def is = "ChunkSpec".title ^ s2"""
+  chunk equality $chunkEquality
+  chunk inequality $chunkInequality
+  flatMap chunk $flatMapChunk
+  filter chunk $filterChunk
+  drop chunk $dropChunk
+  drop singleton chunk $dropSingletonChunk
+  drop slice chunk $dropSliceChunk
+  take chunk $takeChunk
+  take singleton chunk $takeSingletonChunk
+  take slice chunk $takeSliceChunk
+  dropWhile chunk $dropWhile
+  dropWhile singleton chunk $dropWhileSingleton
+  dropWhile slice chunk $dropWhileSlice
+  dropWhile array chunk $dropWhileArray
+  takeWhile chunk $takeWhile
+  takeWhile singleton chunk $takeWhileSingleton
+  takeWhile slice chunk $takeWhileSlice
+  takeWhile array chunk $takeWhileArray
+  An Array-based chunk that is filtered empty and mapped must not throw NPEs. $nullArrayBug
+  toArray on concat of a slice must work properly. $toArrayOnConcatOfSlice
+  toArray on concat of empty and integers must work properly. $toArrayOnConcatOfEmptyAndInts
+  Chunk.filter that results in an empty Chunk must use Chunk.empty $filterConstFalseResultsInEmptyChunk
+  Chunk.Slice toArray $sliceToArray
+  Chunk.Slice foreach $sliceForeach
+  """
+
+  def chunkEquality =
+    Chunk(1, 2, 3, 4, 5) must_===
+      Chunk(1, 2, 3, 4, 5)
+
+  def chunkInequality =
+    Chunk(1, 2, 3, 4, 5) must_!==
+      Chunk(1, 2, 3, 4, 5, 6)
+
+  def flatMapChunk = {
+    val c = Chunk.fromArray(Array(1, 2, 3, 4, 5))
+
+    c.flatMap(i => Chunk(i, i)) must_===
+      Chunk(1, 1, 2, 2, 3, 3, 4, 4, 5, 5)
+  }
+
+  def filterChunk =
+    Chunk(1, 2, 3, 4, 5).filter(_ % 2 == 0) must_===
+      Chunk(2, 4)
+
+  def dropChunk =
+    Chunk(1, 2, 3, 4, 5).drop(4) must_===
+      Chunk(5)
+
+  def dropSingletonChunk =
+    Chunk(1).drop(4) must_=== Chunk.empty
+
+  def takeChunk =
+    Chunk(1, 2, 3, 4, 5).take(4) must_===
+      Chunk(1, 2, 3, 4)
+
+  def takeSingletonChunk =
+    Chunk(1).take(4) must_=== Chunk(1)
+
+  def nullArrayBug = {
+    val c = Chunk.fromArray(Array(1, 2, 3, 4, 5))
+
+    // foreach should not throw
+    c.foreach(_ => ())
+
+    c.filter(_ => false).map(_ * 2).length must_=== 0
+  }
+
+  def toArrayOnConcatOfSlice = {
+    val onlyOdd: Int => Boolean = _ % 2 != 0
+    val concat = Chunk(1, 1, 1).filter(onlyOdd) ++
+      Chunk(2, 2, 2).filter(onlyOdd) ++
+      Chunk(3, 3, 3).filter(onlyOdd)
+
+    val array = concat.toArray
+
+    array must_=== Array(1, 1, 1, 3, 3, 3)
+  }
+
+  def toArrayOnConcatOfEmptyAndInts =
+    (Chunk.empty ++ Chunk.fromArray(Array(1, 2, 3))).toArray must_=== Array(1, 2, 3)
+
+  def filterConstFalseResultsInEmptyChunk = Chunk.fromArray(Array(1, 2, 3)).filter(_ => false) must_=== Chunk.empty
+
+  def dropWhile =
+    Chunk
+      .fromArray(Array(1, 2, 3, 4))
+      .dropWhile(_ < 3) must_=== Chunk(3, 4)
+
+  def takeWhile = Chunk(1, 2, 3, 4).takeWhile(_ < 3) must_=== Chunk(1, 2)
+
+  def sliceToArray =
+    Chunk.fromArray(Array(1, 2, 3, 4)).dropWhile(_ < 3).toArray must_=== Array(3, 4)
+
+  def dropSliceChunk =
+    Chunk(1, 2, 3, 4, 5).dropWhile(_ < 3).drop(2) must_=== Chunk(5)
+
+  def takeSliceChunk =
+    Chunk(1, 2, 3, 4, 5).dropWhile(_ < 3).take(2) must_=== Chunk(3, 4)
+
+  def dropWhileSingleton =
+    Chunk(1).dropWhile(_ == 1) must_=== Chunk.empty
+
+  def dropWhileSlice =
+    Chunk(1, 2, 3, 4, 5).dropWhile(_ == 1).dropWhile(_ < 4) must_=== Chunk(4, 5)
+
+  def dropWhileArray =
+    Chunk(1, 2, 3, 4, 5).dropWhile(_ <= 3) must_=== Chunk(4, 5)
+
+  def takeWhileSingleton =
+    Chunk(1).takeWhile(_ == 1) must_=== Chunk(1)
+
+  def takeWhileSlice = Chunk(1, 2, 3, 4, 5).takeWhile(_ <= 4).takeWhile(_ <= 2) must_=== Chunk(1, 2)
+
+  def takeWhileArray = Chunk(1, 2, 3, 4, 5).takeWhile(_ <= 3) must_=== Chunk(1, 2, 3)
+
+  def sliceForeach = {
+    var sum = 0
+
+    val c = Chunk(1, 1, 1, 1, 1).take(3)
+    c.foreach(sum += _)
+
+    sum must_=== 3
+  }
+}

--- a/core/jvm/src/test/scala/scalaz/zio/stream/SinkSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/stream/SinkSpec.scala
@@ -1,0 +1,81 @@
+package scalaz.zio.stream
+
+import org.specs2.ScalaCheck
+import scala.{ Stream => _ }
+import scalaz.zio.{ AbstractRTSSpec, ExitResult, GenIO, IO }
+
+class SinkSpec extends AbstractRTSSpec with GenIO with ScalaCheck {
+  def is = "SinkSpec".title ^ s2"""
+  A sink written with Sink.foldM works properly. $jsonNumArrayParsingSinkFoldM
+  A sink written with combinators works properly. $jsonNumArrayParsingSinkWithCombinators
+  """
+
+  def jsonNumArrayParsingSinkFoldM = {
+    sealed trait ParserState
+    object ParserState {
+      case object Start               extends ParserState
+      case class Element(acc: String) extends ParserState
+      case object Done                extends ParserState
+    }
+
+    val numArrayParser =
+      Sink
+        .foldM(IO.now((ParserState.Start: ParserState, List.empty[Int]))) { (s, a: Char) =>
+          s match {
+            case (ParserState.Start, acc) =>
+              a match {
+                case a if a.isWhitespace => IO.now(Sink.Step.more((ParserState.Start, acc)))
+                case '['                 => IO.now(Sink.Step.more((ParserState.Element(""), acc)))
+                case _                   => IO.fail("Expected '['")
+              }
+
+            case (ParserState.Element(el), acc) =>
+              a match {
+                case a if a.isDigit => IO.now(Sink.Step.more((ParserState.Element(el + a), acc)))
+                case ','            => IO.now(Sink.Step.more((ParserState.Element(""), acc :+ el.toInt)))
+                case ']'            => IO.now(Sink.Step.done((ParserState.Done, acc :+ el.toInt), Chunk.empty))
+                case _              => IO.fail("Expected a digit or ,")
+              }
+
+            case (ParserState.Done, acc) =>
+              IO.now(Sink.Step.done((ParserState.Done, acc), Chunk.empty))
+          }
+        }
+        .map(_._2)
+        .chunked
+
+    val src1         = StreamChunk.point(Chunk.fromArray(Array('[', '1', '2')))
+    val src2         = StreamChunk.point(Chunk.fromArray(Array('3', ',', '4', ']')))
+    val partialParse = unsafeRunSync(src1.run(numArrayParser))
+    val fullParse    = unsafeRunSync((src1 ++ src2).run(numArrayParser))
+
+    (partialParse must_=== (ExitResult.Succeeded(List()))) and
+      (fullParse must_=== (ExitResult.Succeeded(List(123, 4))))
+  }
+
+  def jsonNumArrayParsingSinkWithCombinators = {
+    val comma = Sink.readWhile[Char](_ == ',')
+    val brace = Sink.read1[String, Char](a => s"Expected closing brace; instead: ${a}")((_: Char) == ']')
+    val number: Sink[String, Char, Char, Int] =
+      Sink.readWhile[Char](_.isDigit).map(_.mkString.toInt)
+    val numbers = (number ~ (comma *> number).repeatWhile(_ != ']'))
+      .map(tp => tp._1 :: tp._2)
+
+    val elements = numbers <* brace
+
+    lazy val start: Sink[String, Char, Char, List[Int]] =
+      Sink.more(IO.fail("Input was empty")) {
+        case a if a.isWhitespace => start
+        case '['                 => elements
+        case _                   => Sink.fail("Expected '['")
+      }
+
+    val src1         = StreamChunk.point(Chunk.fromArray(Array('[', '1', '2')))
+    val src2         = StreamChunk.point(Chunk.fromArray(Array('3', ',', '4', ']')))
+    val partialParse = unsafeRunSync(src1.run(start.chunked))
+    val fullParse    = unsafeRunSync((src1 ++ src2).run(start.chunked))
+
+    (partialParse must_=== (ExitResult.checked("Expected closing brace; instead: None"))) and
+      (fullParse must_=== (ExitResult.Succeeded(List(123, 4))))
+  }
+}

--- a/core/jvm/src/test/scala/scalaz/zio/stream/SinkSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/stream/SinkSpec.scala
@@ -4,7 +4,7 @@ import org.specs2.ScalaCheck
 import scala.{ Stream => _ }
 import scalaz.zio.{ AbstractRTSSpec, ExitResult, GenIO, IO }
 
-class SinkSpec extends AbstractRTSSpec with GenIO with ScalaCheck {
+class SinkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends AbstractRTSSpec with GenIO with ScalaCheck {
   def is = "SinkSpec".title ^ s2"""
   A sink written with Sink.foldM works properly. $jsonNumArrayParsingSinkFoldM
   A sink written with combinators works properly. $jsonNumArrayParsingSinkWithCombinators

--- a/core/jvm/src/test/scala/scalaz/zio/stream/StreamSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/stream/StreamSpec.scala
@@ -1,0 +1,185 @@
+package scalaz.zio.stream
+
+import org.specs2.ScalaCheck
+import scala.{ Stream => _ }
+import scalaz.zio.{ AbstractRTSSpec, GenIO, IO }
+
+class StreamSpec extends AbstractRTSSpec with GenIO with ScalaCheck {
+  def is = "StreamSpec".title ^ s2"""
+  PureStream.filter       $filter
+  PureStream.dropWhile    $dropWhile
+  PureStream.takeWhile    $takeWhile
+  PureStream.map          $map
+  PureStream.mapConcat    $mapConcat
+  PureStream.scan         $scan
+  Stream.unfold           $unfold
+  Stream.unfoldM          $unfoldM
+  Stream.range            $range
+  Stream.take             $take
+  Stream.zipWithIndex     $zipWithIndex
+  Stream.++               $concat
+  Stream.foreach0         $foreach0
+  Stream.foreach          $foreach
+  Stream.collect          $collect
+  Stream.flatMap          $flatMap
+  Stream.forever          $forever
+  Stream.joinWith         $joinWith
+  Stream.merge            $merge
+  Stream.mergeEither      $mergeEither
+  Stream.mergeWith        $mergeWith
+  """
+
+  def slurp[E, A](s: Stream[E, A]) = s match {
+    case s: StreamPure[A] => s.foldPure(List[A]())((acc, el) => Stream.Step.cont(el :: acc)).extract.reverse
+    case s                => slurpM(s)
+  }
+
+  def slurpM[E, A](s: Stream[E, A]) =
+    unsafeRun(s.fold(List[A]())((acc, el) => IO.now(Stream.Step.cont(el :: acc)))).extract.reverse
+
+  def filter = {
+    val stream = Stream(1, 2, 3, 4, 5).filter(_ % 2 == 0)
+    (slurp(stream) must_=== List(2, 4)) and (slurpM(stream) must_=== List(2, 4))
+  }
+
+  def dropWhile = {
+    val stream = Stream(1, 1, 1, 3, 4, 5).dropWhile(_ == 1)
+    (slurp(stream) must_=== List(3, 4, 5)) and (slurpM(stream) must_=== List(3, 4, 5))
+  }
+
+  def takeWhile = {
+    val stream = Stream(3, 4, 5, 1, 1, 1).takeWhile(_ != 1)
+    (slurp(stream) must_=== List(3, 4, 5)) and (slurpM(stream) must_=== List(3, 4, 5))
+  }
+
+  def map = {
+    val stream = Stream(1, 1, 1).map(_ + 1)
+    (slurp(stream) must_=== List(2, 2, 2)) and (slurpM(stream) must_=== List(2, 2, 2))
+  }
+
+  def mapConcat = {
+    val stream = Stream(1, 2, 3).mapConcat(i => Chunk(i, i))
+    (slurp(stream) must_=== List(1, 1, 2, 2, 3, 3)) and (slurpM(stream) must_=== List(1, 1, 2, 2, 3, 3))
+  }
+
+  def zipWithIndex = {
+    val stream = Stream(1, 1, 1).zipWithIndex
+    (slurp(stream) must_=== List((1, 0), (1, 1), (1, 2))) and (slurpM(stream) must_=== List((1, 0), (1, 1), (1, 2)))
+  }
+
+  def scan = {
+    val stream = Stream(1, 1, 1).scan(0)((acc, el) => (acc + el, acc + el))
+    (slurp(stream) must_=== List(1, 2, 3)) and (slurpM(stream) must_=== List(1, 2, 3))
+  }
+
+  def unfold = {
+    val s = Stream.unfold(0)(i => if (i < 10) Some((i, i + 1)) else None)
+    slurp(s) must_=== (0 to 9).toList and (slurpM(s) must_=== (0 to 9).toList)
+  }
+
+  def unfoldM = {
+    val s = Stream.unfoldM(0)(i => if (i < 10) IO.now(Some((i, i + 1))) else IO.now(None))
+    slurp(s) must_=== (0 to 9).toList and (slurpM(s) must_=== (0 to 9).toList)
+  }
+
+  def range = {
+    val s = Stream.range(0, 9)
+    slurp(s) must_=== (0 to 9).toList and (slurpM(s) must_=== (0 to 9).toList)
+  }
+
+  def take = {
+    val s = Stream.range(0, 9).take(3)
+    slurp(s) must_=== (0 to 2).toList and (slurpM(s) must_=== (0 to 2).toList)
+  }
+
+  def concat = {
+    val s = Stream(1, 2, 3) ++ Stream(4, 5, 6)
+    slurp(s) must_=== (1 to 6).toList and (slurpM(s) must_=== (1 to 6).toList)
+  }
+
+  def foreach0 = {
+    var sum = 0
+    val s   = Stream(1, 1, 1, 1, 1, 1)
+
+    unsafeRun(
+      s.foreach0(
+        a =>
+          IO.sync(
+            if (sum >= 3) false
+            else {
+              sum += a; true
+            }
+          )
+      )
+    )
+    sum must_=== 3
+  }
+
+  def foreach = {
+    var sum = 0
+    val s   = Stream(1, 1, 1, 1, 1)
+
+    unsafeRun(s.foreach(a => IO.sync(sum += a)))
+    sum must_=== 5
+  }
+
+  def collect = {
+    val s = Stream(Left(1), Right(2), Left(3)).collect {
+      case Right(n) => n
+    }
+
+    slurp(s) must_=== List(2) and (slurpM(s) must_=== List(2))
+  }
+
+  def flatMap = {
+    val s = Stream(1, 1).flatMap(a => Stream(a, a))
+
+    slurp(s) must_=== List(1, 1, 1, 1) and (slurpM(s) must_=== List(1, 1, 1, 1))
+  }
+
+  def forever = {
+    var sum = 0
+    val s   = Stream(1).forever.foreach0(a => IO.sync { sum += a; if (sum >= 9) false else true })
+
+    unsafeRun(s)
+    sum must_=== 9
+  }
+
+  def joinWith = {
+    val s1 = Stream(1, 1)
+    val s2 = Stream(2, 2)
+    val join = s1.joinWith(s2, 1, 1)(
+      (a: IO[Nothing, Option[Int]], b: IO[Nothing, Option[Int]]) =>
+        a.seqWith(b)((a, b) => a flatMap (a => b map ((a, _))))
+    )
+
+    slurp(join) must_=== List((1, 2), (1, 2)) and (slurpM(join) must_=== List((1, 2), (1, 2)))
+  }
+
+  def merge = {
+    val s1 = Stream(Left(1), Left(2))
+    val s2 = Stream(Right(1), Right(2))
+
+    val merge = s1.merge(s2)
+
+    slurpM(merge) must containTheSameElementsAs(List(Left(1), Left(2), Right(1), Right(2)))
+  }
+
+  def mergeEither = {
+    val s1 = Stream(1, 2)
+    val s2 = Stream(1, 2)
+
+    val merge = s1.mergeEither(s2)
+
+    slurpM(merge) must containTheSameElementsAs(List(Left(1), Left(2), Right(1), Right(2)))
+  }
+
+  def mergeWith = {
+    val s1 = Stream(1, 2)
+    val s2 = Stream(1, 2)
+
+    val merge = s1.mergeWith(s2)(_.toString, _.toString)
+
+    slurpM(merge) must containTheSameElementsAs(List("1", "2", "1", "2"))
+  }
+}

--- a/core/shared/src/main/scala/scalaz/zio/Managed.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Managed.scala
@@ -112,7 +112,7 @@ object Managed {
     new Managed[E, R] {
       type R0 = R
 
-      protected def acquire: IO[E, R] = IO.never
+      protected def acquire: IO[E, R] = fa
 
       protected def release: R => IO[Nothing, _] = _ => IO.unit
 
@@ -125,6 +125,12 @@ object Managed {
    */
   final def unwrap[E, R](fa: IO[E, Managed[E, R]]): Managed[E, R] =
     new Managed[E, R] {
+      type R0 = R
+
+      protected def acquire: IO[E, R] = IO.never
+
+      protected def release: R => IO[Nothing, Unit] = _ => IO.unit
+
       def use[E1 >: E, A](f: R => IO[E1, A]): IO[E1, A] =
         fa.flatMap(_.use(f))
     }
@@ -136,7 +142,7 @@ object Managed {
     new Managed[Nothing, R] {
       type R0 = R
 
-      protected def acquire: IO[Nothing, R] = IO.never
+      protected def acquire: IO[Nothing, R] = IO.now(r)
 
       protected def release: R => IO[Nothing, _] = _ => IO.unit
 
@@ -150,7 +156,7 @@ object Managed {
     new Managed[Nothing, R] {
       type R0 = R
 
-      protected def acquire: IO[Nothing, R] = IO.never
+      protected def acquire: IO[Nothing, R] = IO.point(r)
 
       protected def release: R => IO[Nothing, _] = _ => IO.unit
 

--- a/core/shared/src/main/scala/scalaz/zio/Managed.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Managed.scala
@@ -121,6 +121,15 @@ object Managed {
     }
 
   /**
+   * Unwraps a `Managed` that is inside an `IO`.
+   */
+  final def unwrap[E, R](fa: IO[E, Managed[E, R]]): Managed[E, R] =
+    new Managed[E, R] {
+      def use[E1 >: E, A](f: R => IO[E1, A]): IO[E1, A] =
+        fa.flatMap(_.use(f))
+    }
+
+  /**
    * Lifts a strict, pure value into a Managed.
    */
   final def now[R](r: R): Managed[Nothing, R] =

--- a/core/shared/src/main/scala/scalaz/zio/stream/Chunk.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/Chunk.scala
@@ -1,0 +1,848 @@
+package scalaz.zio.stream
+
+import scalaz.zio._
+import scala.reflect._
+
+/**
+ * A `Chunk[A]` represents a chunk of values of type `A`. Chunks are designed
+ * are usually backed by arrays, but expose a purely functional, safe interface
+ * to the underlying elements, and they become lazy on operations that would be
+ * costly with arrays, such as repeated concatenation.
+ */
+sealed trait Chunk[@specialized +A] { self =>
+
+  /**
+   * The number of elements in the chunk.
+   */
+  def length: Int
+
+  /**
+   * Determines if the chunk is empty.
+   */
+  final def isEmpty: Boolean = length == 0
+
+  /**
+   * Determines if the chunk is not empty.
+   */
+  final def notEmpty: Boolean = length > 0
+
+  /**
+   * Returns the concatenation of this chunk with the specified chunk.
+   */
+  final def ++[A1 >: A](that: Chunk[A1]): Chunk[A1] =
+    if (self.length == 0) that
+    else if (that.length == 0) self
+    else Chunk.Concat(self, that)
+
+  /**
+   * Returns a filtered, mapped subset of the elements of this chunk.
+   */
+  def collect[@specialized B](p: PartialFunction[A, B]): Chunk[B] =
+    self.materialize.collect(p)
+
+  /**
+   * Drops the first `n` elements of the chunk.
+   */
+  final def drop(n: Int): Chunk[A] =
+    self match {
+      case Chunk.Slice(c, o, l) =>
+        Chunk.Slice(c, o + n, l - n)
+      case c @ Chunk.Singleton(_) =>
+        if (n <= 0) c else Chunk.empty
+      case _ =>
+        Chunk.Slice(self, n, self.length - n)
+    }
+
+  /**
+   * Drops all elements so long as the predicate returns true.
+   */
+  def dropWhile(f: A => Boolean): Chunk[A] = {
+    val len = self.length
+
+    var i = 0
+    while (i < len && f(self(i))) {
+      i += 1
+    }
+
+    if (i == len) Chunk.empty
+    else if (i == 0) this
+    else Chunk.Slice(self, i, len - i)
+  }
+
+  override def equals(that: Any): Boolean = that match {
+    case that: Chunk[_] =>
+      if (self.length != that.length) false
+      else {
+        var i     = 0
+        var equal = true
+        val len   = self.length
+
+        while (equal && i < len) {
+          equal = self(i) == that(i)
+          i += 1
+        }
+
+        equal
+      }
+    case _ => false
+  }
+
+  /**
+   * Returns a filtered subset of this chunk.
+   */
+  def filter(f: A => Boolean): Chunk[A] = {
+    implicit val B = Chunk.classTagOf(this)
+
+    val len  = self.length
+    val dest = Array.ofDim[A](len)
+
+    var i = 0
+    var j = 0
+    while (i < len) {
+      val elem = self(i)
+
+      if (f(elem)) {
+        dest(j) = elem
+        j += 1
+      }
+
+      i += 1
+    }
+
+    if (j == 0) Chunk.Empty
+    else Chunk.Slice(Chunk.Arr(dest), 0, j)
+  }
+
+  /**
+   * Returns the concatenation of mapping every element into a new chunk using
+   * the specified function.
+   */
+  def flatMap[@specialized B](f: A => Chunk[B]): Chunk[B] = {
+    val len                    = self.length
+    var chunks: List[Chunk[B]] = Nil
+
+    var i               = 0
+    var total           = 0
+    var B0: ClassTag[B] = null.asInstanceOf[ClassTag[B]]
+    while (i < len) {
+      val chunk = f(self(i))
+      if (chunk.length > 0) B0 = Chunk.classTagOf(chunk)
+      chunks ::= chunk
+      i += 1
+      total += chunk.length
+    }
+    chunks = chunks.reverse
+
+    if (B0 == null) Chunk.empty
+    else {
+      implicit val B = B0
+
+      val dest: Array[B] = Array.ofDim(total)
+
+      val it = chunks.iterator
+      var n  = 0
+      while (it.hasNext) {
+        val chunk = it.next
+
+        chunk.toArray(n, dest)
+        n += chunk.length
+      }
+
+      Chunk.Arr(dest)
+    }
+  }
+
+  final def foldMLazy[E, S](z: S)(pred: S => Boolean)(f: (S, A) => IO[E, S]): IO[E, S] = {
+    val len = length
+
+    def loop(s: S, i: Int): IO[E, S] =
+      if (i >= len) IO.now(s)
+      else {
+        if (pred(s)) f(s, self(i)).flatMap(loop(_, i + 1))
+        else IO.now(s)
+      }
+
+    loop(z, 0)
+  }
+
+  final def foldLeftLazy[S](z: S)(pred: S => Boolean)(f: (S, A) => S): S = {
+    val len = length
+    var s   = z
+    var i   = 0
+    while (i < len && pred(s)) {
+      s = f(s, self(i))
+      i += 1
+    }
+    s
+  }
+
+  /**
+   * Folds over the elements in this chunk from the left.
+   */
+  def foldLeft[@specialized S](s0: S)(f: (S, A) => S): S = {
+    val len = self.length
+    var s   = s0
+
+    var i = 0
+    while (i < len) {
+      s = f(s, self(i))
+      i += 1
+    }
+
+    s
+  }
+
+  /**
+   * Effectfully folds over the elements in this chunk from the left.
+   */
+  final def foldM[E, S](s: S)(f: (S, A) => IO[E, S]): IO[E, S] =
+    foldLeft[IO[E, S]](IO.now(s)) { (s, a) =>
+      s.flatMap(f(_, a))
+    }
+
+  /**
+   * Folds over the elements in this chunk from the right.
+   */
+  def foldRight[@specialized S](s0: S)(f: (A, S) => S): S = {
+    val len = self.length
+    var s   = s0
+
+    var i = len - 1
+    while (i >= 0) {
+      s = f(self(i), s)
+      i -= 1
+    }
+
+    s
+  }
+
+  override final def hashCode: Int = toArray.toSeq.hashCode
+
+  /**
+   * Returns a chunk with the elements mapped by the specified function.
+   */
+  def map[@specialized B](f: A => B): Chunk[B] = {
+    val len  = self.length
+    var dest = null.asInstanceOf[Array[B]]
+
+    var i = 0
+    while (i < len) {
+      val b = f(self(i))
+
+      if (dest == null) {
+        implicit val B: ClassTag[B] = Chunk.Tags.fromValue(b)
+
+        dest = Array.ofDim[B](len)
+      }
+
+      dest(i) = b
+
+      i = i + 1
+    }
+
+    if (dest != null) Chunk.Arr(dest)
+    else Chunk.Empty
+  }
+
+  /**
+   * Materializes a chunk into a chunk backed by an array. This method can
+   * improve the performance of bulk operations.
+   */
+  def materialize[A1 >: A]: Chunk[A1] = Chunk.Arr(toArray)
+
+  /**
+   * Generates a readable string representation of this chunk using the
+   * specified start, separator, and end strings.
+   */
+  final def mkString(start: String, sep: String, end: String): String = {
+    val builder = new scala.collection.mutable.StringBuilder()
+
+    builder.append(start)
+
+    var i   = 0
+    val len = self.length
+
+    while (i < len) {
+      if (i != 0) builder.append(sep)
+      builder.append(self(i).toString)
+      i += 1
+    }
+
+    builder.append(end)
+
+    builder.toString
+  }
+
+  /**
+   * Generates a readable string representation of this chunk using the
+   * specified separator string.
+   */
+  final def mkString(sep: String): String = mkString("", sep, "")
+
+  /**
+   * Generates a readable string representation of this chunk.
+   */
+  final def mkString: String = mkString("")
+
+  /**
+   * Scans over the chunk, statefully producing new elements of type `B`.
+   */
+  final def scan[@specialized S1, @specialized B](s1: S1)(f1: (S1, A) => (S1, B)): (S1, Chunk[B]) = {
+    var s: S1          = s1
+    var i              = 0
+    var dest: Array[B] = null.asInstanceOf[Array[B]]
+
+    while (i < self.length) {
+      val a = self(i)
+      val t = f1(s, a)
+
+      s = t._1
+      val b = t._2
+
+      if (dest == null) {
+        implicit val B: ClassTag[B] = Chunk.Tags.fromValue(b)
+
+        dest = Array.ofDim(self.length)
+      }
+
+      dest(i) = b
+
+      i += 1
+    }
+
+    s ->
+      (if (dest == null) Chunk.empty
+       else Chunk.Arr(dest))
+  }
+
+  /**
+   * Takes the first `n` elements of the chunk.
+   */
+  final def take(n: Int): Chunk[A] =
+    if (n <= 0) Chunk.Empty
+    else
+      self match {
+        case Chunk.Slice(c, o, l) =>
+          if (n >= l) this
+          else Chunk.Slice(c, o, n)
+        case c @ Chunk.Singleton(_) =>
+          c
+        case _ =>
+          Chunk.Slice(self, 0, n)
+      }
+
+  /**
+   * Takes all elements so long as the predicate returns true.
+   */
+  def takeWhile(f: A => Boolean): Chunk[A] = {
+    val len = self.length
+
+    var i = 0
+    while (i < len && f(self(i))) {
+      i += 1
+    }
+
+    if (i == 0) Chunk.Empty
+    else if (i == len) this
+    else Chunk.Slice(this, 0, i)
+  }
+
+  /**
+   * Converts the chunk into an array.
+   */
+  def toArray[A1 >: A]: Array[A1] = {
+    implicit val A1: ClassTag[A1] = Chunk.classTagOf(self)
+
+    val dest = Array.ofDim[A1](self.length)
+
+    self.toArray(0, dest)
+
+    dest
+  }
+
+  override def toString: String =
+    toArray.mkString("Chunk(", ",", ")")
+
+  /**
+   * Effectfully traverses the elements of this chunk.
+   */
+  final def traverse[E, B](f: A => IO[E, B]): IO[E, Chunk[B]] = {
+    val len                    = self.length
+    var array: IO[E, Array[B]] = IO.now(null.asInstanceOf[Array[B]])
+    var i                      = 0
+
+    while (i < len) {
+      array = array.seqWith(f(self.apply(i))) { (array, b) =>
+        val array2 = if (array == null) {
+          implicit val B: ClassTag[B] = Chunk.Tags.fromValue(b)
+          Array.ofDim[B](len)
+        } else array
+
+        array2(i) = b
+        array2
+      }
+
+      i += 1
+    }
+
+    array.map(
+      array =>
+        if (array == null) Chunk.empty
+        else Chunk.fromArray(array)
+    )
+  }
+
+  /**
+   * Effectfully traverses the elements of this chunk purely for the effects.
+   */
+  final def traverse_[E](f: A => IO[E, Unit]): IO[E, Unit] = {
+    val len             = self.length
+    var io: IO[E, Unit] = IO.unit
+    var i               = 0
+
+    while (i < len) {
+      io = io *> f(self(i))
+      i += 1
+    }
+
+    io
+  }
+
+  /**
+   * Returns two splits of this chunk at the specified index.
+   */
+  final def splitAt(n: Int): (Chunk[A], Chunk[A]) =
+    (take(n), drop(n))
+
+  /**
+   * Zips this chunk with the specified chunk using the specified combiner.
+   */
+  final def zipWith[@specialized B, @specialized C](that: Chunk[B])(f: (A, B) => C): Chunk[C] = {
+    val size = self.length.min(that.length)
+
+    if (size == 0) Chunk.empty
+    else {
+      var dest = null.asInstanceOf[Array[C]]
+
+      var i = 0
+      while (i < size) {
+        val c = f(self(i), that(i))
+        if (dest == null) {
+          implicit val C: ClassTag[C] = Chunk.Tags.fromValue(c)
+
+          dest = Array.ofDim[C](size)
+        }
+
+        dest(i) = c
+
+        i = i + 1
+      }
+
+      Chunk.Arr(dest)
+    }
+  }
+
+  /**
+   * Zips this chunk with the index of every element, starting from the initial
+   * index value.
+   */
+  final def zipWithIndex0(indexOffset: Int): Chunk[(A, Int)] = {
+    val len  = self.length
+    val dest = Array.ofDim[(A, Int)](len)
+
+    var i = 0
+
+    while (i < len) {
+      dest(i) = (self(i), i + indexOffset)
+
+      i += 1
+    }
+
+    Chunk.Arr(dest)
+  }
+
+  /**
+   * Zips this chunk with the index of every element.
+   */
+  final def zipWithIndex: Chunk[(A, Int)] = zipWithIndex0(0)
+
+  protected[zio] def apply(n: Int): A
+  protected[zio] def foreach(f: A => Unit): Unit
+  protected[zio] def toArray[A1 >: A](n: Int, dest: Array[A1]): Unit
+}
+
+object Chunk {
+
+  /**
+   * Returns a chunk from a number of values.
+   */
+  final def apply[A](as: A*) = fromIterable(as)
+
+  /**
+   * Returns the empty chunk.
+   */
+  final val empty: Chunk[Nothing] = Empty
+
+  /**
+   * Returns a chunk backed by an array.
+   */
+  final def fromArray[@specialized A](array: Array[A]): Chunk[A] = Arr(array)
+
+  /**
+   * Returns a chunk backed by an iterable.
+   */
+  final def fromIterable[A](it: Iterable[A]): Chunk[A] =
+    if (it.size <= 0) Empty
+    else if (it.size == 1) Singleton(it.head)
+    else {
+      it match {
+        case l: Vector[A] => VectorChunk(l)
+        case _ =>
+          val first = it.head
+
+          implicit val A: ClassTag[A] = Tags.fromValue(first)
+
+          fromArray(it.toArray)
+      }
+    }
+
+  /**
+   * Returns a singleton chunk.
+   */
+  final def point[@specialized A](a: A): Chunk[A] = Singleton(a)
+
+  /**
+   * Returns the `ClassTag` for the element type of the chunk.
+   */
+  private final def classTagOf[A](chunk: Chunk[A]): ClassTag[A] = chunk match {
+    case x: Arr[A]         => x.classTag
+    case x: Concat[A]      => x.classTag
+    case Empty             => classTag[java.lang.Object].asInstanceOf[ClassTag[A]]
+    case x: Singleton[A]   => x.classTag
+    case x: Slice[A]       => x.classTag
+    case x: VectorChunk[A] => x.classTag
+  }
+
+  private case class Arr[@specialized A](private val array: Array[A]) extends Chunk[A] {
+    implicit lazy val classTag: ClassTag[A] = ClassTag(array.getClass.getComponentType)
+
+    override def collect[@specialized B](p: PartialFunction[A, B]): Chunk[B] = {
+      val self = array
+      val len  = self.length
+      var dest = null.asInstanceOf[Array[B]]
+
+      var i = 0
+      var j = 0
+      while (i < len) {
+        val a = self(i)
+
+        if (p.isDefinedAt(a)) {
+          val b = p(a)
+
+          if (dest == null) {
+            implicit val B: ClassTag[B] = Chunk.Tags.fromValue(b)
+
+            dest = Array.ofDim[B](len)
+          }
+
+          dest(j) = b
+
+          j += 1
+        }
+
+        i += 1
+      }
+
+      if (dest == null) Chunk.Empty
+      else Chunk.Slice(Chunk.Arr(dest), 0, j)
+    }
+
+    override def dropWhile(f: A => Boolean): Chunk[A] = {
+      val self = array
+      val len  = self.length
+
+      var i = 0
+      while (i < len && f(self(i))) {
+        i += 1
+      }
+
+      if (i == len) Chunk.empty
+      else if (i == 0) this
+      else Chunk.Slice(this, i, len - i)
+    }
+
+    override def filter(f: A => Boolean): Chunk[A] = {
+      val self = array
+      val len  = self.length
+      val dest = Array.ofDim[A](len)
+
+      var i = 0
+      var j = 0
+      while (i < len) {
+        val elem = self(i)
+
+        if (f(elem)) {
+          dest(j) = elem
+          j += 1
+        }
+
+        i += 1
+      }
+
+      if (dest == null) Chunk.Empty
+      else Chunk.Slice(Chunk.Arr(dest), 0, j)
+    }
+
+    override def flatMap[@specialized B](f: A => Chunk[B]): Chunk[B] = {
+      val self                   = array
+      val len                    = self.length
+      var chunks: List[Chunk[B]] = Nil
+
+      var i               = 0
+      var total           = 0
+      var B0: ClassTag[B] = null.asInstanceOf[ClassTag[B]]
+      while (i < len) {
+        val chunk = f(self(i))
+        if (chunk.length > 0) B0 = Chunk.classTagOf(chunk)
+        chunks ::= chunk
+        i += 1
+        total += chunk.length
+      }
+      chunks = chunks.reverse
+
+      if (B0 == null) Chunk.empty
+      else {
+        implicit val B = B0
+
+        val dest: Array[B] = Array.ofDim(total)
+
+        val it = chunks.iterator
+        var n  = 0
+        while (it.hasNext) {
+          val chunk = it.next
+
+          chunk.toArray(n, dest)
+          n += chunk.length
+        }
+
+        Arr(dest)
+      }
+    }
+
+    override def foldLeft[@specialized S](s0: S)(f: (S, A) => S): S = {
+      val self = array
+      val len  = self.length
+      var s    = s0
+
+      var i = 0
+      while (i < len) {
+        s = f(s, self(i))
+        i += 1
+      }
+
+      s
+    }
+
+    override def foldRight[@specialized S](s0: S)(f: (A, S) => S): S = {
+      val self = array
+      val len  = self.length
+      var s    = s0
+
+      var i = len - 1
+      while (i >= 0) {
+        s = f(self(i), s)
+        i -= 1
+      }
+
+      s
+    }
+
+    override def map[@specialized B](f: A => B): Chunk[B] = {
+      val self = array
+      val len  = self.length
+      var dest = null.asInstanceOf[Array[B]]
+
+      var i = 0
+      while (i < len) {
+        val b = f(self(i))
+
+        if (dest == null) {
+          implicit val B: ClassTag[B] = Chunk.Tags.fromValue(b)
+
+          dest = Array.ofDim[B](len)
+        }
+
+        dest(i) = b
+
+        i = i + 1
+      }
+
+      if (dest != null) Chunk.Arr(dest)
+      else Chunk.Empty
+    }
+
+    override def materialize[A1 >: A]: Chunk[A1] = this
+
+    override def takeWhile(f: A => Boolean): Chunk[A] = {
+      val self = array
+      val len  = self.length
+
+      var i = 0
+      while (i < len && f(self(i))) {
+        i += 1
+      }
+
+      if (i == 0) Chunk.Empty
+      else if (i == len) this
+      else Chunk.Slice(this, 0, i)
+    }
+
+    override def toArray[A1 >: A]: Array[A1] = array.asInstanceOf[Array[A1]]
+
+    override def length: Int = array.length
+
+    override def apply(n: Int): A = array(n)
+
+    override def foreach(f: A => Unit): Unit = array.foreach(f)
+
+    override def toArray[A1 >: A](n: Int, dest: Array[A1]): Unit =
+      Array.copy(array, 0, dest, n, length)
+  }
+
+  private case class Concat[@specialized A](l: Chunk[A], r: Chunk[A]) extends Chunk[A] {
+    self =>
+    implicit lazy val classTag: ClassTag[A] =
+      l match {
+        case Empty => classTagOf(r)
+        case _     => classTagOf(l)
+      }
+
+    override def length: Int = l.length + r.length
+
+    override def apply(n: Int): A = if (n < l.length) l(n) else r(n - l.length)
+
+    override def foreach(f: A => Unit): Unit = {
+      l.foreach(f)
+      r.foreach(f)
+    }
+
+    override def toArray[A1 >: A](n: Int, dest: Array[A1]): Unit = {
+      l.toArray(n, dest)
+      r.toArray(n + l.length, dest)
+    }
+  }
+
+  private case object Empty extends Chunk[Nothing] {
+    override def length: Int = 0
+
+    protected[zio] def apply(n: Int): Nothing = throw new ArrayIndexOutOfBoundsException(s"Empty chunk access to ${n}")
+
+    protected[zio] def foreach(f: Nothing => Unit): Unit = ()
+
+    protected[zio] def toArray[A1 >: Nothing](n: Int, dest: Array[A1]): Unit = ()
+  }
+
+  private case class Singleton[A](a: A) extends Chunk[A] {
+    implicit lazy val classTag: ClassTag[A] = Tags.fromValue(a)
+
+    def length = 1
+
+    override def apply(n: Int): A =
+      if (n == 0) a
+      else throw new ArrayIndexOutOfBoundsException(s"Singleton chunk access to ${n}")
+
+    override def foreach(f: A => Unit): Unit = f(a)
+
+    override def toArray[A1 >: A](n: Int, dest: Array[A1]): Unit =
+      dest(n) = a
+  }
+
+  private case class Slice[@specialized A](private val chunk: Chunk[A], offset: Int, length: Int) extends Chunk[A] {
+    implicit lazy val classTag: ClassTag[A] = classTagOf(chunk)
+
+    override def apply(n: Int): A = chunk.apply(offset + n)
+
+    override def foreach(f: A => Unit): Unit = {
+      var i = 0
+      while (i < length) {
+        f(apply(i))
+        i += 1
+      }
+    }
+
+    override def toArray[A1 >: A](n: Int, dest: Array[A1]): Unit = {
+      var i = 0
+      var j = n
+
+      while (i < length) {
+        dest(j) = apply(i)
+
+        i += 1
+        j += 1
+      }
+    }
+  }
+
+  private case class VectorChunk[@specialized A](private val vector: Vector[A]) extends Chunk[A] {
+    implicit lazy val classTag: ClassTag[A] = Tags.fromValue(vector(0))
+
+    def length = vector.length
+
+    override def apply(n: Int): A = vector(n)
+
+    override def foreach(f: A => Unit): Unit = vector.foreach(f)
+
+    override def toArray[A1 >: A](n: Int, dest: Array[A1]): Unit =
+      vector.copyToArray(dest, n, length)
+  }
+
+  private object Tags {
+    final def fromValue[A](a: A): ClassTag[A] =
+      unbox(ClassTag(a.getClass))
+
+    private final def unbox[A](c: ClassTag[A]): ClassTag[A] =
+      if (isBoolean(c)) BooleanClass.asInstanceOf[ClassTag[A]]
+      else if (isByte(c)) ByteClass.asInstanceOf[ClassTag[A]]
+      else if (isShort(c)) ShortClass.asInstanceOf[ClassTag[A]]
+      else if (isInt(c)) IntClass.asInstanceOf[ClassTag[A]]
+      else if (isLong(c)) LongClass.asInstanceOf[ClassTag[A]]
+      else if (isFloat(c)) FloatClass.asInstanceOf[ClassTag[A]]
+      else if (isDouble(c)) DoubleClass.asInstanceOf[ClassTag[A]]
+      else if (isChar(c)) CharClass.asInstanceOf[ClassTag[A]]
+      else classTag[java.lang.Object].asInstanceOf[ClassTag[A]]
+
+    private final def isBoolean(c: ClassTag[_]): Boolean =
+      c == BooleanClass || c == BooleanClassBox
+    private final def isByte(c: ClassTag[_]): Boolean =
+      c == ByteClass || c == ByteClassBox
+    private final def isShort(c: ClassTag[_]): Boolean =
+      c == ShortClass || c == ShortClassBox
+    private final def isInt(c: ClassTag[_]): Boolean =
+      c == IntClass || c == IntClassBox
+    private final def isLong(c: ClassTag[_]): Boolean =
+      c == LongClass || c == LongClassBox
+    private final def isFloat(c: ClassTag[_]): Boolean =
+      c == FloatClass || c == FloatClassBox
+    private final def isDouble(c: ClassTag[_]): Boolean =
+      c == DoubleClass || c == DoubleClassBox
+    private final def isChar(c: ClassTag[_]): Boolean =
+      c == CharClass || c == CharClassBox
+
+    private val BooleanClass    = classTag[Boolean]
+    private val BooleanClassBox = classTag[java.lang.Boolean]
+    private val ByteClass       = classTag[Byte]
+    private val ByteClassBox    = classTag[java.lang.Byte]
+    private val ShortClass      = classTag[Short]
+    private val ShortClassBox   = classTag[java.lang.Short]
+    private val IntClass        = classTag[Int]
+    private val IntClassBox     = classTag[java.lang.Integer]
+    private val LongClass       = classTag[Long]
+    private val LongClassBox    = classTag[java.lang.Long]
+    private val FloatClass      = classTag[Float]
+    private val FloatClassBox   = classTag[java.lang.Float]
+    private val DoubleClass     = classTag[Double]
+    private val DoubleClassBox  = classTag[java.lang.Double]
+    private val CharClass       = classTag[Char]
+    private val CharClassBox    = classTag[java.lang.Character]
+  }
+}

--- a/core/shared/src/main/scala/scalaz/zio/stream/Chunk.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/Chunk.scala
@@ -45,13 +45,14 @@ sealed trait Chunk[@specialized +A] { self =>
    * Drops the first `n` elements of the chunk.
    */
   final def drop(n: Int): Chunk[A] =
-    if (n <= 0) self else
+    if (n <= 0) self
+    else
       self match {
-        case Chunk.Slice(c, o, l) => Chunk.Slice(c, o + n, l - n)
+        case Chunk.Slice(c, o, l)        => Chunk.Slice(c, o + n, l - n)
         case Chunk.Singleton(_) if n > 0 => Chunk.empty
-        case c @ Chunk.Singleton(_) => c
-        case Chunk.Empty => Chunk.empty
-        case _ => Chunk.Slice(self, n, self.length - n)
+        case c @ Chunk.Singleton(_)      => c
+        case Chunk.Empty                 => Chunk.empty
+        case _                           => Chunk.Slice(self, n, self.length - n)
       }
 
   /**
@@ -329,7 +330,7 @@ sealed trait Chunk[@specialized +A] { self =>
           if (n >= l) this
           else Chunk.Slice(c, o, n)
         case c @ Chunk.Singleton(_) => c
-        case _ => Chunk.Slice(self, 0, n)
+        case _                      => Chunk.Slice(self, 0, n)
       }
 
   /**
@@ -363,8 +364,8 @@ sealed trait Chunk[@specialized +A] { self =>
 
   def toSeq: Seq[A] = {
     val seqBuilder = Seq.newBuilder[A]
-    var i = 0
-    val len = length
+    var i          = 0
+    val len        = length
     seqBuilder.sizeHint(len)
     while (i < len) {
       seqBuilder += apply(i)
@@ -699,13 +700,14 @@ object Chunk {
     override def materialize[A1 >: A]: Chunk[A1] = this
 
     /**
-      * Takes all elements so long as the predicate returns true.
-      */
+     * Takes all elements so long as the predicate returns true.
+     */
     override def takeWhile(f: A => Boolean): Chunk[A] = {
-      val len = length
+      val self = array
+      val len  = length
 
       var i = 0
-      while (i < len && f(apply(i))) {
+      while (i < len && f(self(i))) {
         i += 1
       }
 

--- a/core/shared/src/main/scala/scalaz/zio/stream/Sink.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/Sink.scala
@@ -1,0 +1,834 @@
+package scalaz.zio.stream
+
+import scalaz.zio._
+import scala.language.postfixOps
+
+/**
+ * A `Sink[E, A0, A, B]` consumes values of type `A`, ultimately producing
+ * either an error of type `E`, or a value of type `B` together with a remainder
+ * of type `A0`.
+ *
+ * Sinks form monads and combine in the usual ways.
+ */
+trait Sink[+E, +A0, -A, +B] { self =>
+  import Sink.Step
+
+  type State
+
+  def initial: IO[E, Step[State, Nothing]]
+
+  def step(state: State, a: A): IO[E, Step[State, A0]]
+
+  def extract(state: State): IO[E, B]
+
+  def stepChunk[A1 <: A](state: State, as: Chunk[A1]): IO[E, Step[State, A0]] = {
+    val len = as.length
+
+    def loop(s: Step[State, A0], i: Int): IO[E, Step[State, A0]] =
+      if (i >= len) IO.now(s)
+      else if (Step.cont(s)) self.step(Step.state(s), as(i)).flatMap(loop(_, i + 1))
+      else IO.now(s)
+
+    loop(Step.more(state), 0)
+  }
+
+  final def update(state: Step[State, Nothing]): Sink[E, A0, A, B] =
+    new Sink[E, A0, A, B] {
+      type State = self.State
+      val initial: IO[E, Step[State, Nothing]]             = IO.now(state)
+      def step(state: State, a: A): IO[E, Step[State, A0]] = self.step(state, a)
+      def extract(state: State): IO[E, B]                  = self.extract(state)
+    }
+
+  /**
+   * Takes a `Sink`, and lifts it to be chunked in its input and output. This
+   * will not improve performance, but can be used to adapt non-chunked sinks
+   * wherever chunked sinks are required.
+   */
+  final def chunked[A1 >: A0, A2 <: A]: Sink[E, A1, Chunk[A2], B] =
+    new Sink[E, A1, Chunk[A2], B] {
+      type State = self.State
+      val initial = self.initial
+      def step(state: State, a: Chunk[A2]): IO[E, Step[State, A1]] =
+        self.stepChunk(state, a)
+      def extract(state: State): IO[E, B] = self.extract(state)
+    }
+
+  /**
+   * Effectfully maps the value produced by this sink.
+   */
+  final def mapM[E1 >: E, C](f: B => IO[E1, C]): Sink[E1, A0, A, C] =
+    new Sink[E1, A0, A, C] {
+      type State = self.State
+
+      val initial: IO[E, Step[State, Nothing]] = self.initial
+
+      def step(state: State, a: A): IO[E, Step[State, A0]] = self.step(state, a)
+
+      def extract(state: State): IO[E1, C] = self.extract(state).flatMap(f)
+    }
+
+  /**
+   * Maps the value produced by this sink.
+   */
+  def map[C](f: B => C): Sink[E, A0, A, C] =
+    new Sink[E, A0, A, C] {
+      type State = self.State
+
+      val initial: IO[E, Step[State, Nothing]] = self.initial
+
+      def step(state: State, a: A): IO[E, Step[State, A0]] = self.step(state, a)
+
+      def extract(state: State): IO[E, C] = self.extract(state).map(f)
+    }
+
+  /**
+   * Effectfully filters the inputs fed to this sink.
+   */
+  final def filterM[E1 >: E, A1 <: A](f: A1 => IO[E1, Boolean]): Sink[E1, A0, A1, B] =
+    new Sink[E1, A0, A1, B] {
+      type State = self.State
+
+      val initial = self.initial
+
+      def step(state: State, a: A1) =
+        f(a).flatMap(
+          b =>
+            if (b) self.step(state, a)
+            else IO.now(Step.more(state))
+        )
+
+      def extract(state: State) = self.extract(state)
+    }
+
+  /**
+   * Filters the inputs fed to this sink.
+   */
+  def filter[A1 <: A](f: A1 => Boolean): Sink[E, A0, A1, B] =
+    new Sink[E, A0, A1, B] {
+      type State = self.State
+
+      val initial = self.initial
+
+      def step(state: State, a: A1) =
+        if (f(a)) self.step(state, a)
+        else IO.now(Step.more(state))
+
+      def extract(state: State) = self.extract(state)
+    }
+
+  final def filterNot[A1 <: A](f: A1 => Boolean): Sink[E, A0, A1, B] =
+    filter(a => !f(a))
+
+  final def filterNotM[E1 >: E, A1 <: A](f: A1 => IO[E1, Boolean]): Sink[E1, A0, A1, B] =
+    filterM(a => f(a).map(!_))
+
+  final def contramapM[E1 >: E, C](f: C => IO[E1, A]): Sink[E1, A0, C, B] =
+    new Sink[E1, A0, C, B] {
+      type State = self.State
+
+      val initial = self.initial
+
+      def step(state: State, c: C) = f(c).flatMap(self.step(state, _))
+
+      def extract(state: State): IO[E1, B] = self.extract(state)
+    }
+
+  def contramap[C](f: C => A): Sink[E, A0, C, B] =
+    new Sink[E, A0, C, B] {
+      type State = self.State
+
+      val initial = self.initial
+
+      def step(state: State, c: C) = self.step(state, f(c))
+
+      def extract(state: State): IO[E, B] = self.extract(state)
+    }
+
+  def dimap[C, D](f: C => A)(g: B => D): Sink[E, A0, C, D] =
+    new Sink[E, A0, C, D] {
+      type State = self.State
+
+      val initial = self.initial
+
+      def step(state: State, c: C): IO[E, Step[State, A0]] = self.step(state, f(c))
+
+      def extract(state: State): IO[E, D] = self.extract(state).map(g)
+    }
+
+  def mapError[E1](f: E => E1): Sink[E1, A0, A, B] =
+    new Sink[E1, A0, A, B] {
+      type State = self.State
+
+      val initial = self.initial.leftMap(f)
+
+      def step(state: State, a: A): IO[E1, Step[State, A0]] =
+        self.step(state, a).leftMap(f)
+
+      def extract(state: State): IO[E1, B] =
+        self.extract(state).leftMap(f)
+    }
+
+  def mapRemainder[A1](f: A0 => A1): Sink[E, A1, A, B] =
+    new Sink[E, A1, A, B] {
+      type State = self.State
+
+      val initial = self.initial
+
+      def step(state: State, a: A): IO[E, Step[State, A1]] =
+        self.step(state, a).map(Step.map(_)(f))
+
+      def extract(state: State): IO[E, B] = self.extract(state)
+    }
+
+  final def const[C](c: => C): Sink[E, A0, A, C] = self.map(_ => c)
+
+  final def void: Sink[E, A0, A, Unit] = const(())
+
+  final def untilOutput(f: B => Boolean): Sink[E, A0, A, B] =
+    new Sink[E, A0, A, B] {
+      type State = self.State
+
+      val initial = self.initial
+
+      def step(state: State, a: A): IO[E, Step[State, A0]] =
+        self.step(state, a).flatMap { s =>
+          if (Step.cont(s))
+            extract(Step.state(s))
+              .redeem(
+                _ => IO.now(s),
+                b => if (f(b)) IO.now(Step.done(Step.state(s), Chunk.empty)) else IO.now(s)
+              )
+          else IO.now(s)
+        }
+
+      def extract(state: State): IO[E, B] = self.extract(state)
+    }
+
+  /**
+   * Returns a new sink that tries to produce the `B`, but if there is an
+   * error in stepping or extraction, produces `None`.
+   */
+  final def ? : Sink[Nothing, A0, A, Option[B]] =
+    new Sink[Nothing, A0, A, Option[B]] {
+      type State = Option[self.State]
+
+      val initial = self.initial.map(Step.leftMap(_)(Some(_))) orElse
+        IO.now(Step.done(None, Chunk.empty))
+
+      def step(state: State, a: A): IO[Nothing, Step[State, A0]] =
+        state match {
+          case None => IO.now(Step.done(state, Chunk.empty))
+          case Some(state) =>
+            self
+              .step(state, a)
+              .redeem(
+                _ => IO.now(Step.done[State, A0](Some(state), Chunk.empty)),
+                s => IO.now(Step.leftMap(s)(Some(_)))
+              )
+        }
+
+      def extract(state: State): IO[Nothing, Option[B]] =
+        state match {
+          case None        => IO.now(None)
+          case Some(state) => self.extract(state).map(Some(_)) orElse IO.now(None)
+        }
+    }
+
+  /**
+   * A named alias for `?`.
+   */
+  final def optional: Sink[Nothing, A0, A, Option[B]] = self ?
+
+  /**
+   * Runs both sinks in parallel on the input, returning the result from the
+   * one that finishes successfully first.
+   */
+  final def race[E1 >: E, A2 >: A0, A1 <: A, B1 >: B](that: Sink[E1, A2, A1, B1]): Sink[E1, A2, A1, B1] =
+    self.raceBoth(that).map(_.merge)
+
+  /**
+   * A named alias for `race`.
+   */
+  final def |[E1 >: E, A2 >: A0, A1 <: A, B1 >: B](that: Sink[E1, A2, A1, B1]): Sink[E1, A2, A1, B1] =
+    self.race(that)
+
+  /**
+   * Runs both sinks in parallel on the input, returning the result from the
+   * one that finishes successfully first.
+   */
+  final def raceBoth[E1 >: E, A2 >: A0, A1 <: A, C](that: Sink[E1, A2, A1, C]): Sink[E1, A2, A1, Either[B, C]] =
+    new Sink[E1, A2, A1, Either[B, C]] {
+      type State = (Either[E1, self.State], Either[E1, that.State])
+
+      def sequence[E, S, A0](e: Either[E, Step[S, A0]]): Step[Either[E, S], A0] =
+        e match {
+          case Left(e)                   => Step.done(Left(e), Chunk.empty)
+          case Right(s) if Step.cont(s)  => Step.more(Right(Step.state(s)))
+          case Right(s) if !Step.cont(s) => Step.done(Right(Step.state(s)), Step.leftover(s))
+        }
+
+      val initial = self.initial.attempt.map(sequence).parWith(that.initial.attempt.map(sequence))(Step.both)
+
+      def step(state: State, a: A1): IO[E1, Step[State, A2]] =
+        state match {
+          case (l, r) =>
+            val lr = l.fold(e => IO.now(Left(e)), self.step(_, a).attempt)
+            val rr = r.fold(e => IO.now(Left(e)), that.step(_, a).attempt)
+
+            lr.parWith(rr) {
+              case (Right(s), _) if !Step.cont(s) => Step.done((Right(Step.state(s)), r), Step.leftover(s))
+              case (_, Right(s)) if !Step.cont(s) => Step.done((l, Right(Step.state(s))), Step.leftover(s))
+              case (lr, rr)                       => Step.more((lr.right.map(Step.state), rr.right.map(Step.state)))
+            }
+        }
+
+      def extract(state: State): IO[E1, Either[B, C]] =
+        state match {
+          case (Right(s), _) => self.extract(s).map(Left(_))
+          case (_, Right(s)) => that.extract(s).map(Right(_))
+          case (Left(e), _)  => IO.fail(e)
+          case (_, Left(e))  => IO.fail(e)
+        }
+    }
+
+  final def takeWhile[A1 <: A](pred: A1 => Boolean): Sink[E, A0, A1, B] =
+    new Sink[E, A0, A1, B] {
+      type State = self.State
+
+      val initial = self.initial
+
+      def step(state: State, a: A1): IO[E, Step[State, A0]] =
+        if (pred(a)) self.step(state, a)
+        else IO.now(Step.done(state, Chunk.empty))
+
+      def extract(state: State) = self.extract(state)
+    }
+
+  final def dropWhile[A1 <: A](pred: A1 => Boolean): Sink[E, A0, A1, B] =
+    new Sink[E, A0, A1, B] {
+      type State = (self.State, Boolean)
+
+      val initial = self.initial.map(step => Step.leftMap(step)((_, true)))
+
+      def step(state: State, a: A1): IO[E, Step[State, A0]] =
+        if (!state._2) self.step(state._1, a).map(Step.leftMap(_)((_, false)))
+        else {
+          if (pred(a)) IO.now(Sink.Step.more((state)))
+          else self.step(state._1, a).map(Step.leftMap(_)((_, false)))
+        }
+
+      def extract(state: State) = self.extract(state._1)
+    }
+}
+
+object Sink {
+  private[Sink] object internal {
+    sealed trait Side[+E, +S, +A]
+    object Side {
+      final case class Error[E](value: E) extends Side[E, Nothing, Nothing]
+      final case class State[S](value: S) extends Side[Nothing, S, Nothing]
+      final case class Value[A](value: A) extends Side[Nothing, Nothing, A]
+    }
+  }
+
+  trait StepModule {
+    type Step[+S, +A0]
+
+    def state[S, A0](s: Step[S, A0]): S
+    def leftover[S, A0](s: Step[S, A0]): Chunk[A0]
+    def cont[S, A0](s: Step[S, A0]): Boolean
+
+    def more[S](s: S): Step[S, Nothing]
+    def done[@specialized S, A0](s: S, a0: Chunk[A0]): Step[S, A0]
+
+    def map[S, A0, B](s: Step[S, A0])(f: A0 => B): Step[S, B]
+    def leftMap[S, A0, B](s: Step[S, A0])(f: S => B): Step[B, A0]
+    def bimap[S, S1, A, B](s: Step[S, A])(f: S => S1, g: A => B): Step[S1, B]
+    def both[S1, S2](s1: Step[S1, Nothing], s2: Step[S2, Nothing]): Step[(S1, S2), Nothing]
+    def either[S1, A0](s1: Step[S1, A0], s2: Step[S1, A0]): Step[S1, A0]
+  }
+
+  private class Done[@specialized S, A0](val s: S, val leftover: Chunk[A0])
+
+  val Step: StepModule = new StepModule {
+    type Step[+S, +A0] = AnyRef
+
+    final def state[S, A0](s: Step[S, A0]): S =
+      s match {
+        case x: Done[_, _] => x.s.asInstanceOf[S]
+        case x             => x.asInstanceOf[S]
+      }
+    final def leftover[S, A0](s: Step[S, A0]): Chunk[A0] =
+      s match {
+        case x: Done[_, _] => x.leftover.asInstanceOf[Chunk[A0]]
+        case _             => Chunk.empty
+      }
+    final def cont[S, A0](s: Step[S, A0]): Boolean =
+      !s.isInstanceOf[Done[_, _]]
+
+    final def more[S](s: S): Step[S, Nothing] = s.asInstanceOf[Step[S, Nothing]]
+    final def done[@specialized S, A0](s: S, a0: Chunk[A0]): Step[S, A0] =
+      new Done(s, a0)
+
+    final def map[S, A, B](s: Step[S, A])(f: A => B): Step[S, B] =
+      s match {
+        case x: Done[_, _] => new Done(x.s.asInstanceOf[S], x.leftover.asInstanceOf[Chunk[A]].map(f))
+        case x             => x.asInstanceOf[Step[S, B]]
+      }
+
+    final def leftMap[S, A0, B](s: Step[S, A0])(f: S => B): Step[B, A0] =
+      s match {
+        case x: Done[_, _] => new Done(f(x.s.asInstanceOf[S]), x.leftover)
+        case x             => f(x.asInstanceOf[S]).asInstanceOf[Step[B, A0]]
+      }
+
+    final def bimap[S, S1, A, B](s: Step[S, A])(f: S => S1, g: A => B): Step[S1, B] =
+      s match {
+        case x: Done[_, _] => new Done(f(x.s.asInstanceOf[S]), x.leftover.asInstanceOf[Chunk[A]].map(g))
+        case x             => f(x.asInstanceOf[S]).asInstanceOf[Step[S1, B]]
+      }
+
+    final def both[S1, S2](s1: Step[S1, Nothing], s2: Step[S2, Nothing]): Step[(S1, S2), Nothing] =
+      (s1, s2) match {
+        case (x: Done[_, _], y: Done[_, _]) => done((state(x), state(y)), Chunk.empty)
+        case (x, y: Done[_, _])             => done((state(x), state(y)), Chunk.empty)
+        case (x: Done[_, _], y)             => done((state(x), state(y)), Chunk.empty)
+        case (x, y)                         => more((state(x), state(y)))
+      }
+
+    final def either[S1, A0](s1: Step[S1, A0], s2: Step[S1, A0]): Step[S1, A0] =
+      (s1, s2) match {
+        case (x: Done[_, _], _: Done[_, _]) => done(state(x), Chunk.empty)
+        case (x, _: Done[_, _])             => more(state(x))
+        case (_: Done[_, _], y)             => more(state(y))
+        case (x, _)                         => more(state(x))
+      }
+  }
+
+  type Step[+S, +A0] = Step.Step[S, A0]
+
+  final def more[E, A0, A, B](end: IO[E, B])(input: A => Sink[E, A0, A, B]): Sink[E, A0, A, B] =
+    new Sink[E, A0, A, B] {
+      type State = Option[(Sink[E, A0, A, B], Any)]
+
+      val initial = IO.now(Step.more(None))
+
+      def step(state: State, a: A): IO[E, Step[State, A0]] = state match {
+        case None =>
+          val sink = input(a)
+
+          sink.initial.map(state => Step.more(Some((sink, state))))
+
+        case Some((sink, state)) =>
+          sink.step(state.asInstanceOf[sink.State], a).map(Step.leftMap(_)(state => Some(sink -> state)))
+      }
+
+      def extract(state: State): IO[E, B] = state match {
+        case None                => end
+        case Some((sink, state)) => sink.extract(state.asInstanceOf[sink.State])
+      }
+    }
+
+  final def point[B](b: => B): Sink[Nothing, Nothing, Any, B] =
+    new SinkPure[Nothing, Nothing, Any, B] {
+      type State = Unit
+      val initialPure                                          = Step.done((), Chunk.empty)
+      def stepPure(state: State, a: Any): Step[State, Nothing] = Step.done(state, Chunk.empty)
+      def extractPure(state: State): Either[Nothing, B]        = Right(b)
+    }
+
+  final def drain: Sink[Nothing, Nothing, Any, Unit] =
+    fold(())((s, _) => Step.more(s))
+
+  final def collect[A]: Sink[Nothing, Nothing, A, List[A]] =
+    fold[Nothing, A, List[A]](List.empty[A])((as, a) => Step.more(a :: as)).map(_.reverse)
+
+  final def liftIO[E, B](b: => IO[E, B]): Sink[E, Nothing, Any, B] =
+    new Sink[E, Nothing, Any, B] {
+      type State = Unit
+      val initial                                                 = IO.now(Step.done((), Chunk.empty))
+      def step(state: State, a: Any): IO[E, Step[State, Nothing]] = IO.now(Step.done(state, Chunk.empty))
+      def extract(state: State): IO[E, B]                         = b
+    }
+
+  final def lift[A, B](f: A => B): Sink[Unit, Nothing, A, B] =
+    new SinkPure[Unit, Nothing, A, B] {
+      type State = Option[A]
+      val initialPure                                        = Step.more(None)
+      def stepPure(state: State, a: A): Step[State, Nothing] = Step.done(Some(a), Chunk.empty)
+      def extractPure(state: State): Either[Unit, B]         = state.fold[Either[Unit, B]](Left(()))(a => Right(f(a)))
+    }
+
+  final def identity[A]: Sink[Unit, A, A, A] =
+    new SinkPure[Unit, A, A, A] {
+      type State = Option[A]
+      val initialPure                                  = Step.more(None)
+      def stepPure(state: State, a: A): Step[State, A] = Step.done(Some(a), Chunk.empty)
+      def extractPure(state: State): Either[Unit, A]   = state.fold[Either[Unit, A]](Left(()))(a => Right(a))
+    }
+
+  final def fail[E](e: E): Sink[E, Nothing, Any, Nothing] =
+    new SinkPure[E, Nothing, Any, Nothing] {
+      type State = Unit
+      val initialPure                                          = Step.done((), Chunk.empty)
+      def stepPure(state: State, a: Any): Step[State, Nothing] = Step.done(state, Chunk.empty)
+      def extractPure(state: State): Either[E, Nothing]        = Left(e)
+    }
+
+  def fold[A0, A, S](z: S)(f: (S, A) => Step[S, A0]): Sink[Nothing, A0, A, S] =
+    new SinkPure[Nothing, A0, A, S] {
+      type State = S
+      val initialPure                           = Step.more(z)
+      def stepPure(s: S, a: A): Step[S, A0]     = f(s, a)
+      def extractPure(s: S): Either[Nothing, S] = Right(s)
+    }
+
+  def foldLeft[A0, A, S](z: S)(f: (S, A) => S): Sink[Nothing, A0, A, S] =
+    new SinkPure[Nothing, A0, A, S] {
+      type State = S
+      val initialPure                           = Step.more(z)
+      def stepPure(s: S, a: A): Step[S, A0]     = Step.more(f(s, a))
+      def extractPure(s: S): Either[Nothing, S] = Right(s)
+    }
+
+  def foldM[E, A0, A, S](z: IO[E, S])(f: (S, A) => IO[E, Step[S, A0]]): Sink[E, A0, A, S] =
+    new Sink[E, A0, A, S] {
+      type State = S
+      val initial                              = z.map(Step.more)
+      def step(s: S, a: A): IO[E, Step[S, A0]] = f(s, a)
+      def extract(s: S): IO[E, S]              = IO.now(s)
+    }
+
+  def readWhileM[E, A](p: A => IO[E, Boolean]): Sink[E, A, A, List[A]] =
+    Sink
+      .foldM(IO.now(List.empty[A])) { (s, a: A) =>
+        p(a).map(if (_) Step.more(a :: s) else Step.done(s, Chunk(a)))
+      }
+      .map(_.reverse)
+
+  def readWhile[A](p: A => Boolean): Sink[Nothing, A, A, List[A]] =
+    readWhileM(a => IO.now(p(a)))
+
+  def ignoreWhileM[E, A](p: A => IO[E, Boolean]): Sink[E, A, A, Unit] =
+    new Sink[E, A, A, Unit] {
+      type State = Unit
+
+      val initial = IO.now(Step.more(()))
+
+      def step(state: State, a: A): IO[E, Step[State, A]] =
+        p(a).map(if (_) Step.more(()) else Step.done((), Chunk(a)))
+
+      def extract(state: State) = IO.now(())
+    }
+
+  def ignoreWhile[A](p: A => Boolean): Sink[Nothing, A, A, Unit] =
+    ignoreWhileM(a => IO.now(p(a)))
+
+  def await[A]: Sink[Unit, Nothing, A, A] =
+    new SinkPure[Unit, Nothing, A, A] {
+      type State = Either[Unit, A]
+
+      val initialPure = Step.more(Left(()))
+
+      def stepPure(state: State, a: A) =
+        Step.done(Right(a), Chunk.empty)
+
+      def extractPure(state: State): Either[Unit, A] =
+        state
+    }
+
+  def read1[E, A](e: Option[A] => E)(p: A => Boolean): Sink[E, A, A, A] =
+    new SinkPure[E, A, A, A] {
+      type State = Either[E, Option[A]]
+
+      val initialPure = Step.more(Right(None))
+
+      def stepPure(state: State, a: A) =
+        state match {
+          case Right(Some(_)) => Step.done(state, Chunk(a))
+          case Right(None) =>
+            if (p(a)) Step.done(Right(Some(a)), Chunk.empty)
+            else Step.done(Left(e(Some(a))), Chunk(a))
+          case s => Step.done(s, Chunk(a))
+        }
+
+      def extractPure(state: State) =
+        state match {
+          case Right(Some(a)) => Right(a)
+          case Right(None)    => Left(e(None))
+          case Left(e)        => Left(e)
+        }
+    }
+
+  implicit class InvariantOps[E, A0, A, B](self: Sink[E, A, A, B]) {
+    final def <|[E1, B1 >: B](
+      that: Sink[E1, A, A, B1]
+    ): Sink[E1, A, A, B1] =
+      (self orElse that).map(_.merge)
+
+    /**
+     * Runs both sinks in parallel on the same input. If the left one succeeds,
+     * its value will be produced. Otherwise, whatever the right one produces
+     * will be produced. If the right one succeeds before the left one, it
+     * accumulates the full input until the left one fails, so it can return
+     * it as the remainder. This allows this combinator to function like `choice`
+     * in parser combinator libraries.
+     *
+     * Left:  ============== FAIL!
+     * Right: ===== SUCCEEDS!
+     *             xxxxxxxxx <- Should NOT be consumed
+     */
+    final def orElse[E1, C](
+      that: Sink[E1, A, A, C]
+    ): Sink[E1, A, A, Either[B, C]] =
+      new Sink[E1, A, A, Either[B, C]] {
+        import Sink.internal._
+
+        def sequence[E, S, A0](e: Either[E, Step[S, A0]]): Step[Either[E, S], A0] =
+          e match {
+            case Left(e)                   => Step.done(Left(e), Chunk.empty)
+            case Right(s) if Step.cont(s)  => Step.more(Right(Step.state(s)))
+            case Right(s) if !Step.cont(s) => Step.done(Right(Step.state(s)), Step.leftover(s))
+          }
+
+        def eitherToSide[E, A, B](e: Either[E, A]): Side[E, A, B] =
+          e match {
+            case Left(e)  => Side.Error(e)
+            case Right(s) => Side.State(s)
+          }
+
+        type State = (Side[E, self.State, B], Side[E1, that.State, (Chunk[A], C)])
+
+        val l: IO[Nothing, Step[Either[E, self.State], Nothing]]  = self.initial.attempt.map(sequence)
+        val r: IO[Nothing, Step[Either[E1, that.State], Nothing]] = that.initial.attempt.map(sequence)
+
+        val initial: IO[E1, Step[State, Nothing]] =
+          l.parWith(r) { (l, r) =>
+            Step.both(Step.leftMap(l)(eitherToSide), Step.leftMap(r)(eitherToSide))
+          }
+
+        def step(state: State, a: A): IO[E1, Step[State, A]] = {
+          val leftStep: IO[Nothing, Step[Side[E, self.State, B], A]] =
+            state._1 match {
+              case Side.State(s) =>
+                self
+                  .step(s, a)
+                  .redeem(
+                    e => IO.now(Step.done(Side.Error(e), Chunk.empty)),
+                    s =>
+                      if (Step.cont(s)) IO.now(Step.more(Side.State(Step.state(s))))
+                      else
+                        self
+                          .extract(Step.state(s))
+                          .redeemPure(
+                            e => Step.done(Side.Error(e), Step.leftover(s)),
+                            b => Step.done(Side.Value(b), Step.leftover(s))
+                          )
+                  )
+              case s => IO.now(Step.done(s, Chunk.empty))
+            }
+          val rightStep: IO[Nothing, Step[Side[E1, that.State, (Chunk[A], C)], A]] =
+            state._2 match {
+              case Side.State(s) =>
+                that
+                  .step(s, a)
+                  .redeem(
+                    e => IO.now(Step.done(Side.Error(e), Chunk.empty)),
+                    s =>
+                      if (Step.cont(s)) IO.now(Step.more(Side.State(Step.state(s))))
+                      else {
+                        that
+                          .extract(Step.state(s))
+                          .redeemPure(
+                            e => Step.done(Side.Error(e), Step.leftover(s)),
+                            c => Step.done(Side.Value((Step.leftover(s), c)), Step.leftover(s))
+                          )
+                      }
+                  )
+              case Side.Value((a0, c)) =>
+                val a3 = a0 ++ Chunk(a)
+
+                IO.now(Step.done(Side.Value((a3, c)), a3))
+
+              case s => IO.now(Step.done(s, Chunk.empty))
+            }
+
+          leftStep.seq(rightStep).flatMap {
+            case (s1, s2) =>
+              if (Step.cont(s1) && Step.cont(s2))
+                IO.now(Step.more((Step.state(s1), Step.state(s2))))
+              else if (!Step.cont(s1) && !Step.cont(s2)) {
+                // Step.Done(s1, a1), Step.Done(s2, a2)
+                Step.state(s1) match {
+                  case Side.Error(_) => IO.now(Step.done((Step.state(s1), Step.state(s2)), Step.leftover(s2)))
+                  case Side.Value(_) => IO.now(Step.done((Step.state(s1), Step.state(s2)), Step.leftover(s1)))
+                  case Side.State(s) =>
+                    self
+                      .extract(s)
+                      .redeemPure(
+                        e => Step.done((Side.Error(e), Step.state(s2)), Step.leftover(s2)),
+                        b => Step.done((Side.Value(b), Step.state(s2)), Step.leftover(s1))
+                      )
+                }
+              } else if (Step.cont(s1) && !Step.cont(s2)) IO.now(Step.more((Step.state(s1), Step.state(s2))))
+              else {
+                // Step.Done(s1, a1), Step.More(s2)
+                Step.state(s1) match {
+                  case Side.Error(_) => IO.now(Step.more((Step.state(s1), Step.state(s2))))
+                  case Side.Value(_) => IO.now(Step.done((Step.state(s1), Step.state(s2)), Step.leftover(s1)))
+                  case Side.State(s) =>
+                    self.extract(s).redeemPure(Side.Error(_), Side.Value(_)).map(s1 => Step.more((s1, Step.state(s2))))
+                }
+
+              }
+          }
+        }
+
+        def extract(state: State): IO[E1, Either[B, C]] = {
+          def fromRight: IO[E1, Either[B, C]] = state._2 match {
+            case Side.Value((_, c)) => IO.now(Right(c))
+            case Side.State(s)      => that.extract(s).map(Right(_))
+            case Side.Error(e)      => IO.fail(e)
+          }
+
+          state match {
+            case (Side.Value(b), _) => IO.now(Left(b))
+            case (Side.State(s), _) => self.extract(s).redeem(_ => fromRight, b => IO.now(Left(b)))
+            case _                  => fromRight
+          }
+        }
+      }
+
+    final def flatMap[E1 >: E, C](
+      f: B => Sink[E1, A, A, C]
+    ): Sink[E1, A, A, C] =
+      new Sink[E1, A, A, C] {
+        type State = Either[self.State, (Sink[E1, A, A, C], Any)]
+
+        val initial: IO[E1, Step[State, Nothing]] = self.initial.map(Step.leftMap(_)(Left(_)))
+
+        def step(state: State, a: A): IO[E1, Step[State, A]] = state match {
+          case Left(s1) =>
+            self.step(s1, a) flatMap { s1 =>
+              if (Step.cont(s1)) IO.now(Step.more(Left(Step.state(s1))))
+              else {
+                val as = Step.leftover(s1)
+
+                self.extract(Step.state(s1)).flatMap { b =>
+                  val that = f(b)
+
+                  that.initial.flatMap(
+                    s2 =>
+                      that
+                        .stepChunk(Step.state(s2).asInstanceOf[that.State], as)
+                        .map(Step.leftMap(_)(s2 => Right((that, s2))))
+                  )
+                }
+              }
+            }
+
+          case Right((that, s2)) =>
+            that.step(s2.asInstanceOf[that.State], a).map(Step.leftMap(_)(s2 => Right((that, s2))))
+        }
+
+        def extract(state: State): IO[E1, C] =
+          state match {
+            case Left(s1) =>
+              self.extract(s1).flatMap { b =>
+                val that = f(b)
+
+                that.initial.flatMap(s2 => that.extract(Step.state(s2)))
+              }
+
+            case Right((that, s2)) => that.extract(s2.asInstanceOf[that.State])
+          }
+      }
+
+    final def seq[E1 >: E, C](that: Sink[E1, A, A, C]): Sink[E1, A, A, (B, C)] =
+      flatMap(b => that.map(c => (b, c)))
+
+    final def seqWith[E1 >: E, C, D](that: Sink[E1, A, A, C])(f: (B, C) => D): Sink[E1, A, A, D] =
+      seq(that).map(f.tupled)
+
+    final def ~[E1 >: E, C](that: Sink[E1, A, A, C]): Sink[E1, A, A, (B, C)] =
+      seq(that)
+
+    final def *>[E1 >: E, C](that: Sink[E1, A, A, C]): Sink[E1, A, A, C] =
+      seq(that).map(_._2)
+
+    final def <*[E1 >: E, C](that: Sink[E1, A, A, C]): Sink[E1, A, A, B] =
+      seq(that).map(_._1)
+
+    final def repeat0[S](z: S)(f: (S, B) => S): Sink[E, A, A, S] =
+      new Sink[E, A, A, S] {
+        type State = (Option[E], S, self.State)
+
+        val initial = self.initial.map(step => Step.leftMap(step)((None, z, _)))
+
+        def step(state: State, a: A): IO[E, Step[State, A]] =
+          self
+            .step(state._3, a)
+            .redeem(
+              e => IO.now(Step.done((Some(e), state._2, state._3), Chunk.empty)),
+              step =>
+                if (Step.cont(step)) IO.now(Step.more((state._1, state._2, Step.state(step))))
+                else {
+                  val s  = Step.state(step)
+                  val as = Step.leftover(step)
+
+                  self.extract(s).flatMap { b =>
+                    self.initial.flatMap { init =>
+                      self
+                        .stepChunk(Step.state(init), as)
+                        .redeemPure(
+                          e => Step.done((Some(e), f(state._2, b), Step.state(init)), Chunk.empty),
+                          s => Step.leftMap(s)((state._1, f(state._2, b), _))
+                        )
+                    }
+                  }
+                }
+            )
+
+        def extract(state: State): IO[E, S] =
+          IO.now(state._2)
+      }
+
+    final def repeat: Sink[E, A, A, List[B]] =
+      repeat0(List.empty[B])((bs, b) => b :: bs).map(_.reverse)
+
+    final def repeatN(i: Int): Sink[E, A, A, List[B]] =
+      repeat0[(Int, List[B])]((0, Nil))((s, b) => (s._1 + 1, b :: s._2)).untilOutput(_._1 >= i).map(_._2.reverse)
+
+    final def repeatWhile0[S](p: A => Boolean)(z: S)(f: (S, B) => S): Sink[E, A, A, S] =
+      new Sink[E, A, A, S] {
+        type State = (S, self.State)
+
+        val initial = self.initial.map(Step.leftMap(_)((z, _)))
+
+        def step(state: State, a: A): IO[E, Step[State, A]] =
+          if (!p(a)) self.extract(state._2).map(b => Step.done((f(state._1, b), state._2), Chunk(a)))
+          else
+            self.step(state._2, a).flatMap { step =>
+              if (Step.cont(step)) IO.now(Step.more((state._1, Step.state(step))))
+              else {
+                val s  = Step.state(step)
+                val as = Step.leftover(step)
+
+                self.extract(s).flatMap { b =>
+                  self.initial.flatMap { init =>
+                    self.stepChunk(Step.state(init), as).map(Step.leftMap(_)((f(state._1, b), _)))
+                  }
+                }
+              }
+            }
+
+        def extract(state: State): IO[E, S] =
+          IO.now(state._1)
+      }
+
+    final def repeatWhile(p: A => Boolean): Sink[E, A, A, List[B]] =
+      repeatWhile0(p)(List.empty[B])((bs, b) => b :: bs)
+        .map(_.reverse)
+  }
+}

--- a/core/shared/src/main/scala/scalaz/zio/stream/Stream.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/Stream.scala
@@ -1,0 +1,743 @@
+package scalaz.zio.stream
+
+import scalaz.zio._
+
+/**
+ * A `Stream[E, A]` represents an effectful stream that can produce values of
+ * type `A`, or potentially fail with a value of type `E`.
+ *
+ * Streams have a very similar API to Scala collections, making them immediately
+ * familiar to most developers. Unlike Scala collections, streams can be used
+ * on effectful streams of data, such as HTTP connections, files, and so forth.
+ *
+ * Streams do not leak resources. This guarantee holds in the presence of early
+ * termination (not all of a stream is consumed), failure, or even interruption.
+ *
+ * Thanks to only first-order types, appropriate variance annotations, and
+ * specialized effect type (ZIO), streams feature extremely good type inference
+ * and should almost never require specification of any type parameters.
+ *
+ */
+trait Stream[+E, +A] { self =>
+  import Stream._
+
+  /**
+   * Executes an effectful fold over the stream of values.
+   */
+  def fold[E1 >: E, A1 >: A, S](s: S)(f: (S, A1) => IO[E1, Step[S]]): IO[E1, Step[S]] =
+    foldLazy[E1, A1, Step[S]](Step.cont(s)) {
+      case Step.Cont(_) => true
+      case _            => false
+    }((s, a) => f(s.extract, a))
+
+  def foldLazy[E1 >: E, A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => IO[E1, S]): IO[E1, S] =
+    fold[E1, A1, S](s) { (s, a) =>
+      if (cont(s)) f(s, a).map(Step.cont)
+      else IO.now(Step.stop(s))
+    }.map(_.extract)
+
+  def foldLeft[A1 >: A, S](s: S)(f: (S, A1) => S): IO[E, S] =
+    foldLazy(s)(_ => true)((s, a) => IO.now(f(s, a)))
+
+  /**
+   * Concatenates the specified stream to this stream.
+   */
+  final def ++[E1 >: E, A1 >: A](that: => Stream[E1, A1]): Stream[E1, A1] =
+    new Stream[E1, A1] {
+      override def foldLazy[E2 >: E1, A2 >: A1, S](s: S)(cont: S => Boolean)(f: (S, A2) => IO[E2, S]): IO[E2, S] =
+        self.foldLazy[E2, A, S](s)(cont)(f).flatMap { s =>
+          if (cont(s)) that.foldLazy[E2, A1, S](s)(cont)(f)
+          else IO.now(s)
+        }
+    }
+
+  /**
+   * Filters this stream by the specified predicate, retaining all elements for
+   * which the predicate evaluates to true.
+   */
+  def filter(pred: A => Boolean): Stream[E, A] = new Stream[E, A] {
+    override def foldLazy[E1 >: E, A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => IO[E1, S]): IO[E1, S] =
+      self.foldLazy[E1, A, S](s)(cont) { (s, a) =>
+        if (pred(a)) f(s, a)
+        else IO.now(s)
+      }
+  }
+
+  /**
+   * Filters this stream by the specified predicate, removing all elements for
+   * which the predicate evaluates to true.
+   */
+  final def filterNot(pred: A => Boolean): Stream[E, A] = filter(a => !pred(a))
+
+  /**
+   * Consumes elements of the stream, passing them to the specified callback,
+   * and terminating consumption when the callback returns `false`.
+   */
+  final def foreach0[E1 >: E](f: A => IO[E1, Boolean]): IO[E1, Unit] =
+    self
+      .foldLazy[E1, A, Boolean](true)(identity)(
+        (cont, a) =>
+          if (cont) f(a)
+          else IO.now(cont)
+      )
+      .void
+
+  /**
+   * Performs a filter and map in a single step.
+   */
+  def collect[B](pf: PartialFunction[A, B]): Stream[E, B] =
+    new Stream[E, B] {
+      override def foldLazy[E1 >: E, B1 >: B, S](s: S)(cont: S => Boolean)(f: (S, B1) => IO[E1, S]): IO[E1, S] =
+        self.foldLazy[E1, A, S](s)(cont) { (s, a) =>
+          if (pf isDefinedAt a) f(s, pf(a))
+          else IO.now(s)
+        }
+    }
+
+  /**
+   * Drops the specified number of elements from this stream.
+   */
+  final def drop(n: Int): Stream[E, A] =
+    self.zipWithIndex.filter(_._2 > n - 1).map(_._1)
+
+  /**
+   * Drops all elements of the stream for as long as the specified predicate
+   * evaluates to `true`.
+   */
+  def dropWhile(pred: A => Boolean): Stream[E, A] = new Stream[E, A] {
+    override def foldLazy[E1 >: E, A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => IO[E1, S]): IO[E1, S] =
+      self
+        .foldLazy[E1, A, (Boolean, S)](true -> s)(tp => cont(tp._2)) {
+          case ((true, s), a) if pred(a) => IO.now(true       -> s)
+          case ((_, s), a)               => f(s, a).map(false -> _)
+        }
+        .map(_._2)
+  }
+
+  /**
+   * Maps each element of this stream to another stream, and returns the
+   * concatenation of those streams.
+   */
+  final def flatMap[E1 >: E, B](f0: A => Stream[E1, B]): Stream[E1, B] = new Stream[E1, B] {
+    override def foldLazy[E2 >: E1, B1 >: B, S](s: S)(cont: S => Boolean)(f: (S, B1) => IO[E2, S]): IO[E2, S] =
+      self.foldLazy[E2, A, S](s)(cont)((s, a) => f0(a).foldLazy[E2, B1, S](s)(cont)(f))
+  }
+
+  /**
+   * Consumes all elements of the stream, passing them to the specified callback.
+   */
+  final def foreach[E1 >: E](f: A => IO[E1, Unit]): IO[E1, Unit] =
+    foreach0(f.andThen(_.const(true)))
+
+  /**
+   * Repeats this stream forever.
+   */
+  def forever: Stream[E, A] =
+    new Stream[E, A] {
+      override def foldLazy[E1 >: E, A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => IO[E1, S]): IO[E1, S] = {
+        def loop(s: S): IO[E1, S] =
+          self.foldLazy[E1, A, S](s)(cont)(f) flatMap { s =>
+            if (cont(s)) loop(s)
+            else IO.now(s)
+          }
+
+        loop(s)
+      }
+    }
+
+  /**
+   * Joins two streams together with a specified join function.
+   */
+  final def joinWith[E1 >: E, B, C](that: Stream[E1, B], lc: Int = 1, rc: Int = 1)(
+    f0: (IO[E1, Option[A]], IO[E1, Option[B]]) => IO[E1, Option[C]]
+  ): Stream[E1, C] =
+    new Stream[E1, C] {
+      override def foldLazy[E2 >: E1, A1 >: C, S](s: S)(cont: S => Boolean)(f: (S, A1) => IO[E2, S]): IO[E2, S] = {
+        def loop(q1: Queue[Take[E1, A]], q2: Queue[Take[E1, B]], s: S): IO[E2, S] =
+          f0(Take.option(q1.take), Take.option(q2.take)) flatMap {
+            case None => IO.now(s)
+            case Some(c) =>
+              f(s, c) flatMap { s =>
+                if (cont(s)) loop(q1, q2, s)
+                else IO.now(s)
+              }
+          }
+
+        self.toQueue[E1, A](lc).use { q1 =>
+          that.toQueue[E1, B](rc).use { q2 =>
+            loop(q1, q2, s)
+          }
+        }
+      }
+    }
+
+  /**
+   * Maps over elements of the stream with the specified function.
+   */
+  def map[B](f0: A => B): Stream[E, B] = new Stream[E, B] {
+    override def foldLazy[E1 >: E, B1 >: B, S](s: S)(cont: S => Boolean)(f: (S, B1) => IO[E1, S]): IO[E1, S] =
+      self.foldLazy[E1, A, S](s)(cont)((s, a) => f(s, f0(a)))
+  }
+
+  /**
+   * Maps each element to a chunk, and flattens the chunks into the output of
+   * this stream.
+   */
+  def mapConcat[B](f0: A => Chunk[B]): Stream[E, B] = new Stream[E, B] {
+    override def foldLazy[E1 >: E, B1 >: B, S](s: S)(cont: S => Boolean)(f: (S, B1) => IO[E1, S]): IO[E1, S] =
+      self.foldLazy[E1, A, S](s)(cont)((s, a) => f0(a).foldMLazy(s)(cont)(f))
+  }
+
+  /**
+   * Maps over elements of the stream with the specified effectful function.
+   */
+  final def mapM[E1 >: E, B](f0: A => IO[E1, B]): Stream[E1, B] = new Stream[E1, B] {
+    override def foldLazy[E2 >: E1, B1 >: B, S](s: S)(cont: S => Boolean)(f: (S, B1) => IO[E2, S]): IO[E2, S] =
+      self.foldLazy[E2, A, S](s)(cont)((s, a) => f0(a).flatMap(f(s, _)))
+  }
+
+  /**
+   * Merges this stream and the specified stream together.
+   */
+  final def merge[E1 >: E, A1 >: A](that: Stream[E1, A1], capacity: Int = 1): Stream[E1, A1] =
+    self.mergeWith(that, capacity)(identity, identity)
+
+  /**
+   * Merges this stream and the specified stream together to produce a stream of
+   * eithers.
+   */
+  final def mergeEither[E1 >: E, B](that: Stream[E1, B], capacity: Int = 1): Stream[E1, Either[A, B]] =
+    self.mergeWith(that, capacity)(Left(_), Right(_))
+
+  /**
+   * Merges this stream and the specified stream together to a common element
+   * type with the specified mapping functions.
+   */
+  final def mergeWith[E1 >: E, B, C](that: Stream[E1, B], capacity: Int = 1)(l: A => C, r: B => C): Stream[E1, C] =
+    new Stream[E1, C] {
+      override def foldLazy[E2 >: E1, C1 >: C, S](s: S)(cont: S => Boolean)(f: (S, C1) => IO[E2, S]): IO[E2, S] = {
+        type Elem = Either[Take[E2, A], Take[E2, B]]
+
+        def loop(leftDone: Boolean, rightDone: Boolean, s: S, queue: Queue[Elem]): IO[E2, S] =
+          queue.take.flatMap {
+            case Left(Take.Fail(e))  => IO.fail(e)
+            case Right(Take.Fail(e)) => IO.fail(e)
+            case Left(Take.End) =>
+              if (rightDone) IO.now(s)
+              else loop(true, rightDone, s, queue)
+            case Left(Take.Value(a)) =>
+              f(s, l(a)).flatMap { s =>
+                if (cont(s)) loop(leftDone, rightDone, s, queue)
+                else IO.now(s)
+              }
+            case Right(Take.End) =>
+              if (leftDone) IO.now(s)
+              else loop(leftDone, true, s, queue)
+            case Right(Take.Value(b)) =>
+              f(s, r(b)).flatMap { s =>
+                if (cont(s)) loop(leftDone, rightDone, s, queue)
+                else IO.now(s)
+              }
+          }
+
+        (for {
+          queue  <- Queue.bounded[Elem](capacity)
+          putL   = (a: A) => queue.offer(Left(Take.Value(a))).void
+          putR   = (b: B) => queue.offer(Right(Take.Value(b))).void
+          catchL = (e: E2) => queue.offer(Left(Take.Fail(e)))
+          catchR = (e: E2) => queue.offer(Right(Take.Fail(e)))
+          endL   = queue.offer(Left(Take.End)).forever
+          endR   = queue.offer(Right(Take.End)).forever
+          _      <- (self.foreach(putL) *> endL).catchAll(catchL).fork
+          _      <- (that.foreach(putR) *> endR).catchAll(catchR).fork
+          step   <- loop(false, false, s, queue)
+        } yield step).supervised
+      }
+    }
+
+  /**
+   * Peels off enough material from the stream to construct an `R` using the
+   * provided `Sink`, and then returns both the `R` and the remainder of the
+   * `Stream` in a managed resource. Like all `Managed` resources, the provided
+   * remainder is valid only within the scope of `Managed`.
+   */
+  final def peel[E1 >: E, A1 >: A, R](sink: Sink[E1, A1, A1, R]): Managed[E1, (R, Stream[E1, A1])] = {
+    type Folder = (Any, A1) => IO[E1, Step[Any]]
+    type Fold   = (Any, Folder)
+    type State  = Either[sink.State, Fold]
+    type Result = (R, Stream[E1, A1])
+
+    def feed[S](chunk: Chunk[A1], i: Int = 0)(s: S, f: (S, A1) => IO[E1, Step[S]]): IO[E1, Step[S]] =
+      if (i >= chunk.length) IO.now(Step.Cont(s))
+      else {
+        val a1 = chunk(i)
+
+        f(s, a1).flatMap {
+          case Step.Stop(s) => IO.now(Step.Stop(s))
+          case Step.Cont(s) => feed(chunk, i + 1)(s, f)
+        }
+      }
+
+    def tail(resume: Promise[Nothing, Fold], done: Promise[E1, Step[Any]]): Stream[E1, A1] =
+      new Stream[E1, A1] {
+        override def fold[E2 >: E1, A2 >: A1, S](s: S)(f: (S, A2) => IO[E2, Step[S]]): IO[E2, Step[S]] =
+          resume.complete(s -> f.asInstanceOf[Folder]) *>
+            done.get.asInstanceOf[IO[E2, Step[S]]]
+      }
+
+    def acquire(lstate: sink.State): IO[Nothing, (Fiber[E1, Step[State]], Promise[E1, Result])] =
+      for {
+        resume <- Promise.make[Nothing, Fold]
+        done   <- Promise.make[E1, Step[Any]]
+        result <- Promise.make[E1, Result]
+        fiber <- self
+                  .fold[E1, A1, State](Left(lstate)) {
+                    case (Left(lstate), a) =>
+                      sink.step(lstate, a).flatMap { step =>
+                        if (Sink.Step.cont(step)) IO.now(Step.Cont(Left(Sink.Step.state(step))))
+                        else {
+                          val lstate = Sink.Step.state(step)
+                          val as     = Chunk(a) ++ Sink.Step.leftover(step)
+
+                          sink.extract(lstate).flatMap { r =>
+                            result.complete(r -> tail(resume, done)) *>
+                              resume.get
+                                .flatMap(t => feed(as)(t._1, t._2).map(step => step.map(s => Right(s -> t._2))))
+                          }
+                        }
+                      }
+                    case (Right((rstate, f)), a) =>
+                      f(rstate, a).flatMap {
+                        case Step.Stop(rstate) =>
+                          IO.now(Step.Stop(Right(rstate -> f)))
+
+                        case Step.Cont(rstate) =>
+                          IO.now(Step.Cont(Right(rstate -> f)))
+                      }
+                  }
+                  .onError(result.done(_).void)
+                  .fork
+                  .flatMap(fiber => fiber.observe.flatMap(done.done(_).fork.void).const(fiber))
+      } yield (fiber, result)
+
+    Managed
+      .liftIO(sink.initial)
+      .flatMap(step => Managed(acquire(Sink.Step.state(step)))(_._1.interrupt).flatMap(t => Managed.liftIO(t._2.get)))
+  }
+
+  /**
+   * Repeats the entire stream using the specified schedule. The stream will execute normally,
+   * and then repeat again according to the provided schedule.
+   */
+  def repeat(schedule: Schedule[Unit, _], clock: Clock = Clock.Live): Stream[E, A] =
+    new Stream[E, A] {
+      override def foldLazy[E1 >: E, A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => IO[E1, S]) = {
+        def loop(s: S, sched: schedule.State): IO[E1, S] =
+          self.foldLazy[E1, A1, S](s)(cont)(f).seq(schedule.update((), sched, clock)).flatMap {
+            case (s, decision) =>
+              if (decision.cont) IO.unit.delay(decision.delay) *> loop(s, decision.state)
+              else IO.now(s)
+          }
+
+        schedule.initial(clock).flatMap(loop(s, _))
+      }
+    }
+
+  /**
+   * Repeats elements of the stream using the provided schedule.
+   */
+  def repeatElems[B](schedule: Schedule[A, B], clock: Clock = Clock.Live): Stream[E, A] =
+    new Stream[E, A] {
+      override def foldLazy[E1 >: E, A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => IO[E1, S]) = {
+        def loop(s: S, sched: schedule.State, a: A): IO[E1, S] =
+          schedule.update(a, sched, clock).flatMap { decision =>
+            if (decision.cont)
+              IO.unit.delay(decision.delay) *> f(s, a).flatMap(loop(_, decision.state, a))
+            else IO.now(s)
+          }
+
+        schedule.initial(clock).flatMap { sched =>
+          self.foldLazy[E1, A, S](s)(cont) { (s, a) =>
+            loop(s, sched, a)
+          }
+        }
+      }
+    }
+
+  /**
+   * Runs the sink on the stream to produce either the sink's result or an error.
+   */
+  def run[E1 >: E, A0, A1 >: A, B](sink: Sink[E1, A0, A1, B]): IO[E1, B] =
+    sink.initial
+      .flatMap(
+        state =>
+          self
+            .foldLazy[E1, A1, Sink.Step[sink.State, A0]](state)(Sink.Step.cont)(
+              (s, a) => sink.step(Sink.Step.state(s), a)
+            )
+            .flatMap(step => sink.extract(Sink.Step.state(step)))
+      )
+
+  /**
+   * Statefully maps over the elements of this stream to produce new elements.
+   */
+  def scan[S1, B](s1: S1)(f1: (S1, A) => (S1, B)): Stream[E, B] = new Stream[E, B] {
+    override def fold[E1 >: E, B1 >: B, S](s: S)(f: (S, B1) => IO[E1, Step[S]]): IO[E1, Step[S]] =
+      self
+        .fold[E1, A, (S, S1)](s -> s1) {
+          case ((s, s1), a) =>
+            val (s2, b) = f1(s1, a)
+
+            f(s, b).map(_.map(s => s -> s2))
+        }
+        .map(_.map(_._1))
+  }
+
+  /**
+   * Statefully and effectfully maps over the elements of this stream to produce
+   * new elements.
+   */
+  final def scanM[E1 >: E, S1, B](s1: S1)(f1: (S1, A) => IO[E1, (S1, B)]): Stream[E1, B] = new Stream[E1, B] {
+    override def fold[E2 >: E1, B1 >: B, S](s: S)(f: (S, B1) => IO[E2, Step[S]]): IO[E2, Step[S]] =
+      self
+        .fold[E2, A, (S, S1)](s -> s1) {
+          case ((s, s1), a) =>
+            f1(s1, a).flatMap {
+              case (s1, b) =>
+                f(s, b).map(_.map(s => s -> s1))
+            }
+        }
+        .map(_.map(_._1))
+  }
+
+  /**
+   * Takes the specified number of elements from this stream.
+   */
+  final def take(n: Int): Stream[E, A] =
+    self.zipWithIndex.takeWhile(_._2 < n).map(_._1)
+
+  /**
+   * Takes all elements of the stream for as long as the specified predicate
+   * evaluates to `true`.
+   */
+  def takeWhile(pred: A => Boolean): Stream[E, A] = new Stream[E, A] {
+    override def fold[E1 >: E, A1 >: A, S](s: S)(f: (S, A1) => IO[E1, Step[S]]): IO[E1, Step[S]] =
+      self.fold[E1, A, S](s)((s, a) => if (pred(a)) f(s, a) else IO.now(Step.Stop(s)))
+  }
+
+  /**
+   * Converts the stream to a managed queue. After managed queue is used, the
+   * queue will never again produce values and should be discarded.
+   */
+  final def toQueue[E1 >: E, A1 >: A](capacity: Int = 1): Managed[Nothing, Queue[Take[E1, A1]]] =
+    for {
+      queue    <- Managed.liftIO(Queue.bounded[Take[E1, A1]](capacity))
+      offerVal = (a: A) => queue.offer(Take.Value(a)).void
+      offerErr = (e: E) => queue.offer(Take.Fail(e))
+      enqueuer = (self.foreach[E](offerVal).catchAll(offerErr) *> queue.offer(Take.End).forever).fork
+      _        <- Managed(enqueuer)(_.interrupt)
+    } yield queue
+
+  /**
+   * Applies a transducer to the stream, which converts one or more elements
+   * of type `A` into elements of type `C`.
+   */
+  final def transduce[E1 >: E, A1 >: A, C](sink: Sink[E1, A1, A1, C]): Stream[E1, C] =
+    new Stream[E1, C] {
+      override def fold[E2 >: E1, C1 >: C, S2](s2: S2)(f: (S2, C1) => IO[E2, Step[S2]]): IO[E2, Step[S2]] = {
+        def feed(s1: sink.State, s2: S2, a: Chunk[A1]): IO[E2, Step[(sink.State, S2)]] =
+          sink.stepChunk(s1, a).flatMap { step =>
+            if (Sink.Step.cont(step)) IO.now(Step.cont((Sink.Step.state(step), s2)))
+            else {
+              sink
+                .extract(Sink.Step.state(step))
+                .flatMap(
+                  c =>
+                    f(s2, c).flatMap {
+                      case Step.Cont(s2) =>
+                        sink.initial.flatMap(s1 => feed(Sink.Step.state(s1), s2, Sink.Step.leftover(s1)))
+                      case Step.Stop(s2) => IO.now(Step.Stop((s1, s2)))
+                    }
+                )
+            }
+          }
+
+        sink.initial
+          .flatMap(
+            s1 =>
+              self.fold[E2, A, (sink.State, S2)]((Sink.Step.state(s1), s2)) {
+                case ((s1, s2), a) => feed(s1, s2, Chunk(a))
+              }
+          )
+          .map(_.map(_._2))
+      }
+    }
+
+  /**
+   * Adds an effect to consumption of every element of the stream.
+   */
+  final def withEffect[E1 >: E, A1 >: A](f0: A1 => IO[E1, Unit]): Stream[E1, A] =
+    new Stream[E1, A] {
+      override def fold[E2 >: E1, A2 >: A, S](s: S)(f: (S, A2) => IO[E2, Step[S]]): IO[E2, Step[S]] =
+        self.fold[E2, A, S](s)((s, a2) => f0(a2) *> f(s, a2))
+    }
+
+  /**
+   * Zips this stream together with the specified stream.
+   */
+  final def zip[E1 >: E, B](that: Stream[E1, B], lc: Int = 1, rc: Int = 1): Stream[E1, (A, B)] =
+    self.zipWith(that, lc, rc)(
+      (left, right) => left.flatMap(a => right.map(a -> _))
+    )
+
+  /**
+   * Zips two streams together with a specified function.
+   */
+  final def zipWith[E1 >: E, B, C](that: Stream[E1, B], lc: Int = 1, rc: Int = 1)(
+    f0: (Option[A], Option[B]) => Option[C]
+  ): Stream[E1, C] =
+    new Stream[E1, C] {
+      override def fold[E2 >: E1, A1 >: C, S](s: S)(f: (S, A1) => IO[E2, Step[S]]): IO[E2, Step[S]] = {
+        def loop(q1: Queue[Take[E2, A]], q2: Queue[Take[E2, B]], s: S): IO[E2, Step[S]] =
+          Take.option(q1.take).seqWith(Take.option(q2.take))(f0).flatMap {
+            case None => IO.now(Step.Cont(s))
+            case Some(c) =>
+              f(s, c).flatMap {
+                case Step.Cont(s) => loop(q1, q2, s)
+                case s            => IO.now(s)
+              }
+          }
+
+        self.toQueue[E2, A](lc).use(q1 => that.toQueue[E2, B](rc).use(q2 => loop(q1, q2, s)))
+      }
+    }
+
+  /**
+   * Zips this stream together with the index of elements of the stream.
+   */
+  def zipWithIndex: Stream[E, (A, Int)] = new Stream[E, (A, Int)] {
+    override def fold[E1 >: E, A1 >: (A, Int), S](s: S)(f: (S, A1) => IO[E1, Step[S]]): IO[E1, Step[S]] =
+      self
+        .fold[E1, A, (S, Int)]((s, 0)) {
+          case ((s, index), a) => f(s, (a, index)).map(_.map(s => (s, index + 1)))
+        }
+        .map(_.map(_._1))
+  }
+}
+
+object Stream {
+  sealed trait Step[+A] {
+    final def extract: A = this match {
+      case Step.Cont(value) => value
+      case Step.Stop(value) => value
+    }
+
+    final def map[B](f: A => B): Step[B] = this match {
+      case Step.Cont(value) => Step.Cont(f(value))
+      case Step.Stop(value) => Step.Stop(f(value))
+    }
+
+    final def duplicate: Step[Step[A]] = this match {
+      case Step.Cont(value) => Step.Cont(Step.Cont(value))
+      case Step.Stop(value) => Step.Stop(Step.Stop(value))
+    }
+
+    final def fold[Z](cont: A => Z, stop: A => Z): Z = this match {
+      case Step.Cont(a) => cont(a)
+      case Step.Stop(a) => stop(a)
+    }
+  }
+  object Step {
+    final case class Cont[A](value: A) extends Step[A]
+    final case class Stop[A](value: A) extends Step[A]
+
+    def cont[A](a: A): Step[A] = Cont(a)
+    def stop[A](a: A): Step[A] = Stop(a)
+  }
+
+  final def apply[A](as: A*): Stream[Nothing, A] = fromIterable(as)
+
+  /**
+   * Constructs a pure stream from the specified `Iterable`.
+   */
+  final def fromIterable[A](it: Iterable[A]): Stream[Nothing, A] = new StreamPure[A] {
+    override def fold[E >: Nothing, A1 >: A, S](s: S)(f: (S, A1) => IO[E, Step[S]]): IO[E, Step[S]] = {
+      val iterator = it.iterator
+
+      def loop(s: S): IO[E, Step[S]] =
+        IO.flatten(IO.sync {
+          if (iterator.hasNext) f(s, iterator.next).flatMap {
+            case Step.Cont(s) => loop(s)
+            case s            => IO.now(s)
+          } else IO.now(Step.Cont(s))
+        })
+
+      loop(s)
+    }
+
+    override def foldPure[A1 >: A, S](s: S)(f: (S, A1) => Step[S]): Step[S] = {
+      val iterator = it.iterator
+
+      def loop(s: S): Step[S] =
+        if (iterator.hasNext)
+          f(s, iterator.next) match {
+            case Step.Cont(s) => loop(s)
+            case s            => s
+          } else Step.cont(s)
+
+      loop(s)
+    }
+  }
+
+  final def fromChunk[@specialized A](c: Chunk[A]): Stream[Nothing, A] =
+    new StreamPure[A] {
+      override def fold[E >: Nothing, A1 >: A, S](s: S)(f: (S, A1) => IO[E, Step[S]]): IO[E, Step[S]] =
+        c.foldM[E, Step[S]](Step.cont(s)) { (step, a) =>
+          step.fold(f(_, a), s => IO.now(Step.stop(s)))
+        }
+
+      override def foldPure[A1 >: A, S](s: S)(f: (S, A1) => Step[S]): Step[S] = {
+        def loop(i: Int, s: S): Step[S] =
+          if (i >= c.length) Step.cont(s)
+          else {
+            val step = f(s, c(i))
+            step match {
+              case Step.Cont(_) => loop(i + 1, step.extract)
+              case _            => step
+            }
+          }
+
+        loop(0, s)
+      }
+    }
+
+  /**
+   * Returns the empty stream.
+   */
+  final val empty: Stream[Nothing, Nothing] = new StreamPure[Nothing] {
+    override def fold[E >: Nothing, A1 >: Nothing, S](s: S)(f: (S, A1) => IO[E, Step[S]]): IO[E, Step[S]] =
+      IO.now(Step.Cont(s))
+
+    override def foldPure[A1 >: Nothing, S](s: S)(f: (S, A1) => Step[S]): Step[S] = Step.cont(s)
+  }
+
+  /**
+   * Constructs a singleton stream.
+   */
+  final def point[A](a: => A): Stream[Nothing, A] = new StreamPure[A] {
+    override def fold[E >: Nothing, A1 >: A, S](s: S)(f: (S, A1) => IO[E, Step[S]]): IO[E, Step[S]] =
+      f(s, a)
+
+    override def foldPure[A1 >: A, S](s: S)(f: (S, A1) => Step[S]): Step[S] = f(s, a)
+  }
+
+  /**
+   * Lifts an effect producing an `A` into a stream producing that `A`.
+   */
+  final def lift[E, A](fa: IO[E, A]): Stream[E, A] = new Stream[E, A] {
+    override def fold[E1 >: E, A1 >: A, S](s: S)(f: (S, A1) => IO[E1, Step[S]]): IO[E1, Step[S]] =
+      fa.flatMap(f(s, _))
+  }
+
+  /**
+   * Flattens a stream of streams into a stream, by concatenating all the
+   * substreams.
+   */
+  final def flatten[E, A](fa: Stream[E, Stream[E, A]]): Stream[E, A] =
+    fa.flatMap(identity)
+
+  /**
+   * Unwraps a stream wrapped inside of an `IO` value.
+   */
+  final def unwrap[E, A](stream: IO[E, Stream[E, A]]): Stream[E, A] =
+    new Stream[E, A] {
+      override def fold[E1 >: E, A1 >: A, S](s: S)(f: (S, A1) => IO[E1, Step[S]]): IO[E1, Step[S]] =
+        stream.flatMap(_.fold[E1, A1, S](s)(f))
+    }
+
+  /**
+   * Constructs a stream from a resource that must be acquired and released.
+   */
+  final def bracket[E, A, B](
+    acquire: IO[E, A]
+  )(release: A => IO[Nothing, Unit])(read: A => IO[E, Option[B]]): Stream[E, B] =
+    managed(Managed(acquire)(release))(read)
+
+  final def managed[E, A, B](m: Managed[E, A])(read: A => IO[E, Option[B]]) =
+    new Stream[E, B] {
+      override def fold[E1 >: E, B1 >: B, S](s: S)(f: (S, B1) => IO[E1, Step[S]]): IO[E1, Step[S]] =
+        m use { a =>
+          read(a).flatMap {
+            case None    => IO.now(Step.Stop(s))
+            case Some(b) => f(s, b)
+          }
+        }
+    }
+
+  /**
+   * Constructs an infinite stream from a `Queue`.
+   */
+  final def fromQueue[A](queue: Queue[A]): Stream[Nothing, A] =
+    unfoldM(())(_ => queue.take.map(a => Some((a, ()))))
+
+  /**
+   * Constructs a stream from effectful state. This method should not be used
+   * for resources that require safe release. See `Stream.fromResource`.
+   */
+  final def unfoldM[S, E, A](s: S)(f0: S => IO[E, Option[(A, S)]]): Stream[E, A] =
+    new Stream[E, A] {
+      override def fold[E1 >: E, A1 >: A, S2](s2: S2)(f: (S2, A1) => IO[E1, Step[S2]]): IO[E1, Step[S2]] = {
+        def loop(s: S, s2: S2): IO[E1, Step[(S, S2)]] =
+          f0(s).flatMap {
+            case None => IO.now(Step.Stop((s, s2)))
+            case Some((a, s)) =>
+              f(s2, a).flatMap {
+                case Step.Stop(s2) => IO.now(Step.Stop((s, s2)))
+                case Step.Cont(s2) => loop(s, s2)
+              }
+          }
+
+        loop(s, s2).map(_.map(_._2))
+      }
+    }
+
+  /**
+   * Constructs a stream from state.
+   */
+  final def unfold[S, A](s: S)(f0: S => Option[(A, S)]): Stream[Nothing, A] =
+    new StreamPure[A] {
+      override def fold[E, A1 >: A, S2](s2: S2)(f: (S2, A1) => IO[E, Step[S2]]): IO[E, Step[S2]] = {
+        def loop(s: S, s2: S2): IO[E, Step[(S, S2)]] =
+          f0(s) match {
+            case None => IO.now(Step.Stop((s, s2)))
+            case Some((a, s)) =>
+              f(s2, a).flatMap {
+                case Step.Stop(s2) => IO.now(Step.Stop((s, s2)))
+                case Step.Cont(s2) => loop(s, s2)
+              }
+          }
+
+        loop(s, s2).map(_.map(_._2))
+      }
+
+      override def foldPure[A1 >: A, S2](s2: S2)(f: (S2, A1) => Step[S2]): Step[S2] = {
+        def loop(s: S, s2: S2): Step[(S, S2)] =
+          f0(s) match {
+            case None => Step.Stop((s, s2))
+            case Some((a, s)) =>
+              f(s2, a) match {
+                case Step.Stop(s2) => Step.Stop((s, s2))
+                case Step.Cont(s2) => loop(s, s2)
+              }
+          }
+
+        loop(s, s2).map(_._2)
+      }
+    }
+
+  /**
+   * Constructs a stream from a range of integers (inclusive).
+   */
+  final def range(min: Int, max: Int): Stream[Nothing, Int] =
+    unfold[Int, Int](min)(cur => if (cur > max) None else Some((cur, cur + 1)))
+}

--- a/core/shared/src/main/scala/scalaz/zio/stream/StreamChunk.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/StreamChunk.scala
@@ -66,8 +66,8 @@ trait StreamChunk[+E, @specialized +A] { self =>
   final def foreach[E1 >: E](f: A => IO[E1, Unit]): IO[E1, Unit] =
     foreach0[E1](f(_).const(true))
 
-  final def withEffect[E1 >: E, A1 >: A](f0: A1 => IO[E1, Unit]): StreamChunk[E1, A] =
-    StreamChunk(chunks.withEffect[E1, Chunk[A1]] { as =>
+  final def withEffect[E1 >: E](f0: A => IO[E1, Unit]): StreamChunk[E1, A] =
+    StreamChunk(chunks.withEffect[E1] { as =>
       as.traverse_(f0)
     })
 

--- a/core/shared/src/main/scala/scalaz/zio/stream/StreamChunk.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/StreamChunk.scala
@@ -1,0 +1,212 @@
+package scalaz.zio.stream
+
+import scalaz.zio._
+
+trait StreamChunk[+E, @specialized +A] { self =>
+  import Stream.Step
+
+  val chunks: Stream[E, Chunk[A]]
+
+  /**
+   * Executes an effectful fold over the elements of the chunks.
+   */
+  def fold[E1 >: E, A1 >: A, S](s: S)(f: (S, A1) => IO[E1, Step[S]]): IO[E1, Step[S]] =
+    chunks.fold[E1, Chunk[A1], S](s) { (s, as) =>
+      def loop(s: S, i: Int): IO[E1, Step[S]] =
+        if (i >= as.length) IO.now(Step.cont(s))
+        else
+          f(s, as(i)) flatMap {
+            case s: Step.Cont[S] => loop(s.extract, i + 1)
+            case s               => IO.now(s)
+          }
+
+      loop(s, 0)
+    }
+
+  def foldLazy[E1 >: E, A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => IO[E1, S]): IO[E1, S] =
+    chunks.foldLazy[E1, Chunk[A1], S](s)(cont) { (s, as) =>
+      as.foldMLazy(s)(cont)(f)
+    }
+
+  def foldLeft[A1 >: A, S](s: S)(f: (S, A1) => S): IO[E, S] =
+    foldLazy(s)(_ => true)((s, a) => IO.now(f(s, a)))
+
+  /**
+   * Executes an effectful fold over the stream of chunks.
+   */
+  def foldChunks[E1 >: E, A1 >: A, S](s: S)(f: (S, Chunk[A1]) => IO[E1, Step[S]]): IO[E1, Step[S]] =
+    chunks.fold[E1, Chunk[A1], S](s)(f)
+
+  def flattenChunks: Stream[E, A] =
+    chunks.flatMap(Stream.fromChunk)
+
+  /**
+   * Runs the sink on the stream to produce either the sink's result or an error.
+   */
+  final def run[E1 >: E, A0, A1 >: A, B](sink: Sink[E1, A0, Chunk[A1], B]): IO[E1, B] =
+    chunks.run(sink)
+
+  /**
+   * Filters this stream by the specified predicate, retaining all elements for
+   * which the predicate evaluates to true.
+   */
+  def filter(pred: A => Boolean): StreamChunk[E, A] =
+    StreamChunk[E, A](self.chunks.map(_.filter(pred)))
+
+  def filterNot(pred: A => Boolean): StreamChunk[E, A] = filter(!pred(_))
+
+  final def foreach0[E1 >: E](f: A => IO[E1, Boolean]): IO[E1, Unit] =
+    chunks.foreach0[E1] { as =>
+      as.foldM(true) { (p, a) =>
+        if (p) f(a)
+        else IO.point(p)
+      }
+    }
+
+  final def foreach[E1 >: E](f: A => IO[E1, Unit]): IO[E1, Unit] =
+    foreach0[E1](f(_).const(true))
+
+  final def withEffect[E1 >: E, A1 >: A](f0: A1 => IO[E1, Unit]): StreamChunk[E1, A] =
+    StreamChunk(chunks.withEffect[E1, Chunk[A1]] { as =>
+      as.traverse_(f0)
+    })
+
+  def dropWhile(pred: A => Boolean): StreamChunk[E, A] =
+    StreamChunk(new Stream[E, Chunk[A]] {
+      override def fold[E1 >: E, A1 >: Chunk[A], S](s: S)(f: (S, A1) => IO[E1, Step[S]]): IO[E1, Step[S]] =
+        self
+          .foldChunks[E1, A, (Boolean, S)](true -> s) {
+            case ((true, s), as) =>
+              val remaining = as.dropWhile(pred)
+
+              if (remaining.length > 0) f(s, remaining).map(_.map(false -> _))
+              else IO.now(Step.Cont(true                                -> s))
+            case ((false, s), as) => f(s, as).map(_.map(false -> _))
+          }
+          // The cast, although redundant, is unfortunately needed to appease Scala 2.11
+          .map(_.map(_._2).asInstanceOf[Step[S]])
+    })
+
+  def takeWhile(pred: A => Boolean): StreamChunk[E, A] =
+    StreamChunk(new Stream[E, Chunk[A]] {
+      override def fold[E1 >: E, A1 >: Chunk[A], S](s: S)(f: (S, A1) => IO[E1, Step[S]]): IO[E1, Step[S]] =
+        self.foldChunks[E1, A, S](s) { (s, as) =>
+          val remaining = as.takeWhile(pred)
+
+          if (remaining.length < as.length) f(s, remaining).map(s => Step.stop(s.extract))
+          else f(s, remaining)
+        }
+    })
+
+  def zipWithIndex: StreamChunk[E, (A, Int)] =
+    StreamChunk(
+      new Stream[E, Chunk[(A, Int)]] {
+        override def fold[E1 >: E, A1 >: Chunk[(A, Int)], S](s: S)(f: (S, A1) => IO[E1, Step[S]]): IO[E1, Step[S]] =
+          chunks
+            .fold[E1, Chunk[A], (S, Int)]((s, 0)) {
+              case ((s, index), as) =>
+                val zipped = as.zipWithIndex0(index)
+
+                f(s, zipped).map(_.map(s => (s, index + as.length)))
+            }
+            // The cast, although redundant, is unfortunately needed to appease Scala 2.11
+            .map(_.map(_._1).asInstanceOf[Step[S]])
+      }
+    )
+
+  final def scan[@specialized S1, @specialized B](s1: S1)(f1: (S1, A) => (S1, B)): StreamChunk[E, B] =
+    StreamChunk(chunks.scan(s1)((s1: S1, as: Chunk[A]) => as.scan(s1)(f1)))
+
+  def map[@specialized B](f: A => B): StreamChunk[E, B] =
+    StreamChunk(chunks.map(_.map(f)))
+
+  def mapConcat[B](f: A => Chunk[B]): StreamChunk[E, B] =
+    StreamChunk(chunks.map(_.flatMap(f)))
+
+  final def mapM[E1 >: E, B](f0: A => IO[E1, B]): StreamChunk[E1, B] =
+    StreamChunk(chunks.mapM(_.traverse(f0)))
+
+  final def flatMap[E1 >: E, B](f0: A => StreamChunk[E1, B]): StreamChunk[E1, B] =
+    StreamChunk(chunks.flatMap(_.map(f0).foldLeft[Stream[E1, Chunk[B]]](Stream.empty)((acc, el) => acc ++ el.chunks)))
+
+  final def ++[E1 >: E, A1 >: A](that: StreamChunk[E1, A1]): StreamChunk[E1, A1] =
+    StreamChunk(chunks ++ that.chunks)
+
+  final def toQueue[E1 >: E, A1 >: A](capacity: Int = 1): Managed[Nothing, Queue[Take[E1, Chunk[A1]]]] =
+    chunks.toQueue(capacity)
+
+  final def toQueueWith[E1 >: E, A1 >: A, Z](f: Queue[Take[E1, Chunk[A1]]] => IO[E1, Z], capacity: Int = 1): IO[E1, Z] =
+    toQueue[E1, A1](capacity).use(f)
+}
+
+object StreamChunk {
+  def apply[E, A](chunkStream: Stream[E, Chunk[A]]): StreamChunk[E, A] =
+    new StreamChunk[E, A] {
+      val chunks = chunkStream
+    }
+
+  def fromChunks[A](as: Chunk[A]*): StreamChunk[Nothing, A] =
+    new StreamChunk[Nothing, A] {
+      import Stream.Step
+
+      val chunks = new StreamPure[Chunk[A]] {
+        override def fold[E >: Nothing, A1 >: Chunk[A], S](s: S)(f: (S, A1) => IO[E, Step[S]]): IO[E, Step[S]] = {
+          val iterator = as.iterator
+
+          def loop(s: S): IO[E, Step[S]] =
+            IO.flatten(IO.sync {
+              if (iterator.hasNext) f(s, iterator.next).flatMap {
+                case Step.Cont(s) => loop(s)
+                case s            => IO.now(s)
+              } else IO.now(Step.Cont(s))
+            })
+
+          loop(s)
+        }
+
+        override def foldLazy[E >: Nothing, A1 >: Chunk[A], S](
+          s: S
+        )(cont: S => Boolean)(f: (S, A1) => IO[E, S]): IO[E, S] = {
+          val iterator = as.iterator
+
+          def loop(s: S): IO[E, S] =
+            IO.flatten {
+              IO.sync {
+                if (iterator.hasNext && cont(s)) f(s, iterator.next).flatMap(loop)
+                else IO.now(s)
+              }
+            }
+
+          loop(s)
+        }
+
+        override def foldPure[A1 >: Chunk[A], S](s: S)(f: (S, A1) => Step[S]): Step[S] = {
+          val iterator = as.iterator
+
+          def loop(s: S): Step[S] =
+            if (iterator.hasNext)
+              f(s, iterator.next) match {
+                case Step.Cont(s) => loop(s)
+                case s            => s
+              } else Step.cont(s)
+
+          loop(s)
+        }
+
+        override def foldPureLazy[A1 >: Chunk[A], S](s: S)(cont: S => Boolean)(f: (S, A1) => S): S = {
+          val iterator = as.iterator
+
+          def loop(s: S): S =
+            if (iterator.hasNext && cont(s)) loop(f(s, iterator.next))
+            else s
+
+          loop(s)
+        }
+      }
+    }
+
+  def point[A](as: => Chunk[A]): StreamChunk[Nothing, A] =
+    StreamChunk(Stream.point(as))
+
+  def empty: StreamChunk[Nothing, Nothing] = StreamChunk(Stream.empty)
+}

--- a/core/shared/src/main/scala/scalaz/zio/stream/StreamChunkPure.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/StreamChunkPure.scala
@@ -1,0 +1,46 @@
+package scalaz.zio.stream
+
+import scalaz.zio._
+
+private[stream] trait StreamChunkPure[@specialized +A] extends StreamChunk[Nothing, A] { self =>
+  import Stream.Step
+
+  val chunks: StreamPure[Chunk[A]]
+
+  def foldPure[A1 >: A, S](s: S)(f: (S, A1) => Step[S]): Step[S] =
+    chunks.foldPure(s) { (s, as) =>
+      def loop(s: S, i: Int): Step[S] =
+        if (i >= as.length) Step.cont(s)
+        else
+          f(s, as(i)) match {
+            case s: Step.Cont[S] => loop(s.extract, i + 1)
+            case s               => s
+          }
+
+      loop(s, 0)
+    }
+
+  def foldPureLazy[A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => S): S =
+    chunks.foldPureLazy(s)(cont) { (s, as) =>
+      as.foldLeftLazy(s)(cont)(f)
+    }
+
+  override def foldLeft[A1 >: A, S](s: S)(f: (S, A1) => S): IO[Nothing, S] =
+    IO.now(foldPureLazy(s)(_ => true)(f))
+
+  override def map[@specialized B](f: A => B): StreamChunkPure[B] =
+    StreamChunkPure(chunks.map(_.map(f)))
+
+  override def filter(pred: A => Boolean): StreamChunkPure[A] =
+    StreamChunkPure(chunks.map(_.filter(pred)))
+
+  override def mapConcat[B](f: A => Chunk[B]): StreamChunkPure[B] =
+    StreamChunkPure(chunks.map(_.flatMap(f)))
+}
+
+object StreamChunkPure {
+  def apply[A](chunkStream: StreamPure[Chunk[A]]): StreamChunkPure[A] =
+    new StreamChunkPure[A] {
+      val chunks = chunkStream
+    }
+}

--- a/core/shared/src/main/scala/scalaz/zio/stream/StreamChunkPure.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/StreamChunkPure.scala
@@ -3,22 +3,7 @@ package scalaz.zio.stream
 import scalaz.zio._
 
 private[stream] trait StreamChunkPure[@specialized +A] extends StreamChunk[Nothing, A] { self =>
-  import Stream.Step
-
   val chunks: StreamPure[Chunk[A]]
-
-  def foldPure[A1 >: A, S](s: S)(f: (S, A1) => Step[S]): Step[S] =
-    chunks.foldPure(s) { (s, as) =>
-      def loop(s: S, i: Int): Step[S] =
-        if (i >= as.length) Step.cont(s)
-        else
-          f(s, as(i)) match {
-            case s: Step.Cont[S] => loop(s.extract, i + 1)
-            case s               => s
-          }
-
-      loop(s, 0)
-    }
 
   def foldPureLazy[A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => S): S =
     chunks.foldPureLazy(s)(cont) { (s, as) =>

--- a/core/shared/src/main/scala/scalaz/zio/stream/StreamPure.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/StreamPure.scala
@@ -3,22 +3,7 @@ package scalaz.zio.stream
 import scalaz.zio._
 
 private[stream] trait StreamPure[+A] extends Stream[Nothing, A] { self =>
-  import Stream.Step
-
-  /**
-   * Executes a fold over the stream of values.
-   */
-  def foldPure[A1 >: A, S](s: S)(f: (S, A1) => Step[S]): Step[S] =
-    foldPureLazy[A1, Step[S]](Step.cont(s)) {
-      case Step.Cont(_) => true
-      case _            => false
-    }((s, a) => f(s.extract, a))
-
-  def foldPureLazy[A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => S): S =
-    foldPure[A1, S](s) { (s, a) =>
-      if (cont(s)) Step.cont(f(s, a))
-      else Step.stop(s)
-    }.extract
+  def foldPureLazy[A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => S): S
 
   override def foldLeft[A1 >: A, S](s: S)(f: (S, A1) => S): IO[Nothing, S] =
     IO.now(foldPureLazy(s)(_ => true)(f))
@@ -44,20 +29,11 @@ private[stream] trait StreamPure[+A] extends Stream[Nothing, A] { self =>
    * which the predicate evaluates to true.
    */
   override def filter(pred: A => Boolean): StreamPure[A] = new StreamPure[A] {
-    override def foldPure[A1 >: A, S](s: S)(f: (S, A1) => Step[S]): Step[S] =
-      self.foldPure[A, S](s) { (s, a) =>
-        if (pred(a)) f(s, a)
-        else Step.cont(s)
-      }
-
     override def foldPureLazy[A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => S): S =
       self.foldPureLazy[A, S](s)(cont) { (s, a) =>
         if (pred(a)) f(s, a)
         else s
       }
-
-    override def fold[E, A1 >: A, S](s: S)(f: (S, A1) => IO[E, Step[S]]): IO[E, Step[S]] =
-      StreamPure.super.filter(pred).fold(s)(f)
 
     override def foldLazy[E, A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => IO[E, S]): IO[E, S] =
       StreamPure.super.filter(pred).foldLazy(s)(cont)(f)
@@ -68,16 +44,16 @@ private[stream] trait StreamPure[+A] extends Stream[Nothing, A] { self =>
    * evaluates to `true`.
    */
   override def dropWhile(pred: A => Boolean): StreamPure[A] = new StreamPure[A] {
-    override def foldPure[A1 >: A, S](s: S)(f: (S, A1) => Step[S]): Step[S] =
-      (self
-        .foldPure[A, (Boolean, S)](true -> s) {
-          case ((true, s), a) if pred(a) => Step.Cont(true    -> s)
-          case ((_, s), a)               => f(s, a).map(false -> _)
-        })
-        .map(_._2)
+    override def foldPureLazy[A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => S): S =
+      self
+        .foldPureLazy[A, (Boolean, S)](true -> s)(tp => cont(tp._2)) {
+          case ((true, s), a) if pred(a) => true  -> s
+          case ((_, s), a)               => false -> f(s, a)
+        }
+        ._2
 
-    override def fold[E, A1 >: A, S](s: S)(f: (S, A1) => IO[E, Step[S]]): IO[E, Step[S]] =
-      StreamPure.super.dropWhile(pred).fold(s)(f)
+    override def foldLazy[E, A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => IO[E, S]): IO[E, S] =
+      StreamPure.super.dropWhile(pred).foldLazy(s)(cont)(f)
   }
 
   /**
@@ -85,74 +61,65 @@ private[stream] trait StreamPure[+A] extends Stream[Nothing, A] { self =>
    * evaluates to `true`.
    */
   override def takeWhile(pred: A => Boolean): StreamPure[A] = new StreamPure[A] {
-    override def foldPure[A1 >: A, S](s: S)(f: (S, A1) => Step[S]): Step[S] =
-      self.foldPure[A, S](s)((s, a) => if (pred(a)) f(s, a) else Step.Stop(s))
+    override def foldPureLazy[A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => S): S =
+      self
+        .foldPureLazy[A, (Boolean, S)](true -> s)(tp => tp._1 && cont(tp._2)) {
+          case ((_, s), a) =>
+            if (pred(a)) true -> f(s, a)
+            else false        -> s
+        }
+        ._2
 
-    override def fold[E, A1 >: A, S](s: S)(f: (S, A1) => IO[E, Step[S]]): IO[E, Step[S]] =
-      StreamPure.super.takeWhile(pred).fold(s)(f)
+    override def foldLazy[E, A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => IO[E, S]): IO[E, S] =
+      StreamPure.super.takeWhile(pred).foldLazy(s)(cont)(f)
   }
 
   /**
    * Maps over elements of the stream with the specified function.
    */
   override def map[B](f0: A => B): StreamPure[B] = new StreamPure[B] {
-    override def fold[E, B1 >: B, S](s: S)(f: (S, B1) => IO[E, Step[S]]): IO[E, Step[S]] =
-      StreamPure.super.map(f0).fold(s)(f)
-
     override def foldLazy[E, B1 >: B, S](s: S)(cont: S => Boolean)(f: (S, B1) => IO[E, S]): IO[E, S] =
       StreamPure.super.map(f0).foldLazy(s)(cont)(f)
-
-    override def foldPure[B1 >: B, S](s: S)(f: (S, B1) => Step[S]): Step[S] =
-      self.foldPure[A, S](s)((s, a) => f(s, f0(a)))
 
     override def foldPureLazy[B1 >: B, S](s: S)(cont: S => Boolean)(f: (S, B1) => S): S =
       self.foldPureLazy[A, S](s)(cont)((s, a) => f(s, f0(a)))
   }
 
   override def mapConcat[B](f0: A => Chunk[B]): StreamPure[B] = new StreamPure[B] {
-    override def fold[E, B1 >: B, S](s: S)(f: (S, B1) => IO[E, Step[S]]): IO[E, Step[S]] =
-      StreamPure.super.mapConcat(f0).fold(s)(f)
+    override def foldPureLazy[B1 >: B, S](s: S)(cont: S => Boolean)(f: (S, B1) => S): S =
+      self.foldPureLazy(s)(cont)((s, a) => f0(a).foldLeftLazy(s)(cont)(f))
 
-    override def foldPure[B1 >: B, S](s: S)(f: (S, B1) => Step[S]): Step[S] = {
-      def loop(s: S, c: Chunk[B], i: Int): Step[S] =
-        if (i >= c.length) Step.cont(s)
-        else
-          f(s, c(i)) match {
-            case Step.Cont(s) => loop(s, c, i + 1)
-            case s            => s
-          }
-
-      self.foldPure[A, S](s)((s, a) => loop(s, f0(a), 0))
-    }
+    override def foldLazy[E, B1 >: B, S](s: S)(cont: S => Boolean)(f: (S, B1) => IO[E, S]): IO[E, S] =
+      StreamPure.super.mapConcat(f0).foldLazy(s)(cont)(f)
   }
 
   override def zipWithIndex: StreamPure[(A, Int)] = new StreamPure[(A, Int)] {
-    override def fold[E, A1 >: (A, Int), S](s: S)(f: (S, A1) => IO[E, Step[S]]): IO[E, Step[S]] =
-      StreamPure.super.zipWithIndex.fold(s)(f)
-
-    override def foldPure[A1 >: (A, Int), S](s: S)(f: (S, A1) => Step[S]): Step[S] =
+    override def foldPureLazy[A1 >: (A, Int), S](s: S)(cont: S => Boolean)(f: (S, A1) => S): S =
       self
-        .foldPure[A, (S, Int)]((s, 0)) {
-          case ((s, index), a) => f(s, (a, index)).map(s => (s, index + 1))
+        .foldPureLazy[A, (S, Int)]((s, 0))(tp => cont(tp._1)) {
+          case ((s, index), a) => (f(s, (a, index)), index + 1)
         }
-        .map(_._1)
+        ._1
+
+    override def foldLazy[E, A1 >: (A, Int), S](s: S)(cont: S => Boolean)(f: (S, A1) => IO[E, S]): IO[E, S] =
+      StreamPure.super.zipWithIndex.foldLazy(s)(cont)(f)
   }
 
   /**
    * Statefully maps over the elements of this stream to produce new elements.
    */
-  override def scan[S1, B](s1: S1)(f1: (S1, A) => (S1, B)): StreamPure[B] = new StreamPure[B] {
-    override def fold[E, B1 >: B, S](s: S)(f: (S, B1) => IO[E, Step[S]]): IO[E, Step[S]] =
-      StreamPure.super.scan(s1)(f1).fold(s)(f)
-
-    override def foldPure[B1 >: B, S](s: S)(f: (S, B1) => Step[S]): Step[S] =
+  override def mapAccum[S1, B](s1: S1)(f1: (S1, A) => (S1, B)): StreamPure[B] = new StreamPure[B] {
+    override def foldPureLazy[B1 >: B, S](s: S)(cont: S => Boolean)(f: (S, B1) => S): S =
       self
-        .foldPure[A, (S, S1)](s -> s1) {
+        .foldPureLazy[A, (S, S1)](s -> s1)(tp => cont(tp._1)) {
           case ((s, s1), a) =>
             val (s2, b) = f1(s1, a)
 
-            f(s, b).map(_ -> s2)
+            f(s, b) -> s2
         }
-        .map(_._1)
+        ._1
+
+    override def foldLazy[E, B1 >: B, S](s: S)(cont: S => Boolean)(f: (S, B1) => IO[E, S]): IO[E, S] =
+      StreamPure.super.mapAccum(s1)(f1).foldLazy(s)(cont)(f)
   }
 }

--- a/core/shared/src/main/scala/scalaz/zio/stream/StreamPure.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/StreamPure.scala
@@ -1,0 +1,158 @@
+package scalaz.zio.stream
+
+import scalaz.zio._
+
+private[stream] trait StreamPure[+A] extends Stream[Nothing, A] { self =>
+  import Stream.Step
+
+  /**
+   * Executes a fold over the stream of values.
+   */
+  def foldPure[A1 >: A, S](s: S)(f: (S, A1) => Step[S]): Step[S] =
+    foldPureLazy[A1, Step[S]](Step.cont(s)) {
+      case Step.Cont(_) => true
+      case _            => false
+    }((s, a) => f(s.extract, a))
+
+  def foldPureLazy[A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => S): S =
+    foldPure[A1, S](s) { (s, a) =>
+      if (cont(s)) Step.cont(f(s, a))
+      else Step.stop(s)
+    }.extract
+
+  override def foldLeft[A1 >: A, S](s: S)(f: (S, A1) => S): IO[Nothing, S] =
+    IO.now(foldPureLazy(s)(_ => true)(f))
+
+  override def run[E, A0, A1 >: A, B](sink: Sink[E, A0, A1, B]): IO[E, B] =
+    sink match {
+      case sink: SinkPure[E, A0, A1, B] =>
+        IO.fromEither(
+          sink.extractPure(
+            Sink.Step.state(
+              foldPureLazy[A1, Sink.Step[sink.State, A0]](sink.initialPure)(Sink.Step.cont) { (s, a) =>
+                sink.stepPure(Sink.Step.state(s), a)
+              }
+            )
+          )
+        )
+
+      case sink: Sink[E, A0, A1, B] => super.run(sink)
+    }
+
+  /**
+   * Filters this stream by the specified predicate, retaining all elements for
+   * which the predicate evaluates to true.
+   */
+  override def filter(pred: A => Boolean): StreamPure[A] = new StreamPure[A] {
+    override def foldPure[A1 >: A, S](s: S)(f: (S, A1) => Step[S]): Step[S] =
+      self.foldPure[A, S](s) { (s, a) =>
+        if (pred(a)) f(s, a)
+        else Step.cont(s)
+      }
+
+    override def foldPureLazy[A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => S): S =
+      self.foldPureLazy[A, S](s)(cont) { (s, a) =>
+        if (pred(a)) f(s, a)
+        else s
+      }
+
+    override def fold[E, A1 >: A, S](s: S)(f: (S, A1) => IO[E, Step[S]]): IO[E, Step[S]] =
+      StreamPure.super.filter(pred).fold(s)(f)
+
+    override def foldLazy[E, A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => IO[E, S]): IO[E, S] =
+      StreamPure.super.filter(pred).foldLazy(s)(cont)(f)
+  }
+
+  /**
+   * Drops all elements of the stream for as long as the specified predicate
+   * evaluates to `true`.
+   */
+  override def dropWhile(pred: A => Boolean): StreamPure[A] = new StreamPure[A] {
+    override def foldPure[A1 >: A, S](s: S)(f: (S, A1) => Step[S]): Step[S] =
+      (self
+        .foldPure[A, (Boolean, S)](true -> s) {
+          case ((true, s), a) if pred(a) => Step.Cont(true    -> s)
+          case ((_, s), a)               => f(s, a).map(false -> _)
+        })
+        .map(_._2)
+
+    override def fold[E, A1 >: A, S](s: S)(f: (S, A1) => IO[E, Step[S]]): IO[E, Step[S]] =
+      StreamPure.super.dropWhile(pred).fold(s)(f)
+  }
+
+  /**
+   * Takes all elements of the stream for as long as the specified predicate
+   * evaluates to `true`.
+   */
+  override def takeWhile(pred: A => Boolean): StreamPure[A] = new StreamPure[A] {
+    override def foldPure[A1 >: A, S](s: S)(f: (S, A1) => Step[S]): Step[S] =
+      self.foldPure[A, S](s)((s, a) => if (pred(a)) f(s, a) else Step.Stop(s))
+
+    override def fold[E, A1 >: A, S](s: S)(f: (S, A1) => IO[E, Step[S]]): IO[E, Step[S]] =
+      StreamPure.super.takeWhile(pred).fold(s)(f)
+  }
+
+  /**
+   * Maps over elements of the stream with the specified function.
+   */
+  override def map[B](f0: A => B): StreamPure[B] = new StreamPure[B] {
+    override def fold[E, B1 >: B, S](s: S)(f: (S, B1) => IO[E, Step[S]]): IO[E, Step[S]] =
+      StreamPure.super.map(f0).fold(s)(f)
+
+    override def foldLazy[E, B1 >: B, S](s: S)(cont: S => Boolean)(f: (S, B1) => IO[E, S]): IO[E, S] =
+      StreamPure.super.map(f0).foldLazy(s)(cont)(f)
+
+    override def foldPure[B1 >: B, S](s: S)(f: (S, B1) => Step[S]): Step[S] =
+      self.foldPure[A, S](s)((s, a) => f(s, f0(a)))
+
+    override def foldPureLazy[B1 >: B, S](s: S)(cont: S => Boolean)(f: (S, B1) => S): S =
+      self.foldPureLazy[A, S](s)(cont)((s, a) => f(s, f0(a)))
+  }
+
+  override def mapConcat[B](f0: A => Chunk[B]): StreamPure[B] = new StreamPure[B] {
+    override def fold[E, B1 >: B, S](s: S)(f: (S, B1) => IO[E, Step[S]]): IO[E, Step[S]] =
+      StreamPure.super.mapConcat(f0).fold(s)(f)
+
+    override def foldPure[B1 >: B, S](s: S)(f: (S, B1) => Step[S]): Step[S] = {
+      def loop(s: S, c: Chunk[B], i: Int): Step[S] =
+        if (i >= c.length) Step.cont(s)
+        else
+          f(s, c(i)) match {
+            case Step.Cont(s) => loop(s, c, i + 1)
+            case s            => s
+          }
+
+      self.foldPure[A, S](s)((s, a) => loop(s, f0(a), 0))
+    }
+  }
+
+  override def zipWithIndex: StreamPure[(A, Int)] = new StreamPure[(A, Int)] {
+    override def fold[E, A1 >: (A, Int), S](s: S)(f: (S, A1) => IO[E, Step[S]]): IO[E, Step[S]] =
+      StreamPure.super.zipWithIndex.fold(s)(f)
+
+    override def foldPure[A1 >: (A, Int), S](s: S)(f: (S, A1) => Step[S]): Step[S] =
+      self
+        .foldPure[A, (S, Int)]((s, 0)) {
+          case ((s, index), a) => f(s, (a, index)).map(s => (s, index + 1))
+        }
+        .map(_._1)
+  }
+
+  /**
+   * Statefully maps over the elements of this stream to produce new elements.
+   */
+  override def scan[S1, B](s1: S1)(f1: (S1, A) => (S1, B)): StreamPure[B] = new StreamPure[B] {
+    override def fold[E, B1 >: B, S](s: S)(f: (S, B1) => IO[E, Step[S]]): IO[E, Step[S]] =
+      StreamPure.super.scan(s1)(f1).fold(s)(f)
+
+    override def foldPure[B1 >: B, S](s: S)(f: (S, B1) => Step[S]): Step[S] =
+      self
+        .foldPure[A, (S, S1)](s -> s1) {
+          case ((s, s1), a) =>
+            val (s2, b) = f1(s1, a)
+
+            f(s, b).map(_ -> s2)
+        }
+        .map(_._1)
+  }
+}

--- a/core/shared/src/main/scala/scalaz/zio/stream/Take.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/Take.scala
@@ -1,0 +1,45 @@
+package scalaz.zio.stream
+
+import scalaz.zio.IO
+
+/**
+ * A `Take[E, A]` represents a single `take` from a queue modeling a stream of
+ * values. A `Take` may be a failure value `E`, an element value `A`, or end-of-
+ * stream marker.
+ */
+sealed trait Take[+E, +A] { self =>
+  final def map[B](f: A => B): Take[E, B] = self match {
+    case t @ Take.Fail(_) => t
+    case Take.Value(a)    => Take.Value(f(a))
+    case Take.End         => Take.End
+  }
+
+  final def flatMap[E1 >: E, B](f: A => Take[E1, B]): Take[E1, B] = self match {
+    case t @ Take.Fail(_) => t
+    case Take.Value(a)    => f(a)
+    case Take.End         => Take.End
+  }
+
+  final def zipWith[E1 >: E, B, C](that: Take[E1, B])(f: (A, B) => C): Take[E1, C] = (self, that) match {
+    case (Take.Value(a), Take.Value(b)) => Take.Value(f(a, b))
+    case (Take.End, _)                  => Take.End
+    case (t @ Take.Fail(_), _)          => t
+    case (_, Take.End)                  => Take.End
+    case (_, t @ Take.Fail(_))          => t
+  }
+
+  final def zip[E1 >: E, B](that: Take[E1, B]): Take[E1, (A, B)] =
+    self.zipWith(that)(_ -> _)
+}
+object Take {
+  final case class Fail[E](value: E)  extends Take[E, Nothing]
+  final case class Value[A](value: A) extends Take[Nothing, A]
+  final case object End               extends Take[Nothing, Nothing]
+
+  final def option[E, A](io: IO[E, Take[E, A]]): IO[E, Option[A]] =
+    io.flatMap {
+      case Take.End      => IO.now(None)
+      case Take.Value(a) => IO.now(Some(a))
+      case Take.Fail(e)  => IO.fail(e)
+    }
+}

--- a/core/shared/src/main/scala/scalaz/zio/stream/package.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/package.scala
@@ -1,0 +1,5 @@
+package scalaz.zio
+
+package object stream {
+  type ChunkedSink[E, A, B] = Sink[E, A, Chunk[A], B]
+}


### PR DESCRIPTION
This pull request contains a Work In Progress implementation of ZIO Stream. Designed as the successor of Scalaz Stream, ZIO Stream features a small API, rich composability, good type inference, clean integration with ZIO (including interruption, typed errors, concurrency, resource safety, and interoperability), good performance, and growing list of combinators.

Unfinished work in this pull request:

 - [ ] Add comprehensive tests for Sink
 - [x] Add comprehensive tests for Stream
 - [ ] Add comprehensive tests for StreamChunk
 - [ ] Add comprehensive tests for hybrid pure variations (pure sink, pure stream, pure stream chunk)
 - [ ] Propagate features like pure/pure fusion throughout all combinators
 - [ ] Add documentation in the microsite
 - [ ] Add additional combinators for common cases
 - [ ] Decide what to specialize and what not to specialize
-  [ ] Add trampolining on Stream
 - [ ] Improve baseline performance (low-hanging fruit)
 - [ ] Hygiene issues such as alphabetizing, organizing public methods before private methods, and so forth

While unfinished, the design is ready for feedback and public contributions! Thanks to all who inspired the design of this library, including Eric Torreborre (Beautiful Folds), Oleg Kiselyov (Iteratees), and the FS2 development team (Michael Pilquist, Fabio Labella, Pavel Chlupacek, and many others).
