### PR TITLE
Fix stream benchmarks

### DIFF
--- a/benchmarks/src/main/scala/scalaz/zio/StreamBenchmarks.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/StreamBenchmarks.scala
@@ -145,8 +145,8 @@ class CSVStreamBenchmarks {
     val chunks = genCsvChunks.map(FS2Chunk.array(_))
     val stream = FS2Stream(chunks: _*)
       .flatMap(FS2Stream.chunk(_))
-      .scan((Vector.empty[Char], Vector.empty[CSV.Token])) {
-        case ((acc, _), char) =>
+      .mapAccumulate(Vector.empty[Char]) {
+        case (acc, char) =>
           if (char == CSV.ColumnSep) {
             Vector.empty[Char] ->
               ((if (acc.length > 0)

--- a/benchmarks/src/main/scala/scalaz/zio/StreamBenchmarks.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/StreamBenchmarks.scala
@@ -134,7 +134,7 @@ class CSVStreamBenchmarks {
                 Vector(CSV.NewCol))
           } else (acc :+ char) -> Vector.empty[CSV.Token]
       }
-      .flatMapConcat(t => AkkaSource(t._2))
+      .mapConcat(t => t._2)
       .toMat(AkkaSink.ignore)(Keep.right)
 
     Await.result(program.run, Duration.Inf)

--- a/benchmarks/src/main/scala/scalaz/zio/StreamBenchmarks.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/StreamBenchmarks.scala
@@ -36,9 +36,9 @@ class StreamBenchmarks {
 
   @Benchmark
   def akkaChunkFilterMapSum = {
-    val chunks = (1 to chunkCount).flatMap(i => Array.fill(chunkSize)(i))
+    val chunks = (1 to chunkCount).map(i => Array.fill(chunkSize)(i))
     val program = AkkaSource
-      .fromIterator(() => chunks.iterator)
+      .fromIterator(() => chunks.iterator.flatten)
       .filter(_ % 2 == 0)
       .map(_.toLong)
       .toMat(AkkaSink.fold(0L)(_ + _))(Keep.right)
@@ -117,7 +117,7 @@ class CSVStreamBenchmarks {
     val chunks = genCsvChunks
 
     val program = AkkaSource
-      .fromIterator(() => chunks.flatten.iterator)
+      .fromIterator(() => chunks.iterator.flatten)
       .scan((Vector.empty[Char], Vector.empty[CSV.Token])) {
         case ((acc, _), char) =>
           if (char == CSV.ColumnSep) {


### PR DESCRIPTION
The Akka/FS2 stream benchmarks were not using the same/equivalent operations as ZIO, even though some of them were supported (namely, `mapConcat` and `mapAccum`).

I also changed the way chunks were handled on the Akka-Streams benchmarks to use `map` instead of `flatMap`. That seems closer to the way the other benchmarks handle the input.
`(1 to chunkCount).flatMap(i => Array.fill(chunkSize)(i))` was creating a new huge vector, and that creation actually took more time than the FS2/ZIO benchmarks 😅.

Benchmark results on my PC:

```
jmh:run scalaz.zio.StreamBenchmarks -i 5 -wi 5 -f 1 -t 1

Benchmark                                      (chunkCount)  (chunkSize)   Mode  Cnt  Score   Error  Units
StreamBenchmarks.akkaChunkFilterMapSum                10000         5000  thrpt    5  0.154 ± 0.035  ops/s
StreamBenchmarks.akkaChunkFilterMapSumNew             10000         5000  thrpt    5  0.254 ± 0.008  ops/s
StreamBenchmarks.fs2ChunkFilterMapSum                 10000         5000  thrpt    5  0.846 ± 0.034  ops/s
StreamBenchmarks.scalazChunkChunkFilterMapSum         10000         5000  thrpt    5  1.956 ± 0.049  ops/s
StreamBenchmarks.scalazChunkFilterMapSum              10000         5000  thrpt    5  1.851 ± 0.056  ops/s

jmh:run scalaz.zio.CSVStreamBenchmarks -i 5 -wi 5 -f 1 -t 1

Benchmark                               (chunkSize)  (cols)  (rows)   Mode  Cnt   Score   Error  Units
CSVStreamBenchmarks.akkaCsvTokenize            5000     100     100  thrpt    5   0.531 ± 0.002  ops/s
CSVStreamBenchmarks.akkaCsvTokenizeNew         5000     100     100  thrpt    5  11.185 ± 0.118  ops/s
CSVStreamBenchmarks.fs2CsvTokenize             5000     100     100  thrpt    5   6.119 ± 1.473  ops/s
CSVStreamBenchmarks.fs2CsvTokenizeNew          5000     100     100  thrpt    5   6.169 ± 0.120  ops/s
CSVStreamBenchmarks.scalazCsvTokenize          5000     100     100  thrpt    5  23.673 ± 0.381  ops/s
```

**Side-note**: I could have used Akka's `statefulMapConcat` as an alternative to `mapAccum` (https://gist.github.com/JD557/9756e4a97bc103122f72ecfd07e69a1f), but I wanted to keep code changes between implementations to a minimum.