### PR TITLE
Bug: FS2's bracket release doesn't fire on interruption

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -88,7 +88,7 @@ lazy val interop = crossProject(JSPlatform, JVMPlatform)
       "org.scalaz"    %%% "scalaz-core"               % "7.2.+"    % Optional,
       "org.typelevel" %%% "cats-effect"               % "1.0.0"    % Optional,
       "org.scalaz"    %%% "scalaz-scalacheck-binding" % "7.2.+"    % Test,
-      "co.fs2"        %%% "fs2-core"                  % "1.0.0-M5" % Test
+      "co.fs2"        %%% "fs2-core"                  % "1.0.0"    % Test
     ),
     scalacOptions in Test ++= Seq("-Yrangepos")
   )

--- a/interop/jvm/src/test/scala/scalaz/zio/interop/Fs2ZioSpec.scala
+++ b/interop/jvm/src/test/scala/scalaz/zio/interop/Fs2ZioSpec.scala
@@ -8,6 +8,7 @@ import fs2.Stream
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.Specification
 import org.specs2.specification.AroundTimeout
+import scalaz.zio.interop.catz._
 
 class ZioWithFs2Spec(implicit ee: ExecutionEnv) extends Specification with AroundTimeout with RTS {
 
@@ -15,6 +16,11 @@ class ZioWithFs2Spec(implicit ee: ExecutionEnv) extends Specification with Aroun
   A simple fs2 join must
     work if `F` is `cats.effect.IO`          ${simpleJoin(fIsCats)}
     work if `F` is `scalaz.zio.interop.Task` ${simpleJoin(fIsZio)}
+
+  fs2 resource handling must
+    work when fiber is failed                ${bracketFail}
+    work when fiber is terminated            ${bracketTerminate}
+    work when fiber is interrupted           ${bracketInterrupt}
   """
 
   def simpleJoin(ints: => List[Int]) = upTo(2.seconds) {
@@ -23,10 +29,68 @@ class ZioWithFs2Spec(implicit ee: ExecutionEnv) extends Specification with Aroun
 
   def fIsCats = testCaseJoin[cats.effect.IO].unsafeRunSync()
 
-  def fIsZio: List[Int] = {
-    import catz._
+  def fIsZio: List[Int] =
     unsafeRun(testCaseJoin[scalaz.zio.interop.Task])
-  }
+
+  def bracketFail =
+    unsafeRun {
+      (for {
+        started  <- Promise.make[Nothing, Unit]
+        released <- Promise.make[Nothing, Unit]
+        fail     <- Promise.make[Nothing, Unit]
+        _ <- Stream
+              .bracket(started.complete(()).void)(_ => released.complete(()).void)
+              .evalMap[Task, Unit] { _ =>
+                fail.get *> IO.fail(new Exception())
+              }
+              .compile
+              .drain
+              .fork
+
+        _ <- started.get
+        _ <- fail.complete(())
+        _ <- released.get
+      } yield ()).timeout(2.seconds)
+    } must_=== Some(())
+
+  def bracketTerminate =
+    unsafeRun {
+      (for {
+        started   <- Promise.make[Nothing, Unit]
+        released  <- Promise.make[Nothing, Unit]
+        terminate <- Promise.make[Nothing, Unit]
+        _ <- Stream
+              .bracket(started.complete(()).void)(_ => released.complete(()).void)
+              .evalMap[Task, Unit] { _ =>
+                terminate.get *> IO.terminate(new Exception())
+              }
+              .compile
+              .drain
+              .fork
+
+        _ <- started.get
+        _ <- terminate.complete(())
+        _ <- released.get
+      } yield ()).timeout(2.seconds)
+    } must_=== Some(())
+
+  def bracketInterrupt =
+    unsafeRun {
+      (for {
+        started  <- Promise.make[Nothing, Unit]
+        released <- Promise.make[Nothing, Unit]
+        f <- Stream
+              .bracket(started.complete(()).void)(_ => released.complete(()).void)
+              .evalMap[Task, Unit](_ => IO.never)
+              .compile
+              .drain
+              .fork
+
+        _ <- started.get
+        _ <- f.interrupt
+        _ <- released.get
+      } yield ()).timeout(2.seconds)
+    } must_=== Some(())
 
   def testCaseJoin[F[_]: Effect]: F[List[Int]] = {
     def one: F[Int]       = Effect[F].delay(1)


### PR DESCRIPTION
See `bracketInterrupt` test. When the fiber is interrupted fs2 finalisers won't run. They do run on when  fiber is terminated or fails, however.