### PR TITLE
Schedule.fixed should not retry/repeat for first time without interval

### DIFF
--- a/core/shared/src/main/scala/scalaz/zio/Schedule.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Schedule.scala
@@ -673,7 +673,7 @@ object Schedule extends Serializable {
     case Duration.Finite(nanos) if nanos == 0 => forever
     case Duration.Finite(nanos) =>
       Schedule[(Long, Int, Int), Any, Int](
-        _.nanoTime.map(nt => (nt, 0, 0)),
+        _.nanoTime.map(nt => (nt, 1, 0)),
         (_, t, clock) =>
           t match {
             case (start, n0, i) =>


### PR DESCRIPTION
`Schedule.fixed` currently doesn't wait after `IO` to `repeat` succeeds for first time.
Please take a look at this action:
```scala
val printTimeAndSleep: IO[Nothing, Unit] = for {
    ct <- system.currentTime
    _  <- putStrLn(ct.toString)
    _  <- IO.sleep(1.second)
  } yield ()

  val repeatFixed = printTimeAndSleep.repeat(Schedule.recurs(3) && Schedule.fixed(3.seconds))
```

It should print current time with 3 seconds intervals. But second retry runs just after first one finished thus just 1 seconds difference between first two printed timestamps.
```
2019-01-13T21:50:47.502963Z
2019-01-13T21:50:48.616334Z
2019-01-13T21:50:50.463356Z
2019-01-13T21:50:53.461341Z
```
with this fix applied *each* repeat occurs with 3 seconds interval
```
2019-01-13T21:55:54.123109Z
2019-01-13T21:55:57.125840Z
2019-01-13T21:56:00.126953Z
2019-01-13T21:56:03.128195Z
```
Unfortunately there are no `ScheduleSpec` in master yet, so only change is in prod code.

PS Build should be green when master is fixed.