### PR TITLE
Return asynchronous toIO & liftIO in catz

### DIFF
--- a/interop-cats/jvm/src/test/scala/scalaz/zio/interop/catzSpec.scala
+++ b/interop-cats/jvm/src/test/scala/scalaz/zio/interop/catzSpec.scala
@@ -38,6 +38,20 @@ class catzSpec
       }
   }
 
+  override implicit def eqIO[A](implicit A: Eq[A], ec: TestContext): Eq[cats.effect.IO[A]] =
+    new Eq[cats.effect.IO[A]] {
+      def eqv(x: cats.effect.IO[A], y: cats.effect.IO[A]): Boolean = {
+        val l = x.attempt.unsafeRunSync
+        val r = y.attempt.unsafeRunSync
+
+        (l, r) match {
+          case (Right(l), Right(r)) => A.eqv(l, r)
+          case (Left(l), Left(r))   => l == r
+          case _                    => false
+        }
+      }
+    }
+
   (1 to 50).foreach { s =>
     checkAllAsync(s"Concurrent[Task] $s", (_) => ConcurrentTests[Task].concurrent[Int, Int, Int])
   }


### PR DESCRIPTION
`IO(unsafeRun(_))` is extremely dangerous (and incorrect) as it will unyieldingly hog up a thread until inner run loop exits. `Concurrent.liftIO` is also required to preserve cancelables captured in cats IO