### PR TITLE
Add tests to StreamChunk and StreamChunkPure

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/stream/ArbitraryStream.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/stream/ArbitraryStream.scala
@@ -7,22 +7,34 @@ import scala.reflect.ClassTag
 
 object ArbitraryStream {
 
-  implicit def arbStream[T: ClassTag](implicit a: Arbitrary[T]): Arbitrary[Stream[String, T]] =
+  implicit def arbStream[T: ClassTag: Arbitrary]: Arbitrary[Stream[String, T]] =
     Arbitrary {
-      val failingStream: Gen[Stream[String, T]] =
-        for {
-          it <- Arbitrary.arbitrary[List[T]]
-          n  <- Gen.choose(0, it.size)
-        } yield
-          Stream.unfoldM((n, it)) {
-            case (_, Nil) | (0, _) =>
-              IO.fail("fail-case")
-            case (n, head :: rest) => IO.now(Some((head, (n - 1, rest))))
-          }
+      val failingStream: Gen[Stream[String, T]] = genFailingStream
 
-      val succeedingStream: Gen[Stream[String, T]] =
-        for (it <- Arbitrary.arbitrary[Iterable[T]]) yield Stream.fromIterable(it)
+      val succeedingStream: Gen[Stream[String, T]] = genPureStream
 
       Gen.oneOf(failingStream, succeedingStream)
     }
+
+  def genPureStream[T: ClassTag: Arbitrary]: Gen[StreamPure[T]] =
+    Arbitrary.arbitrary[Iterable[T]].map(StreamPure.fromIterable)
+
+  def genSucceededStream[T: ClassTag: Arbitrary]: Gen[Stream[Nothing, T]] =
+    Arbitrary.arbitrary[List[T]].map { xs =>
+      Stream.unfoldM[List[T], Nothing, T](xs) {
+        case head :: tail => IO.now(Some(head -> tail))
+        case _            => IO.now(None)
+      }
+    }
+
+  def genFailingStream[T: ClassTag: Arbitrary]: Gen[Stream[String, T]] =
+    for {
+      it <- Arbitrary.arbitrary[List[T]]
+      n  <- Gen.choose(0, it.size)
+    } yield
+      Stream.unfoldM((n, it)) {
+        case (_, Nil) | (0, _) =>
+          IO.fail("fail-case")
+        case (n, head :: rest) => IO.now(Some((head, (n - 1, rest))))
+      }
 }

--- a/core/jvm/src/test/scala/scalaz/zio/stream/ArbitraryStreamChunk.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/stream/ArbitraryStreamChunk.scala
@@ -1,0 +1,28 @@
+package scalaz.zio.stream
+
+import org.scalacheck.Arbitrary
+
+import scala.reflect.ClassTag
+import ArbitraryChunk._
+import ArbitraryStream._
+import org.scalacheck.Gen
+
+object ArbitraryStreamChunk {
+
+  implicit def arbStreamChunk[T: ClassTag: Arbitrary]: Arbitrary[StreamChunk[String, T]] =
+    Arbitrary {
+      Gen.oneOf(
+        genFailingStream[Chunk[T]].map(StreamChunk(_)),
+        genPureStream[Chunk[T]].map(StreamChunkPure(_)),
+        genSucceededStream[Chunk[T]].map(StreamChunk(_))
+      )
+    }
+
+  implicit def arbSucceededStreamChunk[T: ClassTag: Arbitrary]: Arbitrary[StreamChunk[Nothing, T]] =
+    Arbitrary {
+      Gen.oneOf(
+        genPureStream[Chunk[T]].map(StreamChunkPure(_)),
+        genSucceededStream[Chunk[T]].map(StreamChunk(_))
+      )
+    }
+}

