### PR TITLE
ConcurrentEffect WIP

### DIFF
--- a/interop-cats/jvm/src/main/scala/scalaz/zio/interop/catsjvm.scala
+++ b/interop-cats/jvm/src/main/scala/scalaz/zio/interop/catsjvm.scala
@@ -54,7 +54,7 @@ sealed abstract class CatsInstances2 {
 }
 
 private class CatsConcurrentEffect extends CatsConcurrent with effect.ConcurrentEffect[Task] {
-  def runCancelable[A](
+  override def runCancelable[A](
     fa: Task[A]
   )(cb: Either[Throwable, A] => effect.IO[Unit]): effect.SyncIO[effect.CancelToken[Task]] =
     effect.SyncIO {
@@ -68,34 +68,8 @@ private class CatsConcurrentEffect extends CatsConcurrent with effect.Concurrent
       }
     }
 
-//      def runCancelable[A](fa: Task[A])(cb: Either[Throwable, A] => effect.IO[Unit]): effect.SyncIO[effect.CancelToken[Task]] = {
-//    effect.SyncIO {
-//      this.unsafeRun {
-//        fa.sandboxed.redeemPure(ExitResult.Failed(_), ExitResult.Succeeded(_))
-//          .flatMap(exit => IO.syncThrowable(cb(exitResultToEither(exit)).unsafeRunAsync(_ => ())))
-//          .fork.flatMap { f =>
-//            IO.now(f.interrupt.void)
-//        }
-//      }
-//    }
-  // misses ExitCase.Canceled
-
-//    var canceler: effect.CancelToken[Task] = null
-//    runAsync(fa.fork.flatMap {
-//      f => Task { canceler = f.interrupt.void } *> f.join
-//    })(cb).flatMap(_ => effect.SyncIO {
-//      var cont = true
-//      while (cont) {
-//        if (canceler != null) {
-//          cont = false
-//        }
-//      }
-//      canceler
-//    })
-
   override def toIO[A](fa: Task[A]): effect.IO[A] =
     effect.ConcurrentEffect.toIOFromRunCancelable(fa)(this)
-//    effect.Effect.toIOFromRunAsync(fa)(this)
 }
 
 private class CatsConcurrent extends CatsEffect with Concurrent[Task] {

--- a/interop-cats/jvm/src/main/scala/scalaz/zio/interop/catsjvm.scala
+++ b/interop-cats/jvm/src/main/scala/scalaz/zio/interop/catsjvm.scala
@@ -60,8 +60,8 @@ private class CatsConcurrentEffect extends CatsConcurrent with effect.Concurrent
     effect.SyncIO {
       this.unsafeRun {
         fa.fork.flatMap { f =>
-          f.observe
-            .flatMap(exit => IO.syncThrowable(cb(exitResultToEither(exit)).unsafeRunAsync(_ => ())))
+          f.await
+            .flatMap(exit => IO.syncThrowable(cb(exitToEither(exit)).unsafeRunAsync(_ => ())))
             .fork
             .const(f.interrupt.void)
         }

--- a/interop-cats/jvm/src/main/scala/scalaz/zio/interop/catsjvm.scala
+++ b/interop-cats/jvm/src/main/scala/scalaz/zio/interop/catsjvm.scala
@@ -54,7 +54,7 @@ sealed abstract class CatsInstances2 {
 }
 
 private class CatsConcurrentEffect extends CatsConcurrent with effect.ConcurrentEffect[Task] {
-  override def runCancelable[A](
+  override final def runCancelable[A](
     fa: Task[A]
   )(cb: Either[Throwable, A] => effect.IO[Unit]): effect.SyncIO[effect.CancelToken[Task]] =
     effect.SyncIO {
@@ -68,22 +68,22 @@ private class CatsConcurrentEffect extends CatsConcurrent with effect.Concurrent
       }
     }
 
-  override def toIO[A](fa: Task[A]): effect.IO[A] =
+  override final def toIO[A](fa: Task[A]): effect.IO[A] =
     effect.ConcurrentEffect.toIOFromRunCancelable(fa)(this)
 }
 
 private class CatsConcurrent extends CatsEffect with Concurrent[Task] {
 
-  protected[this] final def toFiber[A](f: Fiber[Throwable, A]): effect.Fiber[Task, A] = new effect.Fiber[Task, A] {
-    override val cancel: Task[Unit] = f.interrupt.void
+  private[this] final def toFiber[A](f: Fiber[Throwable, A]): effect.Fiber[Task, A] = new effect.Fiber[Task, A] {
+    override final val cancel: Task[Unit] = f.interrupt.void
 
-    override val join: Task[A] = f.join
+    override final val join: Task[A] = f.join
   }
 
-  override def liftIO[A](ioa: cats.effect.IO[A]): Task[A] =
+  override final def liftIO[A](ioa: cats.effect.IO[A]): Task[A] =
     Concurrent.liftIO(ioa)(this)
 
-  override def cancelable[A](k: (Either[Throwable, A] => Unit) => effect.CancelToken[Task]): Task[A] =
+  override final def cancelable[A](k: (Either[Throwable, A] => Unit) => effect.CancelToken[Task]): Task[A] =
     IO.asyncInterrupt { (kk: IO[Throwable, A] => Unit) =>
       val token: effect.CancelToken[Task] = {
         k(e => kk(eitherToIO(e)))
@@ -92,7 +92,7 @@ private class CatsConcurrent extends CatsEffect with Concurrent[Task] {
       Left(token.orDie)
     }
 
-  override def race[A, B](fa: Task[A], fb: Task[B]): Task[Either[A, B]] =
+  override final def race[A, B](fa: Task[A], fb: Task[B]): Task[Either[A, B]] =
     racePair(fa, fb).flatMap {
       case Left((a, fiberB)) =>
         fiberB.cancel.const(Left(a))
@@ -100,10 +100,10 @@ private class CatsConcurrent extends CatsEffect with Concurrent[Task] {
         fiberA.cancel.const(Right(b))
     }
 
-  override def start[A](fa: Task[A]): Task[effect.Fiber[Task, A]] =
+  override final def start[A](fa: Task[A]): Task[effect.Fiber[Task, A]] =
     fa.fork.map(toFiber)
 
-  override def racePair[A, B](
+  override final def racePair[A, B](
     fa: Task[A],
     fb: Task[B]
   ): Task[Either[(A, effect.Fiber[Task, B]), (effect.Fiber[Task, A], B)]] =
@@ -114,18 +114,18 @@ private class CatsConcurrent extends CatsEffect with Concurrent[Task] {
 }
 
 private class CatsEffect extends CatsMonadError[Throwable] with Effect[Task] with CatsSemigroupK[Throwable] with RTS {
-  @inline final protected def exitToEither[A](e: Exit[Throwable, A]): Either[Throwable, A] =
+  @inline final protected[this] def exitToEither[A](e: Exit[Throwable, A]): Either[Throwable, A] =
     e.fold(_.checked[Throwable] match {
       case t :: Nil => Left(t)
       case _        => e.toEither
     }, Right(_))
 
-  @inline final protected def eitherToIO[A]: Either[Throwable, A] => IO[Throwable, A] = {
+  @inline final protected[this] def eitherToIO[A]: Either[Throwable, A] => IO[Throwable, A] = {
     case Left(t)  => IO.fail(t)
     case Right(r) => IO.succeed(r)
   }
 
-  @inline final protected def exitToExitCase[A]: Exit[Throwable, A] => ExitCase[Throwable] = {
+  @inline final private[this] def exitToExitCase[A]: Exit[Throwable, A] => ExitCase[Throwable] = {
     case Exit.Success(_)                          => ExitCase.Completed
     case Exit.Failure(cause) if cause.interrupted => ExitCase.Canceled
     case Exit.Failure(cause) =>
@@ -135,15 +135,10 @@ private class CatsEffect extends CatsMonadError[Throwable] with Effect[Task] wit
       }
   }
 
-  override def never[A]: Task[A] =
+  override final def never[A]: Task[A] =
     IO.never
 
-  override def toIO[A](
-    fa: Task[A]
-  ): effect.IO[A] =
-    effect.Effect.toIOFromRunAsync(fa)(this)
-
-  override def runAsync[A](
+  override final def runAsync[A](
     fa: Task[A]
   )(cb: Either[Throwable, A] => effect.IO[Unit]): effect.SyncIO[Unit] =
     effect.SyncIO {
@@ -153,28 +148,28 @@ private class CatsEffect extends CatsMonadError[Throwable] with Effect[Task] wit
       }
     }
 
-  override def async[A](k: (Either[Throwable, A] => Unit) => Unit): Task[A] =
+  override final def async[A](k: (Either[Throwable, A] => Unit) => Unit): Task[A] =
     IO.async { (kk: IO[Throwable, A] => Unit) =>
       k(eitherToIO andThen kk)
     }
 
-  override def asyncF[A](k: (Either[Throwable, A] => Unit) => Task[Unit]): Task[A] =
+  override final def asyncF[A](k: (Either[Throwable, A] => Unit) => Task[Unit]): Task[A] =
     IO.asyncIO { (kk: IO[Throwable, A] => Unit) =>
       k(eitherToIO andThen kk).orDie
     }
 
-  override def suspend[A](thunk: => Task[A]): Task[A] =
+  override final def suspend[A](thunk: => Task[A]): Task[A] =
     IO.flatten(IO.syncThrowable(thunk))
 
-  override def delay[A](thunk: => A): Task[A] =
+  override final def delay[A](thunk: => A): Task[A] =
     IO.syncThrowable(thunk)
 
-  override def bracket[A, B](acquire: Task[A])(use: A => Task[B])(
+  override final def bracket[A, B](acquire: Task[A])(use: A => Task[B])(
     release: A => Task[Unit]
   ): Task[B] =
     IO.bracket(acquire)(release(_).orDie)(use)
 
-  override def bracketCase[A, B](
+  override final def bracketCase[A, B](
     acquire: Task[A]
   )(use: A => Task[B])(release: (A, ExitCase[Throwable]) => Task[Unit]): Task[B] =
     IO.bracket0[Throwable, A, B](acquire) { (a, exit) =>
@@ -185,15 +180,15 @@ private class CatsEffect extends CatsMonadError[Throwable] with Effect[Task] wit
   override def uncancelable[A](fa: Task[A]): Task[A] =
     fa.uninterruptible
 
-  override def guarantee[A](fa: Task[A])(finalizer: Task[Unit]): Task[A] =
+  override final def guarantee[A](fa: Task[A])(finalizer: Task[Unit]): Task[A] =
     fa.ensuring(finalizer.orDie)
 }
 
 private class CatsMonad[E] extends Monad[IO[E, ?]] {
-  override def pure[A](a: A): IO[E, A]                                 = IO.succeed(a)
-  override def map[A, B](fa: IO[E, A])(f: A => B): IO[E, B]            = fa.map(f)
-  override def flatMap[A, B](fa: IO[E, A])(f: A => IO[E, B]): IO[E, B] = fa.flatMap(f)
-  override def tailRecM[A, B](a: A)(f: A => IO[E, Either[A, B]]): IO[E, B] =
+  override final def pure[A](a: A): IO[E, A]                                 = IO.succeed(a)
+  override final def map[A, B](fa: IO[E, A])(f: A => B): IO[E, B]            = fa.map(f)
+  override final def flatMap[A, B](fa: IO[E, A])(f: A => IO[E, B]): IO[E, B] = fa.flatMap(f)
+  override final def tailRecM[A, B](a: A)(f: A => IO[E, Either[A, B]]): IO[E, B] =
     f(a).flatMap {
       case Left(l)  => tailRecM(l)(f)
       case Right(r) => IO.succeed(r)
@@ -201,27 +196,27 @@ private class CatsMonad[E] extends Monad[IO[E, ?]] {
 }
 
 private class CatsMonadError[E] extends CatsMonad[E] with MonadError[IO[E, ?], E] {
-  override def handleErrorWith[A](fa: IO[E, A])(f: E => IO[E, A]): IO[E, A] = fa.catchAll(f)
-  override def raiseError[A](e: E): IO[E, A]                                = IO.fail(e)
+  override final def handleErrorWith[A](fa: IO[E, A])(f: E => IO[E, A]): IO[E, A] = fa.catchAll(f)
+  override final def raiseError[A](e: E): IO[E, A]                                = IO.fail(e)
 }
 
 /** lossy, throws away errors using the "first success" interpretation of SemigroupK */
 private trait CatsSemigroupK[E] extends SemigroupK[IO[E, ?]] {
-  override def combineK[A](a: IO[E, A], b: IO[E, A]): IO[E, A] = a.orElse(b)
+  override final def combineK[A](a: IO[E, A], b: IO[E, A]): IO[E, A] = a.orElse(b)
 }
 
 private class CatsAlternative[E: Monoid] extends CatsMonadError[E] with Alternative[IO[E, ?]] {
-  override def combineK[A](a: IO[E, A], b: IO[E, A]): IO[E, A] =
+  override final def combineK[A](a: IO[E, A], b: IO[E, A]): IO[E, A] =
     a.catchAll { e1 =>
       b.catchAll { e2 =>
         IO.fail(Monoid[E].combine(e1, e2))
       }
     }
-  override def empty[A]: IO[E, A] = raiseError(Monoid[E].empty)
+  override final def empty[A]: IO[E, A] = raiseError(Monoid[E].empty)
 }
 
 trait CatsBifunctor extends Bifunctor[IO] {
-  override def bimap[A, B, C, D](fab: IO[A, B])(f: A => C, g: B => D): IO[C, D] =
+  override final def bimap[A, B, C, D](fab: IO[A, B])(f: A => C, g: B => D): IO[C, D] =
     fab.bimap(f, g)
 }
 

--- a/interop-cats/jvm/src/test/scala/scalaz/zio/interop/Fs2ZioSpec.scala
+++ b/interop-cats/jvm/src/test/scala/scalaz/zio/interop/Fs2ZioSpec.scala
@@ -13,7 +13,8 @@ import scala.concurrent.ExecutionContext.global
 
 class ZioWithFs2Spec(implicit ee: ExecutionEnv) extends Specification with AroundTimeout with RTS {
 
-  def is = s2"""
+  def is = s2"""et
+
   fs2 parJoin must
     work if `F` is `cats.effect.IO`          ${simpleJoin(fIsCats)}
     work if `F` is `scalaz.zio.interop.Task` ${simpleJoin(fIsZio)}

--- a/interop-cats/jvm/src/test/scala/scalaz/zio/interop/Fs2ZioSpec.scala
+++ b/interop-cats/jvm/src/test/scala/scalaz/zio/interop/Fs2ZioSpec.scala
@@ -14,10 +14,13 @@ import scala.concurrent.ExecutionContext.global
 
 class ZioWithFs2Spec(implicit ee: ExecutionEnv) extends Specification with AroundTimeout with RTS {
 
-  def is = s2"""
+  def is =
+    s2"""
   fs2 parJoin must
     work if `F` is `cats.effect.IO`          ${simpleJoin(fIsCats)}
-    DOES NOT work currently on fs2-1.0.2 if `F` is `scalaz.zio.interop.Task` - ${expectTimeoutFailure(simpleJoin(fIsZio))}
+    DOES NOT work currently on fs2-1.0.2 if `F` is `scalaz.zio.interop.Task` - ${expectTimeoutFailure(
+      simpleJoin(fIsZio)
+    )}
 
   fs2 resource handling must
     work when fiber is failed                $bracketFail

--- a/interop-cats/jvm/src/test/scala/scalaz/zio/interop/catzSpec.scala
+++ b/interop-cats/jvm/src/test/scala/scalaz/zio/interop/catzSpec.scala
@@ -3,16 +3,16 @@ package interop
 
 import cats.Eq
 import cats.effect.concurrent.Deferred
-import cats.effect.{ConcurrentEffect, ContextShift}
+import cats.effect.{ ConcurrentEffect, ContextShift }
 import cats.effect.laws.ConcurrentEffectLaws
 import cats.effect.laws.discipline.arbitrary._
-import cats.effect.laws.discipline.{ConcurrentEffectTests, ConcurrentTests, EffectTests, Parameters}
-import cats.effect.laws.util.{TestContext, TestInstances}
-import cats.laws.discipline.{AlternativeTests, BifunctorTests, MonadErrorTests, ParallelTests, SemigroupKTests}
+import cats.effect.laws.discipline.{ ConcurrentEffectTests, ConcurrentTests, EffectTests, Parameters }
+import cats.effect.laws.util.{ TestContext, TestInstances }
+import cats.laws.discipline.{ AlternativeTests, BifunctorTests, MonadErrorTests, ParallelTests, SemigroupKTests }
 import cats.implicits._
-import org.scalacheck.{Arbitrary, Cogen}
+import org.scalacheck.{ Arbitrary, Cogen }
 import org.scalatest.prop.Checkers
-import org.scalatest.{BeforeAndAfterAll, FunSuite, Matchers}
+import org.scalatest.{ BeforeAndAfterAll, FunSuite, Matchers }
 import org.typelevel.discipline.Laws
 import org.typelevel.discipline.scalatest.Discipline
 import scalaz.zio.interop.catz._
@@ -28,7 +28,7 @@ trait ConcurrentEffectLawsOverrides[F[_]] extends ConcurrentEffectLaws[F] {
     val lh = Deferred.uncancelable[F, Unit].flatMap { release =>
       val latch = Promise[Unit]()
       // Never ending task
-      val ff = F.cancelable[A] {_ =>
+      val ff = F.cancelable[A] { _ =>
 //          F.runAsync(started.complete(()))(_ => IO.unit).unsafeRunSync()
         latch.success(()); release.complete(())
       }
@@ -50,7 +50,7 @@ object IOConcurrentEffectTests {
     new ConcurrentEffectTests[Task] {
       def laws =
         new ConcurrentEffectLaws[Task] with ConcurrentEffectLawsOverrides[Task] {
-          override val F: ConcurrentEffect[Task] = ce
+          override val F: ConcurrentEffect[Task]        = ce
           override val contextShift: ContextShift[Task] = cs
         }
     }

--- a/interop-cats/jvm/src/test/scala/scalaz/zio/interop/catzSpec.scala
+++ b/interop-cats/jvm/src/test/scala/scalaz/zio/interop/catzSpec.scala
@@ -97,17 +97,8 @@ class catzSpec
       }
     }
 
-//  (1 to 50).foreach { s =>
-//    checkAllAsync(
-//      s"ConcurrentEffect[Task] $s",
-//      implicit tctx => {
-//
-//        IOConcurrentEffectTests().concurrentEffect[Int, Int, Int]
-//      }
-//    )
-//  }
-  checkAllAsync(s"ConcurrentEffect[Task]", implicit tctx => IOConcurrentEffectTests().concurrentEffect[Int, Int, Int])
   // TODO: reintroduce repeated ConcurrentTests as they're removed due to the hanging CI builds (see https://github.com/scalaz/scalaz-zio/pull/482)
+  checkAllAsync(s"ConcurrentEffect[Task]", implicit tctx => IOConcurrentEffectTests().concurrentEffect[Int, Int, Int])
   checkAllAsync("Concurrent[Task]", (_) => ConcurrentTests[Task].concurrent[Int, Int, Int])
   checkAllAsync("Effect[Task]", implicit tctx => EffectTests[Task].effect[Int, Int, Int])
   checkAllAsync("MonadError[IO[Int, ?]]", (_) => MonadErrorTests[IO[Int, ?], Int].monadError[Int, Int, Int])


### PR DESCRIPTION
There are two blockers right now as I can see it:
1. ZIO can't pass `runCancelableIsSynchronous` test because of its inability to guarantee that async canceler will be run in `async0(...).fork.interrupt` – the fiber will be killed *before* `async0` is executed. For cats-effect model this is nonsense, since async action itself provides the cancel ability, not the fiber, a 'Fiber' can't exist before the canceler exists, unlike in ZIO.
2. We fail `runAsyncRunCancelableCoherence` and all of `toIO` consistency tests because from what I can see the cats-IO Eq instance checks whether the number of spawned tasks is the same for both computations – which is never the case in ZIO as `runCancelable` adds an additional fork. Replacing Eq instance with a coarse `eqv(x.unsafeRunSync(), y.unsafeRunSync())` smoothes some of that.

Minor:
`runCancelableStartCancelCoherence` freezes 90% of the time - seems like a regression from about a week ago when it passed constistently, I did not have time to investigate further, sorry.

@jdegoes @alexandru Thoughts?