### PR TITLE
Fix signature of asyncPure

### DIFF
--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -984,11 +984,11 @@ object IO extends Serializable {
    * Imports an asynchronous effect into a pure `IO` value. This formulation is
    * necessary when the effect is itself expressed in terms of `IO`.
    */
-  final def asyncPure[E, A](register: (Callback[E, A]) => IO[E, Unit]): IO[E, A] =
+  final def asyncPure[E, A](register: (Callback[E, A]) => IO[Nothing, Unit]): IO[E, A] =
     for {
       d   <- descriptor
       p   <- Promise.make[E, A]
-      ref <- Ref[Fiber[E, _]](Fiber.unit)
+      ref <- Ref[Fiber[Nothing, _]](Fiber.unit)
       a <- (for {
             _ <- register(p.unsafeDone(_, d.executor.execute)).fork.peek(ref.set(_)).uninterruptibly
             a <- p.get

--- a/interop/jvm/src/main/scala/scalaz/zio/interop/catsjvm.scala
+++ b/interop/jvm/src/main/scala/scalaz/zio/interop/catsjvm.scala
@@ -58,7 +58,7 @@ private class CatsEffect extends CatsMonadError[Throwable] with Effect[Task] wit
 
   override def asyncF[A](k: (Either[Throwable, A] => Unit) => Task[Unit]): Task[A] =
     IO.asyncPure { kk: Callback[Throwable, A] =>
-      k(eitherToExitResult andThen kk)
+      k(eitherToExitResult andThen kk).catchAll(IO.terminate)
     }
 
   override def suspend[A](thunk: => Task[A]): Task[A] =


### PR DESCRIPTION
It used a checked error for the callback register function, which is incorrect.