### PR TITLE
Remove log noise caused by interruptions

### DIFF
--- a/core/jvm/src/main/scala/scalaz/zio/App.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/App.scala
@@ -48,7 +48,7 @@ trait App extends RTS {
         fiber <- run(args0.toList).fork
         _ <- IO.sync(Runtime.getRuntime.addShutdownHook(new Thread {
               override def run() = {
-                val _ = unsafeRun(fiber.interrupt)
+                val _ = unsafeRunSync(fiber.interrupt)
               }
             }))
         result <- fiber.join

--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -1,13 +1,12 @@
 package scalaz.zio
 
-import scalaz.zio.ExitResult.Cause.Interruption
 import scalaz.zio.internal.Env
 
 trait RTS {
   lazy val env =
     Env.newDefaultEnv {
-      case Interruption => IO.unit // do not log interruptions
-      case cause        => IO.sync(println(cause.toString))
+      case cause if cause.interrupted => IO.unit // do not log interruptions
+      case cause                      => IO.sync(println(cause.toString))
     }
 
   final def unsafeRun[E, A](io: IO[E, A]): A =

--- a/core/jvm/src/main/scala/scalaz/zio/RTS.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/RTS.scala
@@ -1,10 +1,14 @@
 package scalaz.zio
 
+import scalaz.zio.ExitResult.Cause.Interruption
 import scalaz.zio.internal.Env
 
 trait RTS {
   lazy val env =
-    Env.newDefaultEnv(cause => IO.sync(println(cause.toString)))
+    Env.newDefaultEnv {
+      case Interruption => IO.unit // do not log interruptions
+      case cause        => IO.sync(println(cause.toString))
+    }
 
   final def unsafeRun[E, A](io: IO[E, A]): A =
     env.unsafeRun(io)


### PR DESCRIPTION
Discussed here: https://github.com/scalaz/scalaz-zio/pull/446#issuecomment-448451895

I also replaced `unsafeRun` by `unsafeRunSync` in the JVM shutdown hook because `unsafeRun` throws and will cause an ugly exception log even though everything was interrupted properly.