### PR TITLE
microsite add Ref section to Data Types page

### DIFF
--- a/microsite/src/main/tut/datatypes/index.md
+++ b/microsite/src/main/tut/datatypes/index.md
@@ -15,6 +15,7 @@ ZIO contains a small number of data types that can help you solve complex proble
  - **[Managed](managed.html)** — A `Managed` is a value that describes an `IO` perishable resource that may be consumed only once inside a given scope.
  - **[Promise](promise.html)** — A `Promise` is a model of a variable that may be set a single time, and awaited on by many fibers.
  - **[Queue](queue.html)** — A `Queue` is an asynchronous queue that never blocks, which is safe for multiple concurrent producers and consumers.
+ - **[Ref](ref.html)** — `Ref[A]` models a mutable reference to a value of type `A`. The two basic operations are `set`, which fills the `Ref` with a new value, and `get`, which retrieves its current content. All operations on a `Ref` are atomic and thread-safe, providing a reliable foundation for synchronizing concurrent programs.
  - **[Schedule](schedule.html)** — A `Schedule` is a model of a recurring schedule, which can be used for repeating successful `IO` values, or retrying failed `IO` values.
  - **[Semaphore](semaphore.html) — A `Semaphore` is an asynchronous (non-blocking) semaphore that plays well with ZIO's interruption.
  - **[Sink](sink.html)** — A `Sink` is a consumer of values from a `Stream`, which may produces a value when it has consumed enough.


### PR DESCRIPTION
On data types one of the sections (exist in the menu) is Ref.
However, it is not visible on Data Types page.

Ref section is added to Data Types page in this PR.