### PR TITLE
Stack safe streams

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/stream/StreamSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/stream/StreamSpec.scala
@@ -193,11 +193,11 @@ class StreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Abstra
 
   private def deepFlatMap = {
     def fib(n: Int): Stream[Nothing, Int] =
-      if (n <= 1) Stream.point(n)
+      if (n <= 1) Stream.succeedLazy(n)
       else
         fib(n - 1).flatMap { a =>
           fib(n - 2).flatMap { b =>
-            Stream.point(a + b)
+            Stream.succeedLazy(a + b)
           }
         }
 

--- a/core/shared/src/main/scala/scalaz/zio/stream/Stream.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/Stream.scala
@@ -148,8 +148,10 @@ trait Stream[+E, +A] { self =>
    * Maps over elements of the stream with the specified function.
    */
   def map[B](f0: A => B): Stream[E, B] = new Stream[E, B] {
-    override def foldLazy[E1 >: E, B1 >: B, S](s: S)(cont: S => Boolean)(f: (S, B1) => IO[E1, S]): IO[E1, S] =
-      self.foldLazy[E1, A, S](s)(cont)((s, a) => f(s, f0(a)))
+    override def fold[E1 >: E, B1 >: B, S]: Fold[E1, B1, S] =
+      IO.point { (s, cont, f) =>
+        self.fold[E1, A, S].flatMap(f1 => f1(s, cont, (s, a) => f(s, f0(a))))
+      }
   }
 
   /**

--- a/core/shared/src/main/scala/scalaz/zio/stream/Stream.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/Stream.scala
@@ -194,46 +194,47 @@ trait Stream[+E, +A] { self =>
    */
   final def mergeWith[E1 >: E, B, C](that: Stream[E1, B], capacity: Int = 1)(l: A => C, r: B => C): Stream[E1, C] =
     new Stream[E1, C] {
-      override def foldLazy[E2 >: E1, C1 >: C, S](s: S)(cont: S => Boolean)(f: (S, C1) => IO[E2, S]): IO[E2, S] = {
-        type Elem = Either[Take[E2, A], Take[E2, B]]
+      override def fold[E2 >: E1, C1 >: C, S]: Fold[E2, C1, S] =
+        IO.point { (s, cont, f) =>
+          type Elem = Either[Take[E2, A], Take[E2, B]]
 
-        def loop(leftDone: Boolean, rightDone: Boolean, s: S, queue: Queue[Elem]): IO[E2, S] =
-          queue.take.flatMap {
-            case Left(Take.Fail(e))  => IO.fail(e)
-            case Right(Take.Fail(e)) => IO.fail(e)
-            case Left(Take.End) =>
-              if (rightDone) IO.succeed(s)
-              else loop(true, rightDone, s, queue)
-            case Left(Take.Value(a)) =>
-              f(s, l(a)).flatMap { s =>
-                if (cont(s)) loop(leftDone, rightDone, s, queue)
-                else IO.succeed(s)
-              }
-            case Right(Take.End) =>
-              if (leftDone) IO.succeed(s)
-              else loop(leftDone, true, s, queue)
-            case Right(Take.Value(b)) =>
-              f(s, r(b)).flatMap { s =>
-                if (cont(s)) loop(leftDone, rightDone, s, queue)
-                else IO.succeed(s)
-              }
-          }
+          def loop(leftDone: Boolean, rightDone: Boolean, s: S, queue: Queue[Elem]): IO[E2, S] =
+            queue.take.flatMap {
+              case Left(Take.Fail(e))  => IO.fail(e)
+              case Right(Take.Fail(e)) => IO.fail(e)
+              case Left(Take.End) =>
+                if (rightDone) IO.succeed(s)
+                else loop(true, rightDone, s, queue)
+              case Left(Take.Value(a)) =>
+                f(s, l(a)).flatMap { s =>
+                  if (cont(s)) loop(leftDone, rightDone, s, queue)
+                  else IO.succeed(s)
+                }
+              case Right(Take.End) =>
+                if (leftDone) IO.succeed(s)
+                else loop(leftDone, true, s, queue)
+              case Right(Take.Value(b)) =>
+                f(s, r(b)).flatMap { s =>
+                  if (cont(s)) loop(leftDone, rightDone, s, queue)
+                  else IO.succeed(s)
+                }
+            }
 
-        if (cont(s)) {
-          (for {
-            queue  <- Queue.bounded[Elem](capacity)
-            putL   = (a: A) => queue.offer(Left(Take.Value(a))).void
-            putR   = (b: B) => queue.offer(Right(Take.Value(b))).void
-            catchL = (e: E2) => queue.offer(Left(Take.Fail(e)))
-            catchR = (e: E2) => queue.offer(Right(Take.Fail(e)))
-            endL   = queue.offer(Left(Take.End))
-            endR   = queue.offer(Right(Take.End))
-            _      <- (self.foreach(putL) *> endL).catchAll(catchL).fork
-            _      <- (that.foreach(putR) *> endR).catchAll(catchR).fork
-            step   <- loop(false, false, s, queue)
-          } yield step).supervise
-        } else IO.succeed(s)
-      }
+          if (cont(s)) {
+            (for {
+              queue  <- Queue.bounded[Elem](capacity)
+              putL   = (a: A) => queue.offer(Left(Take.Value(a))).void
+              putR   = (b: B) => queue.offer(Right(Take.Value(b))).void
+              catchL = (e: E2) => queue.offer(Left(Take.Fail(e)))
+              catchR = (e: E2) => queue.offer(Right(Take.Fail(e)))
+              endL   = queue.offer(Left(Take.End))
+              endR   = queue.offer(Right(Take.End))
+              _      <- (self.foreach(putL) *> endL).catchAll(catchL).fork
+              _      <- (that.foreach(putR) *> endR).catchAll(catchR).fork
+              step   <- loop(false, false, s, queue)
+            } yield step).supervised
+          } else IO.succeed(s)
+        }
     }
 
   /**

--- a/core/shared/src/main/scala/scalaz/zio/stream/Stream.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/Stream.scala
@@ -37,8 +37,8 @@ trait Stream[+E, +A] { self =>
       override def fold[E2 >: E1, A2 >: A1, S]: Fold[E2, A2, S] =
         IO.succeedLazy { (s, cont, f) =>
           self.fold[E2, A, S].flatMap { f0 =>
-            f0(s, cont, f).flatMap { s0 =>
-              if (cont(s0)) that.fold[E2, A1, S].flatMap(f1 => f1(s0, cont, f))
+            f0(s, cont, f).flatMap { s =>
+              if (cont(s)) that.fold[E2, A1, S].flatMap(f1 => f1(s, cont, f))
               else IO.succeed(s)
             }
           }

--- a/core/shared/src/main/scala/scalaz/zio/stream/Stream.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/Stream.scala
@@ -161,9 +161,7 @@ trait Stream[+E, +A] { self =>
   def mapConcat[B](f0: A => Chunk[B]): Stream[E, B] = new Stream[E, B] {
     override def fold[E1 >: E, B1 >: B, S]: Fold[E1, B1, S] =
       IO.point { (s, cont, f) =>
-        self.fold[E1, A, S].flatMap { f1 =>
-          f1(s, cont, (s, a) => f0(a).foldMLazy(s)(cont)(f))
-        }
+        self.fold[E1, A, S].flatMap(f1 => f1(s, cont, (s, a) => f0(a).foldMLazy(s)(cont)(f)))
       }
   }
 
@@ -171,8 +169,10 @@ trait Stream[+E, +A] { self =>
    * Maps over elements of the stream with the specified effectful function.
    */
   final def mapM[E1 >: E, B](f0: A => IO[E1, B]): Stream[E1, B] = new Stream[E1, B] {
-    override def foldLazy[E2 >: E1, B1 >: B, S](s: S)(cont: S => Boolean)(f: (S, B1) => IO[E2, S]): IO[E2, S] =
-      self.foldLazy[E2, A, S](s)(cont)((s, a) => f0(a).flatMap(f(s, _)))
+    override def fold[E2 >: E1, B1 >: B, S]: Fold[E2, B1, S] =
+      IO.point { (s, cont, f) =>
+        self.fold[E2, A, S].flatMap(f1 => f1(s, cont, (s, a) => f0(a).flatMap(f(s, _))))
+      }
   }
 
   /**

--- a/core/shared/src/main/scala/scalaz/zio/stream/Stream.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/Stream.scala
@@ -56,7 +56,6 @@ trait Stream[+E, +A] { self =>
           f0(s, cont, (s, a) => if (pred(a)) f(s, a) else IO.succeed(s))
         }
       }
-    }
   }
 
   /**
@@ -70,6 +69,7 @@ trait Stream[+E, +A] { self =>
    * and terminating consumption when the callback returns `false`.
    */
   final def foreach0[E1 >: E](f: A => IO[E1, Boolean]): IO[E1, Unit] =
+<<<<<<< HEAD
     self
       .foldLazy[E1, A, Boolean](true)(identity)(
         (cont, a) =>
@@ -77,6 +77,9 @@ trait Stream[+E, +A] { self =>
           else IO.succeed(cont)
       )
       .void
+=======
+    self.fold[E1, A, Boolean].flatMap(f0 => f0(true, identity, (cont, a) => if (cont) f(a) else IO.now(cont))).void
+>>>>>>> Implement Stream.foreach0 in terms of fold
 
   /**
    * Performs a filter and map in a single step.

--- a/core/shared/src/main/scala/scalaz/zio/stream/Stream.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/Stream.scala
@@ -159,8 +159,12 @@ trait Stream[+E, +A] { self =>
    * this stream.
    */
   def mapConcat[B](f0: A => Chunk[B]): Stream[E, B] = new Stream[E, B] {
-    override def foldLazy[E1 >: E, B1 >: B, S](s: S)(cont: S => Boolean)(f: (S, B1) => IO[E1, S]): IO[E1, S] =
-      self.foldLazy[E1, A, S](s)(cont)((s, a) => f0(a).foldMLazy(s)(cont)(f))
+    override def fold[E1 >: E, B1 >: B, S]: Fold[E1, B1, S] =
+      IO.point { (s, cont, f) =>
+        self.fold[E1, A, S].flatMap { f1 =>
+          f1(s, cont, (s, a) => f0(a).foldMLazy(s)(cont)(f))
+        }
+      }
   }
 
   /**

--- a/core/shared/src/main/scala/scalaz/zio/stream/Stream.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/Stream.scala
@@ -613,8 +613,10 @@ object Stream {
    */
   final def unwrap[E, A](stream: IO[E, Stream[E, A]]): Stream[E, A] =
     new Stream[E, A] {
-      override def foldLazy[E1 >: E, A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => IO[E1, S]): IO[E1, S] =
-        stream.flatMap(_.foldLazy[E1, A1, S](s)(cont)(f))
+      override def fold[E1 >: E, A1 >: A, S]: Fold[E1, A1, S] =
+        IO.point { (s, cont, f) =>
+          stream.flatMap(_.fold[E1, A1, S].flatMap(f0 => f0(s, cont, f)))
+        }
     }
 
   /**

--- a/core/shared/src/main/scala/scalaz/zio/stream/StreamPure.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/StreamPure.scala
@@ -36,7 +36,7 @@ private[stream] trait StreamPure[+A] extends Stream[Nothing, A] { self =>
       }
 
     override def fold[E, A1 >: A, S]: Stream.Fold[E, A1, S] =
-      IO.point { (s, cont, f) =>
+      IO.succeedLazy { (s, cont, f) =>
         StreamPure.super.filter(pred).fold[E, A1, S].flatMap(f0 => f0(s, cont, f))
       }
   }
@@ -55,7 +55,7 @@ private[stream] trait StreamPure[+A] extends Stream[Nothing, A] { self =>
         ._2
 
     override def fold[E, A1 >: A, S]: Stream.Fold[E, A1, S] =
-      IO.point { (s, cont, f) =>
+      IO.succeedLazy { (s, cont, f) =>
         StreamPure.super.dropWhile(pred).fold[E, A1, S].flatMap(f0 => f0(s, cont, f))
       }
   }
@@ -75,7 +75,7 @@ private[stream] trait StreamPure[+A] extends Stream[Nothing, A] { self =>
         ._2
 
     override def fold[E, A1 >: A, S]: Stream.Fold[E, A1, S] =
-      IO.point { (s, cont, f) =>
+      IO.succeedLazy { (s, cont, f) =>
         StreamPure.super.takeWhile(pred).fold[E, A1, S].flatMap(f0 => f0(s, cont, f))
       }
   }
@@ -85,7 +85,7 @@ private[stream] trait StreamPure[+A] extends Stream[Nothing, A] { self =>
    */
   override def map[B](f0: A => B): StreamPure[B] = new StreamPure[B] {
     override def fold[E, B1 >: B, S]: Stream.Fold[E, B1, S] =
-      IO.point { (s, cont, f) =>
+      IO.succeedLazy { (s, cont, f) =>
         StreamPure.super.map(f0).fold[E, B1, S].flatMap(f1 => f1(s, cont, f))
       }
 
@@ -98,7 +98,7 @@ private[stream] trait StreamPure[+A] extends Stream[Nothing, A] { self =>
       self.foldPureLazy(s)(cont)((s, a) => f0(a).foldLeftLazy(s)(cont)(f))
 
     override def fold[E, B1 >: B, S]: Stream.Fold[E, B1, S] =
-      IO.point { (s, cont, f) =>
+      IO.succeedLazy { (s, cont, f) =>
         StreamPure.super.mapConcat(f0).fold[E, B1, S].flatMap(f1 => f1(s, cont, f))
       }
   }
@@ -112,7 +112,7 @@ private[stream] trait StreamPure[+A] extends Stream[Nothing, A] { self =>
         ._1
 
     override def fold[E, A1 >: (A, Int), S]: Stream.Fold[E, A1, S] =
-      IO.point { (s, cont, f) =>
+      IO.succeedLazy { (s, cont, f) =>
         StreamPure.super.zipWithIndex.fold[E, A1, S].flatMap(f0 => f0(s, cont, f))
       }
   }
@@ -132,7 +132,7 @@ private[stream] trait StreamPure[+A] extends Stream[Nothing, A] { self =>
         ._1
 
     override def fold[E, B1 >: B, S]: Stream.Fold[E, B1, S] =
-      IO.point { (s, cont, f) =>
+      IO.succeedLazy { (s, cont, f) =>
         StreamPure.super.mapAccum(s1)(f1).fold[E, B1, S].flatMap(f0 => f0(s, cont, f))
       }
   }

--- a/core/shared/src/main/scala/scalaz/zio/stream/StreamPure.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/StreamPure.scala
@@ -99,7 +99,7 @@ private[stream] trait StreamPure[+A] extends Stream[Nothing, A] { self =>
 
     override def fold[E, B1 >: B, S]: Stream.Fold[E, B1, S] =
       IO.point { (s, cont, f) =>
-        StreamPure.super.mapConcat(f0).fold[E, B1, S].flatMap(f1 =>f1(s, cont, f))
+        StreamPure.super.mapConcat(f0).fold[E, B1, S].flatMap(f1 => f1(s, cont, f))
       }
   }
 

--- a/core/shared/src/main/scala/scalaz/zio/stream/StreamPure.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/StreamPure.scala
@@ -35,8 +35,10 @@ private[stream] trait StreamPure[+A] extends Stream[Nothing, A] { self =>
         else s
       }
 
-    override def foldLazy[E, A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => IO[E, S]): IO[E, S] =
-      StreamPure.super.filter(pred).foldLazy(s)(cont)(f)
+    override def fold[E, A1 >: A, S]: Stream.Fold[E, A1, S] =
+      IO.point { (s, cont, f) =>
+        StreamPure.super.filter(pred).fold[E, A1, S].flatMap(f0 => f0(s, cont, f))
+      }
   }
 
   /**
@@ -52,8 +54,10 @@ private[stream] trait StreamPure[+A] extends Stream[Nothing, A] { self =>
         }
         ._2
 
-    override def foldLazy[E, A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => IO[E, S]): IO[E, S] =
-      StreamPure.super.dropWhile(pred).foldLazy(s)(cont)(f)
+    override def fold[E, A1 >: A, S]: Stream.Fold[E, A1, S] =
+      IO.point { (s, cont, f) =>
+        StreamPure.super.dropWhile(pred).fold[E, A1, S].flatMap(f0 => f0(s, cont, f))
+      }
   }
 
   /**
@@ -70,16 +74,20 @@ private[stream] trait StreamPure[+A] extends Stream[Nothing, A] { self =>
         }
         ._2
 
-    override def foldLazy[E, A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => IO[E, S]): IO[E, S] =
-      StreamPure.super.takeWhile(pred).foldLazy(s)(cont)(f)
+    override def fold[E, A1 >: A, S]: Stream.Fold[E, A1, S] =
+      IO.point { (s, cont, f) =>
+        StreamPure.super.takeWhile(pred).fold[E, A1, S].flatMap(f0 => f0(s, cont, f))
+      }
   }
 
   /**
    * Maps over elements of the stream with the specified function.
    */
   override def map[B](f0: A => B): StreamPure[B] = new StreamPure[B] {
-    override def foldLazy[E, B1 >: B, S](s: S)(cont: S => Boolean)(f: (S, B1) => IO[E, S]): IO[E, S] =
-      StreamPure.super.map(f0).foldLazy(s)(cont)(f)
+    override def fold[E, B1 >: B, S]: Stream.Fold[E, B1, S] =
+      IO.point { (s, cont, f) =>
+        StreamPure.super.map(f0).fold[E, B1, S].flatMap(f1 => f1(s, cont, f))
+      }
 
     override def foldPureLazy[B1 >: B, S](s: S)(cont: S => Boolean)(f: (S, B1) => S): S =
       self.foldPureLazy[A, S](s)(cont)((s, a) => f(s, f0(a)))
@@ -89,8 +97,10 @@ private[stream] trait StreamPure[+A] extends Stream[Nothing, A] { self =>
     override def foldPureLazy[B1 >: B, S](s: S)(cont: S => Boolean)(f: (S, B1) => S): S =
       self.foldPureLazy(s)(cont)((s, a) => f0(a).foldLeftLazy(s)(cont)(f))
 
-    override def foldLazy[E, B1 >: B, S](s: S)(cont: S => Boolean)(f: (S, B1) => IO[E, S]): IO[E, S] =
-      StreamPure.super.mapConcat(f0).foldLazy(s)(cont)(f)
+    override def fold[E, B1 >: B, S]: Stream.Fold[E, B1, S] =
+      IO.point { (s, cont, f) =>
+        StreamPure.super.mapConcat(f0).fold[E, B1, S].flatMap(f1 =>f1(s, cont, f))
+      }
   }
 
   override def zipWithIndex: StreamPure[(A, Int)] = new StreamPure[(A, Int)] {
@@ -101,8 +111,10 @@ private[stream] trait StreamPure[+A] extends Stream[Nothing, A] { self =>
         }
         ._1
 
-    override def foldLazy[E, A1 >: (A, Int), S](s: S)(cont: S => Boolean)(f: (S, A1) => IO[E, S]): IO[E, S] =
-      StreamPure.super.zipWithIndex.foldLazy(s)(cont)(f)
+    override def fold[E, A1 >: (A, Int), S]: Stream.Fold[E, A1, S] =
+      IO.point { (s, cont, f) =>
+        StreamPure.super.zipWithIndex.fold[E, A1, S].flatMap(f0 => f0(s, cont, f))
+      }
   }
 
   /**
@@ -119,8 +131,10 @@ private[stream] trait StreamPure[+A] extends Stream[Nothing, A] { self =>
         }
         ._1
 
-    override def foldLazy[E, B1 >: B, S](s: S)(cont: S => Boolean)(f: (S, B1) => IO[E, S]): IO[E, S] =
-      StreamPure.super.mapAccum(s1)(f1).foldLazy(s)(cont)(f)
+    override def fold[E, B1 >: B, S]: Stream.Fold[E, B1, S] =
+      IO.point { (s, cont, f) =>
+        StreamPure.super.mapAccum(s1)(f1).fold[E, B1, S].flatMap(f0 => f0(s, cont, f))
+      }
   }
 }
 
@@ -130,20 +144,21 @@ private[stream] object StreamPure {
    * Constructs a pure stream from the specified `Iterable`.
    */
   final def fromIterable[A](it: Iterable[A]): StreamPure[A] = new StreamPure[A] {
-    override def foldLazy[E >: Nothing, A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => IO[E, S]): IO[E, S] = {
-      val iterator = it.iterator
+    override def fold[E >: Nothing, A1 >: A, S]: Stream.Fold[E, A1, S] =
+      IO.succeedLazy { (s, cont, f) =>
+        val iterator = it.iterator
 
-      def loop(s: S): IO[E, S] =
-        IO.flatten {
-          IO.sync {
-            if (iterator.hasNext && cont(s))
-              f(s, iterator.next).flatMap(loop)
-            else IO.succeed(s)
+        def loop(s: S): IO[E, S] =
+          IO.flatten {
+            IO.sync {
+              if (iterator.hasNext && cont(s))
+                f(s, iterator.next).flatMap(loop)
+              else IO.succeed(s)
+            }
           }
-        }
 
-      loop(s)
-    }
+        loop(s)
+      }
 
     override def foldPureLazy[A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => S): S = {
       val iterator = it.iterator
@@ -160,9 +175,11 @@ private[stream] object StreamPure {
    * Constructs a singleton stream.
    */
   final def succeedLazy[A](a: => A): StreamPure[A] = new StreamPure[A] {
-    override def foldLazy[E >: Nothing, A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => IO[E, S]): IO[E, S] =
-      if (cont(s)) f(s, a)
-      else IO.succeed(s)
+    override def fold[E >: Nothing, A1 >: A, S]: Stream.Fold[E, A1, S] =
+      IO.succeedLazy { (s, cont, f) =>
+        if (cont(s)) f(s, a)
+        else IO.succeed(s)
+      }
 
     override def foldPureLazy[A1 >: A, S](s: S)(cont: S => Boolean)(f: (S, A1) => S): S =
       if (cont(s)) f(s, a)
@@ -173,8 +190,8 @@ private[stream] object StreamPure {
    * Returns the empty stream.
    */
   final val empty: StreamPure[Nothing] = new StreamPure[Nothing] {
-    override def foldLazy[E >: Nothing, A1 >: Nothing, S](s: S)(cont: S => Boolean)(f: (S, A1) => IO[E, S]): IO[E, S] =
-      IO.succeed(s)
+    override def fold[E >: Nothing, A1 >: Nothing, S]: Stream.Fold[E, A1, S] =
+      IO.succeedLazy((s, _, _) => IO.succeed(s))
 
     override def foldPureLazy[A1 >: Nothing, S](s: S)(cont: S => Boolean)(f: (S, A1) => S): S = s
   }


### PR DESCRIPTION
This PR resolves #428.

First of all, I am very sorry for the delay in shipping this. 

As expected, stack safety issues shown themselves on a simple recursive Fibonacci calculation. Before and after applying the changes I ran stream benchmarks using the following JMH setup:

```
jmh:run -i 15 -wi 15 -f1 -t1 .*StreamBenchmarks.*
```

The following are benchmark results before changes:

| Benchmark                                     | chunkCount | chunkSize | cols | rows | mode  | cnt | score  | error | units |
|-----------------------------------------------|------------|-----------|------|------|-------|-----|--------|-------|-------|
| CSVStreamBenchmarks.akkaCsvTokenize           |   N/A      |      5000 |  100 |  100 | thrpt |  15 | 10.631 | 0.096 | ops/s |
| CSVStreamBenchmarks.fs2CsvTokenize            |   N/A      |      5000 |  100 |  100 | thrpt |  15 |  5.640 | 0.161 | ops/s |
| CSVStreamBenchmarks.scalazCsvTokenize         |   N/A      |      5000 |  100 |  100 | thrpt |  15 | 20.361 | 1.577 | ops/s |
| StreamBenchmarks.akkaChunkFilterMapSum        | 10000      |      5000 |  N/A |  N/A | thrpt |  15 |  0.241 | 0.002 | ops/s |
| StreamBenchmarks.fs2ChunkFilterMapSum         | 10000      |      5000 |  N/A |  N/A | thrpt |  15 |  0.795 | 0.010 | ops/s |
| StreamBenchmarks.scalazChunkChunkFilterMapSum | 10000      |      5000 |  N/A |  N/A | thrpt |  15 |  1.780 | 0.011 | ops/s |
| StreamBenchmarks.scalazChunkFilterMapSum      | 10000      |      5000 |  N/A |  N/A | thrpt |  15 |  1.721 | 0.008 | ops/s |

And after applying the changes:

| Benchmark                                     | chunkCount | chunkSize | cols | rows | mode  | cnt | score  | error | units |
|-----------------------------------------------|------------|-----------|------|------|-------|-----|--------|-------|-------|
| CSVStreamBenchmarks.akkaCsvTokenize           |   N/A      |      5000 |  100 |  100 | thrpt |  15 |  9.640 | 0.104 | ops/s |
| CSVStreamBenchmarks.fs2CsvTokenize            |   N/A      |      5000 |  100 |  100 | thrpt |  15 |  4.729 | 0.077 | ops/s |
| CSVStreamBenchmarks.scalazCsvTokenize         |   N/A      |      5000 |  100 |  100 | thrpt |  15 | 16.267 | 0.827 | ops/s |
| StreamBenchmarks.akkaChunkFilterMapSum        | 10000      |      5000 |  N/A |  N/A | thrpt |  15 |  0.216 | 0.023 | ops/s |
| StreamBenchmarks.fs2ChunkFilterMapSum         | 10000      |      5000 |  N/A |  N/A | thrpt |  15 |  0.597 | 0.038 | ops/s |
| StreamBenchmarks.scalazChunkChunkFilterMapSum | 10000      |      5000 |  N/A |  N/A | thrpt |  15 |  1.404 | 0.016 | ops/s |
| StreamBenchmarks.scalazChunkFilterMapSum      | 10000      |      5000 |  N/A |  N/A | thrpt |  15 |  0.431 | 0.019 | ops/s |

@iravid @jdegoes looking forward to your feedback! 🙏 