### PR TITLE
Replaces IO.now with IO.succeed to fix compilation and documentation

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/IOSyntaxSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/IOSyntaxSpec.scala
@@ -12,7 +12,7 @@ class IOCreationEagerSyntaxSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
 
   def is = "IOEagerSyntaxSpec".title ^ s2"""
    Generate a String:
-      `.now` extension method returns the same IO[Nothing, String] as `IO.now` does. $t1
+      `.succeed` extension method returns the same IO[Nothing, String] as `IO.succeed` does. $t1
    Generate a String:
       `.fail` extension method returns the same IO[String, Nothing] as `IO.fail` does. $t2
    Generate a String:

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -269,7 +269,7 @@ sealed abstract class IO[+E, +A] extends Serializable { self =>
    * }}}
    */
   final def flatMapError[E2](f: E => IO[Nothing, E2]): IO[E2, A] =
-    self.redeem[E2, A](f.andThen(_.flip), IO.now)
+    self.redeem[E2, A](f.andThen(_.flip), IO.succeed)
 
   /**
    *  Swaps the error/value parameters, applies the function `f` and flips the parameters back
@@ -484,7 +484,7 @@ sealed abstract class IO[+E, +A] extends Serializable { self =>
    * Recovers from all errors.
    *
    * {{{
-   * openFile("config.json").catchAll(_ => IO.now(defaultConfig))
+   * openFile("config.json").catchAll(_ => IO.succeed(defaultConfig))
    * }}}
    */
   final def catchAll[E2, A1 >: A](h: E => IO[E2, A1]): IO[E2, A1] =
@@ -747,13 +747,13 @@ sealed abstract class IO[+E, +A] extends Serializable { self =>
    *   veryBadIO.sandboxed.catchAll {
    *     case Left((_: ArithmeticException) :: Nil) =>
    *       // Caught defect: divided by zero!
-   *       IO.now(0)
+   *       IO.succeed(0)
    *     case Left(ts) =>
    *       // Caught unknown defects, shouldn't recover!
    *       IO.terminate0(ts)
    *     case Right(e) =>
    *       // Caught error: DomainError!
-   *      IO.now(0)
+   *      IO.succeed(0)
    *   }
    * }}}
    */
@@ -776,7 +776,7 @@ sealed abstract class IO[+E, +A] extends Serializable { self =>
    *   veryBadIO.sandboxWith(_.catchSome {
    *     case Left((_: ArithmeticException) :: Nil) =>
    *       // Caught defect: divided by zero!
-   *       IO.now(0)
+   *       IO.succeed(0)
    *   })
    * }}}
    *

--- a/core/shared/src/main/scala/scalaz/zio/RefM.scala
+++ b/core/shared/src/main/scala/scalaz/zio/RefM.scala
@@ -13,7 +13,7 @@ import scalaz.zio.Exit.Cause
  * {{{
  * for {
  *   ref <- RefM(2)
- *   v   <- ref.update(_ + putStrLn("Hello World!").attempt.void *> IO.now(3))
+ *   v   <- ref.update(_ + putStrLn("Hello World!").attempt.void *> IO.succeed(3))
  *   _   <- putStrLn("Value = " + v) // Value = 5
  * } yield ()
  * }}}


### PR DESCRIPTION
`now` compilation `succeed`s (pun intended).
Tests are passing.
`sbt fmt` was run ;-)