### PR TITLE
Track fiber ancestry in descriptor

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -93,6 +93,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec {
     reduceAll                               $testReduceAll
     reduceAll Empty List                    $testReduceAllEmpty
     timeout of failure                      $testTimeoutFailure
+    fork ancestry                           $testForkAncestry
 
   RTS regression tests
     deadlock regression 1                   $testDeadlockRegression
@@ -716,6 +717,15 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec {
     unsafeRun(
       IO.fail("Uh oh").timeout(1.hour)
     ) must (throwA[FiberFailure])
+
+  def testForkAncestry =
+    unsafeRun(
+      for {
+        r <- IO.descriptor
+        f <- IO.descriptor.fork
+        s <- f.join
+      } yield List(r.id) == s.ancestry
+    ) must_=== true
 
   def testDeadlockRegression = {
 

--- a/core/shared/src/main/scala/scalaz/zio/Fiber.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Fiber.scala
@@ -114,10 +114,16 @@ trait Fiber[+E, +A] { self =>
 object Fiber {
   final case class Descriptor(
     id: FiberId,
+    ancestry: List[FiberId],
     interrupted: Boolean,
     executor: ExecutionContext,
     supervisor: ExitResult.Cause[Nothing] => IO[Nothing, Unit]
-  )
+  ) {
+
+    def rootFiberId: FiberId =
+      ancestry.lastOption.getOrElse(id)
+
+  }
 
   final val unit: Fiber[Nothing, Unit] = Fiber.point(())
 


### PR DESCRIPTION
Stores a fiber's ancestry in its fiber descriptor. The current solution is to just keep a list of the ancestry, pushing on the current fiber ID whenever forking a new fiber.

One problem with this is that the ancestry stack is unbounded and may consume a lot of memory (only when we have very deep forking fiber trees, in the multi-millions). We can avoid this for now by storing only the parent fiber ID and the root fiber ID, since those are the most important ones.

With this, we can start building fiber-aware logging/metrics/tracing utilities