--- a/core/jvm/src/test/scala/scalaz/zio/stream/StreamChunkSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/stream/StreamChunkSpec.scala
@@ -1,0 +1,199 @@
+package scalaz.zio.stream
+
+import org.specs2.ScalaCheck
+import org.specs2.scalacheck.Parameters
+
+import scala.{ Stream => _ }
+import scala.concurrent.duration._
+import scalaz.zio.{ AbstractRTSSpec, ExitResult, GenIO, IO }
+
+import scala.annotation.tailrec
+
+class StreamChunkSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
+    extends AbstractRTSSpec
+    with GenIO
+    with ScalaCheck {
+
+  override val DefaultTimeout = 20.seconds
+
+  implicit val params = Parameters(maxSize = 10)
+
+  def is = "StreamChunkSpec".title ^ s2"""
+  StreamChunk.map           $map
+  StreamChunk.filter        $filter
+  StreamChunk.filterNot     $filterNot
+  StreamChunk.mapConcat     $mapConcat
+  StreamChunk.dropWhile     $dropWhile
+  StreamChunk.takeWhile     $takeWhile
+  StreamChunk.mapAccum      $mapAccum
+  StreamChunk.mapM          $mapM
+  StreamChunk.++            $concat
+  StreamChunk.zipWithIndex  $zipWithIndex
+  StreamChunk.foreach0      $foreach0
+  StreamChunk.foreach       $foreach
+  StreamChunk.monadLaw1     $monadLaw1
+  StreamChunk.monadLaw2     $monadLaw2
+  StreamChunk.monadLaw3     $monadLaw3
+  StreamChunk.withEffect    $withEffect
+  StreamChunk.foldLeft      $foldLeft
+  StreamChunk.foldLazy      $foldLazy
+  StreamChunk.flattenChunks $flattenChunks
+  """
+
+  import ArbitraryStreamChunk._
+  import ExitResult._
+
+  private def slurp[E, A](s: StreamChunk[E, A]): ExitResult[E, Seq[A]] = s match {
+    case s: StreamChunkPure[A] =>
+      succeeded(
+        s.chunks.foldPureLazy(Chunk.empty: Chunk[A])(_ => true)((acc, el) => acc ++ el).toSeq
+      )
+    case s => slurpM(s)
+  }
+
+  private def slurpM[E, A](s: StreamChunk[E, A]): ExitResult[E, Seq[A]] =
+    unsafeRunSync {
+      s.foldLazyChunks(Chunk.empty: Chunk[A])(_ => true)((acc, el) => IO.now(acc ++ el)).map(_.toSeq)
+    }
+
+  private def map =
+    prop { (s: StreamChunk[String, String], f: String => Int) =>
+      slurp(s.map(f)) must_=== slurp(s).map(_.map(f))
+    }
+
+  private def filter =
+    prop { (s: StreamChunk[String, String], p: String => Boolean) =>
+      slurp(s.filter(p)) must_=== slurp(s).map(_.filter(p))
+    }
+
+  private def filterNot =
+    prop { (s: StreamChunk[String, String], p: String => Boolean) =>
+      slurp(s.filterNot(p)) must_=== slurp(s).map(_.filterNot(p))
+    }
+
+  private def mapConcat = {
+    import ArbitraryChunk._
+    prop { (s: StreamChunk[String, String], f: String => Chunk[Int]) =>
+      slurp(s.mapConcat(f)) must_=== slurp(s).map(_.flatMap(v => f(v).toSeq))
+    }
+  }
+
+  private def dropWhile =
+    prop { (s: StreamChunk[String, String], p: String => Boolean) =>
+      slurp(s.dropWhile(p)) must_=== slurp(s).map(_.dropWhile(p))
+    }
+
+  private def takeWhile =
+    prop { (s: StreamChunk[Nothing, String], p: String => Boolean) =>
+      val streamTakeWhile = slurp(s.takeWhile(p))
+      val listTakeWhile   = slurp(s).map(_.takeWhile(p))
+      streamTakeWhile must_=== listTakeWhile
+    }
+
+  private def concat =
+    prop { (s1: StreamChunk[String, String], s2: StreamChunk[String, String]) =>
+      val listConcat = for {
+        left  <- slurp(s1)
+        right <- slurp(s2)
+      } yield left ++ right
+      val streamConcat = slurpM(s1 ++ s2)
+      streamConcat must_=== listConcat
+    }
+
+  private def zipWithIndex =
+    prop((s: StreamChunk[String, String]) => slurp(s.zipWithIndex) must_=== slurp(s).map(_.zipWithIndex))
+
+  private def mapAccum =
+    prop { s: StreamChunk[String, Int] =>
+      val slurped = slurpM(s.mapAccum(0)((acc, el) => (acc + el, acc + el)))
+      slurped must_=== slurp(s).map(_.scan(0)((acc, el) => acc + el).drop(1))
+    }
+
+  private def mapM =
+    prop { (s: StreamChunk[String, Int], f: Int => Int) =>
+      slurpM(s.mapM(a => IO.now(f(a)))) must_=== slurp(s).map(_.map(f))
+    }
+
+  private def foreach0 =
+    prop { (s: StreamChunk[String, Int], cont: Int => Boolean) =>
+      var acc = List[Int]()
+
+      val result = unsafeRunSync {
+        s.foreach0 { a =>
+          IO.sync {
+            if (cont(a)) {
+              acc ::= a
+              true
+            } else false
+          }
+        }
+      }
+
+      result.map(_ => acc.reverse) must_=== slurp(s.takeWhile(cont)).map(_.toList)
+    }
+
+  private def foreach =
+    prop { s: StreamChunk[String, Int] =>
+      var acc = List[Int]()
+
+      val result = unsafeRunSync {
+        s.foreach(a => IO.sync(acc ::= a))
+      }
+
+      result.map(_ => acc.reverse) must_=== slurp(s).map(_.toList)
+    }
+
+  private def monadLaw1 =
+    prop(
+      (x: Int, f: Int => StreamChunk[String, Int]) => slurp(StreamChunk.point(Chunk(x)).flatMap(f)) must_=== slurp(f(x))
+    )
+
+  private def monadLaw2 =
+    prop((m: StreamChunk[String, Int]) => slurp(m.flatMap(i => StreamChunk.point(Chunk(i)))) must_=== slurp(m))
+
+  private def monadLaw3 =
+    prop { (m: StreamChunk[String, Int], f: Int => StreamChunk[String, Int], g: Int => StreamChunk[String, Int]) =>
+      val leftStream  = m.flatMap(f).flatMap(g)
+      val rightStream = m.flatMap(x => f(x).flatMap(g))
+      slurp(leftStream) must_=== slurp(rightStream)
+    }
+
+  private def withEffect =
+    prop { (s: StreamChunk[String, String]) =>
+      val withoutEffect = slurp(s)
+      var acc           = List[String]()
+      val withEffect    = slurp(s.withEffect(a => IO.sync(acc ::= a)))
+
+      (withEffect must_=== withoutEffect) and
+        ((Succeeded(acc.reverse) must_== withoutEffect) when withoutEffect.succeeded)
+    }
+
+  private def foldLeft =
+    prop { (s: StreamChunk[String, String], zero: Int, f: (Int, String) => Int) =>
+      unsafeRunSync(s.foldLeft(zero)(f)) must_=== slurp(s).map(_.foldLeft(zero)(f))
+    }
+
+  private def foldLazy =
+    prop { (s: StreamChunk[Nothing, String], zero: Int, cont: Int => Boolean, f: (Int, String) => Int) =>
+      val streamResult = unsafeRunSync(s.foldLazy(zero)(cont)((acc, a) => IO.now(f(acc, a))))
+      val listResult   = slurp(s).map(l => foldLazyList(l.toList, zero)(cont)(f))
+      streamResult must_=== listResult
+    }
+
+  private def foldLazyList[S, T](list: List[T], zero: S)(cont: S => Boolean)(f: (S, T) => S): S = {
+    @tailrec
+    def loop(xs: List[T], state: S): S = xs match {
+      case head :: tail if cont(state) => loop(tail, f(state, head))
+      case _                           => state
+    }
+    loop(list, zero)
+  }
+
+  private def flattenChunks =
+    prop { (s: StreamChunk[String, String]) =>
+      val result = unsafeRunSync {
+        s.flattenChunks.foldLeft[String, List[String]](Nil)((acc, a) => a :: acc).map(_.reverse)
+      }
+      result must_== slurp(s)
+    }
+}

