### PR TITLE
put parens in the right place

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -572,7 +572,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec {
     val io = for {
       ref   <- Ref(0)
       cont  <- Promise.make[Nothing, Unit]
-      io    = cont.complete(()) *> IO.never.onInterrupt(ref.update(_ + 1).void)
+      io    = (cont.complete(()) *> IO.never).onInterrupt(ref.update(_ + 1).void)
       raced <- (io race io).fork
       _     <- cont.get
       _     <- raced.interrupt


### PR DESCRIPTION
Flaky build failed because these parens were in the wrong place.