### PR TITLE
Make ringbuffer serializable

### DIFF
--- a/core/jvm/src/main/java/scalaz/zio/internal/impls/padding/MutableQueueFieldsPadding.java
+++ b/core/jvm/src/main/java/scalaz/zio/internal/impls/padding/MutableQueueFieldsPadding.java
@@ -1,5 +1,6 @@
 package scalaz.zio.internal.impls.padding;
 
+import java.io.Serializable;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import scalaz.zio.internal.MutableConcurrentQueue;
@@ -62,7 +63,7 @@ import scalaz.zio.internal.MutableConcurrentQueue;
  * Instance size: 416 bytes
  * Space losses: 4 bytes internal + 0 bytes external = 4 bytes total
  */
-public abstract class MutableQueueFieldsPadding<A> extends TailPadding<A> {
+public abstract class MutableQueueFieldsPadding<A> extends TailPadding<A> implements Serializable {
     public static final AtomicLongFieldUpdater<HeadPadding> headUpdater = AtomicLongFieldUpdater.newUpdater(HeadPadding.class, "headCounter");
     public static final AtomicLongFieldUpdater<TailPadding> tailUpdater = AtomicLongFieldUpdater.newUpdater(TailPadding.class, "tailCounter");
 
@@ -86,7 +87,7 @@ public abstract class MutableQueueFieldsPadding<A> extends TailPadding<A> {
 
 // Aux classes below
 
-abstract class ClassFieldsPadding<A> extends MutableConcurrentQueue<A> {
+abstract class ClassFieldsPadding<A> extends MutableConcurrentQueue<A> implements Serializable {
     protected long p000;
     protected long p001;
     protected long p002;
@@ -105,11 +106,11 @@ abstract class ClassFieldsPadding<A> extends MutableConcurrentQueue<A> {
     protected long p015;
 }
 
-abstract class HeadPadding<A> extends ClassFieldsPadding<A> {
+abstract class HeadPadding<A> extends ClassFieldsPadding<A> implements Serializable {
     protected volatile long headCounter;
 }
 
-abstract class PreTailPadding<A> extends HeadPadding<A> {
+abstract class PreTailPadding<A> extends HeadPadding<A> implements Serializable {
     protected long p100;
     protected long p101;
     protected long p102;
@@ -128,6 +129,6 @@ abstract class PreTailPadding<A> extends HeadPadding<A> {
     protected long p115;
 }
 
-abstract class TailPadding<A> extends PreTailPadding<A> {
+abstract class TailPadding<A> extends PreTailPadding<A> implements Serializable {
     protected volatile long tailCounter;
 }

--- a/core/jvm/src/main/scala/scalaz/zio/internal/impls/RingBuffer.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/internal/impls/RingBuffer.scala
@@ -2,6 +2,7 @@ package scalaz.zio.internal.impls
 
 import java.util.concurrent.atomic.AtomicLongArray
 import scalaz.zio.internal.impls.padding.MutableQueueFieldsPadding
+import scalaz.zio.internal.impls.padding.MutableQueueFieldsPadding.{headUpdater, tailUpdater}
 
 /**
  * A lock-free array based bounded queue. It is thread-safe and can be
@@ -68,6 +69,18 @@ import scalaz.zio.internal.impls.padding.MutableQueueFieldsPadding
  * be made to work with arbitrary sizes but the user will have to
  * suffer ~20% performance loss.
  *
+ * To ensure good performance reads/writes to `head` and `tail`
+ * fields need to be independant, e.g. they shouldn't fall on the
+ * same (adjacent) cache-line.
+ *
+ * We can make those counters regular volatile long fields and space
+ * them out, but we still need a way to do CAS on them. The only way
+ * to do this except `Unsafe` is to use [[AtomicLongFieldUpdater]],
+ * which is exactly what we have here.
+ *
+ * @see [[MutableQueueFieldsPadding]] for more details on padding
+ * and object's memory layout.
+ *
  * The design is heavily inspired by such libraries as
  * [[https://github.com/LMAX-Exchange/disruptor]] and
  * [[https://github.com/JCTools/JCTools]] which is based off
@@ -95,7 +108,7 @@ import scalaz.zio.internal.impls.padding.MutableQueueFieldsPadding
  * a way yet). This translates into worse performance on average, and
  * better performance in some very specific situations.
  */
-class RingBuffer[A](val desiredCapacity: Int) extends MutableQueueFieldsPadding[A] {
+class RingBuffer[A](val desiredCapacity: Int) extends MutableQueueFieldsPadding[A] with Serializable {
   final val capacity: Int         = nextPow2(desiredCapacity)
   private[this] val idxMask: Long = (capacity - 1).toLong
 
@@ -103,32 +116,16 @@ class RingBuffer[A](val desiredCapacity: Int) extends MutableQueueFieldsPadding[
   private[this] val seq: AtomicLongArray = new AtomicLongArray(capacity)
   0.until(capacity).foreach(i => seq.set(i, i.toLong))
 
-  /*
-   * To ensure good performance reads/writes to `head` and `tail`
-   * fields need to be independant, e.g. they shouldn't fall on the
-   * same (adjacent) cache-line.
-   *
-   * We can make those counters regular volatile long fields and space
-   * them out, but we still need a way to do CAS on them. The only way
-   * to do this except `Unsafe` is to use [[AtomicLongFieldUpdater]],
-   * which is exactly what we have here.
-   *
-   * @see [[MutableQueueFieldsPadding]] for more details on padding
-   * and object's memory layout.
-   */
-  private[this] val head = MutableQueueFieldsPadding.headUpdater
-  private[this] val tail = MutableQueueFieldsPadding.tailUpdater
-
   private[this] final val STATE_LOOP     = 0
   private[this] final val STATE_EMPTY    = -1
   private[this] final val STATE_FULL     = -2
   private[this] final val STATE_RESERVED = 1
 
-  override final def size(): Int = (tail.get(this) - head.get(this)).toInt
+  override final def size(): Int = (tailUpdater.get(this) - headUpdater.get(this)).toInt
 
-  override final def enqueuedCount(): Long = tail.get(this)
+  override final def enqueuedCount(): Long = tailUpdater.get(this)
 
-  override final def dequeuedCount(): Long = head.get(this)
+  override final def dequeuedCount(): Long = headUpdater.get(this)
 
   override final def offer(a: A): Boolean = {
     // Loading all instance fields locally. Otherwise JVM will reload
@@ -139,10 +136,10 @@ class RingBuffer[A](val desiredCapacity: Int) extends MutableQueueFieldsPadding[
     val aSeq   = seq
     var curSeq = 0L
 
-    val aHead   = head
+    val aHead   = headUpdater
     var curHead = 0L
 
-    val aTail   = tail
+    val aTail   = tailUpdater
     var curTail = aTail.get(this)
     var curIdx  = 0
 
@@ -218,11 +215,11 @@ class RingBuffer[A](val desiredCapacity: Int) extends MutableQueueFieldsPadding[
     val aSeq   = seq
     var curSeq = 0L
 
-    val aHead   = head
+    val aHead   = headUpdater
     var curHead = aHead.get(this)
     var curIdx  = 0
 
-    val aTail   = tail
+    val aTail   = tailUpdater
     var curTail = 0L
 
     var state = STATE_LOOP
@@ -298,9 +295,9 @@ class RingBuffer[A](val desiredCapacity: Int) extends MutableQueueFieldsPadding[
     }
   }
 
-  override final def isEmpty(): Boolean = tail.get(this) == head.get(this)
+  override final def isEmpty(): Boolean = tailUpdater.get(this) == headUpdater.get(this)
 
-  override final def isFull(): Boolean = tail.get(this) == head.get(this) + capacity
+  override final def isFull(): Boolean = tailUpdater.get(this) == headUpdater.get(this) + capacity
 
   private def posToIdx(pos: Long, mask: Long): Int = (pos & mask).toInt
 

--- a/core/jvm/src/main/scala/scalaz/zio/internal/impls/RingBuffer.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/internal/impls/RingBuffer.scala
@@ -2,7 +2,7 @@ package scalaz.zio.internal.impls
 
 import java.util.concurrent.atomic.AtomicLongArray
 import scalaz.zio.internal.impls.padding.MutableQueueFieldsPadding
-import scalaz.zio.internal.impls.padding.MutableQueueFieldsPadding.{headUpdater, tailUpdater}
+import scalaz.zio.internal.impls.padding.MutableQueueFieldsPadding.{ headUpdater, tailUpdater }
 
 /**
  * A lock-free array based bounded queue. It is thread-safe and can be

--- a/core/jvm/src/test/scala/scalaz/zio/SerializableSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/SerializableSpec.scala
@@ -5,7 +5,7 @@ import java.io._
 class SerializableSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends AbstractRTSSpec {
 
   def serializeAndBack[T](a: T): IO[_, T] = {
-    import SerializationUtil._
+    import SerializableSpec._
 
     for {
       obj       <- IO.sync(serializeToBytes(a))
@@ -111,7 +111,7 @@ class SerializableSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends 
   }
 }
 
-object SerializationUtil {
+object SerializableSpec {
   def serializeToBytes[T](a: T): Array[Byte] = {
     val bf  = new ByteArrayOutputStream()
     val oos = new ObjectOutputStream(bf)
@@ -124,4 +124,6 @@ object SerializationUtil {
     val ios = new ObjectInputStream(new ByteArrayInputStream(bytes))
     ios.readObject().asInstanceOf[T]
   }
+
+  def serializeAndDeserialize[T](a: T): T = getObjFromBytes(serializeToBytes(a))
 }

--- a/core/jvm/src/test/scala/scalaz/zio/SerializableSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/SerializableSpec.scala
@@ -5,19 +5,7 @@ import java.io._
 class SerializableSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends AbstractRTSSpec {
 
   def serializeAndBack[T](a: T): IO[_, T] = {
-
-    def serializeToBytes[T](a: T): Array[Byte] = {
-      val bf  = new ByteArrayOutputStream()
-      val oos = new ObjectOutputStream(bf)
-      oos.writeObject(a)
-      oos.close()
-      bf.toByteArray
-    }
-
-    def getObjFromBytes[T](bytes: Array[Byte]): T = {
-      val ios = new ObjectInputStream(new ByteArrayInputStream(bytes))
-      ios.readObject().asInstanceOf[T]
-    }
+    import SerializationUtil._
 
     for {
       obj       <- IO.sync(serializeToBytes(a))
@@ -120,5 +108,20 @@ class SerializableSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends 
       case _                           => List.empty
     }
     result must_=== list
+  }
+}
+
+object SerializationUtil {
+  def serializeToBytes[T](a: T): Array[Byte] = {
+    val bf  = new ByteArrayOutputStream()
+    val oos = new ObjectOutputStream(bf)
+    oos.writeObject(a)
+    oos.close()
+    bf.toByteArray
+  }
+
+  def getObjFromBytes[T](bytes: Array[Byte]): T = {
+    val ios = new ObjectInputStream(new ByteArrayInputStream(bytes))
+    ios.readObject().asInstanceOf[T]
   }
 }

--- a/core/jvm/src/test/scala/scalaz/zio/internal/RingBufferSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/internal/RingBufferSpec.scala
@@ -1,7 +1,7 @@
 package scalaz.zio.internal
 
 import org.specs2.Specification
-import scalaz.zio.SerializationUtil._
+import scalaz.zio.SerializableSpec._
 
 /*
  * This spec is just a sanity check and tests RingBuffer correctness
@@ -47,7 +47,7 @@ class RingBufferSpec extends Specification {
   def e4 = {
     val q = MutableConcurrentQueue.bounded[Int](2)
     q.offer(1)
-    val returnQ = getObjFromBytes[MutableConcurrentQueue[Int]](serializeToBytes(q))
+    val returnQ = serializeAndDeserialize(q)
     returnQ.poll(-1) must_=== 1
   }
 }

--- a/core/jvm/src/test/scala/scalaz/zio/internal/RingBufferSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/internal/RingBufferSpec.scala
@@ -1,6 +1,7 @@
 package scalaz.zio.internal
 
 import org.specs2.Specification
+import scalaz.zio.SerializationUtil._
 
 /*
  * This spec is just a sanity check and tests RingBuffer correctness
@@ -15,6 +16,7 @@ class RingBufferSpec extends Specification {
      returns a queue of size 2 which is the next power of 2. $e1
      `offer` of 2 items succeeds, further offers fail. $e2
      `poll` of 2 items from full queue succeeds, further `poll`s return default value. $e3
+     can be serialized. $e4
     """
 
   def e1 = {
@@ -40,5 +42,12 @@ class RingBufferSpec extends Specification {
       .and(q.poll(-1) must_=== 2)
       .and(q.poll(-1) must_=== -1)
       .and(q.isEmpty must beTrue)
+  }
+
+  def e4 = {
+    val q = MutableConcurrentQueue.bounded[Int](2)
+    q.offer(1)
+    val returnQ = getObjFromBytes[MutableConcurrentQueue[Int]](serializeToBytes(q))
+    returnQ.poll(-1) must_=== 1
   }
 }

--- a/core/jvm/src/test/scala/scalaz/zio/internal/RingBufferSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/internal/RingBufferSpec.scala
@@ -48,6 +48,9 @@ class RingBufferSpec extends Specification {
     val q = MutableConcurrentQueue.bounded[Int](2)
     q.offer(1)
     val returnQ = serializeAndDeserialize(q)
-    returnQ.poll(-1) must_=== 1
+    returnQ.offer(2)
+    (returnQ.poll(-1) must_=== 1)
+      .and(returnQ.poll(-1) must_=== 2)
+      .and(returnQ.poll(-1) must_=== -1)
   }
 }


### PR DESCRIPTION
We don't need to capture head and tail Atomic*FieldUpdaters in RingBuffer's fields as they are not a part of its state (which is stored in `headCounter/tailCounter` fields from padding classes.