--- a/core/shared/src/main/scala/scalaz/zio/stream/Chunk.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/Chunk.scala
@@ -422,7 +422,8 @@ sealed trait Chunk[@specialized +A] { self =>
     var i            = 0
 
     while (i < len) {
-      io = io *> f(self(i))
+      val a = self(i)
+      io = io *> f(a)
       i += 1
     }
 

--- a/core/shared/src/main/scala/scalaz/zio/stream/Chunk.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/Chunk.scala
@@ -393,13 +393,14 @@ sealed trait Chunk[@specialized +A] { self =>
     var i                      = 0
 
     while (i < len) {
-      array = array.seqWith(f(self.apply(i))) { (array, b) =>
+      val j = i
+      array = array.seqWith(f(self(j))) { (array, b) =>
         val array2 = if (array == null) {
           implicit val B: ClassTag[B] = Chunk.Tags.fromValue(b)
           Array.ofDim[B](len)
         } else array
 
-        array2(i) = b
+        array2(j) = b
         array2
       }
 

--- a/core/shared/src/main/scala/scalaz/zio/stream/StreamChunk.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/StreamChunk.scala
@@ -76,7 +76,7 @@ trait StreamChunk[+E, @specialized +A] { self =>
             val remaining = as.takeWhile(pred)
 
             if (remaining.length == as.length) f(s._2, as).map(true -> _)
-            else f(s._2, as).map(false                              -> _)
+            else f(s._2, remaining).map(false                       -> _)
           }
           .map(_._2.asInstanceOf[S]) // Cast is redundant but unfortunately necessary to appease Scala 2.11
     })


### PR DESCRIPTION
Closes #430 

Add tests to StreamChunk and StreamChunkPure.

The PR also includes some fixes:

 * `Chunk.traverse_`
 * `Chunk.traverse`
 * `StreamChunk.takeWhile`

And a refactoring to ease creation of pure chunked streams.

The PR does not contains test to `StreamChunk.toQueue` because a [race condition](https://github.com/scalaz/scalaz-zio/issues/447) on the queue prevented me from making the test pass.