### PR TITLE
broken link to Sink page

### DIFF
--- a/microsite/src/main/tut/datatypes/sink.md
+++ b/microsite/src/main/tut/datatypes/sink.md
@@ -1,0 +1,7 @@
+---
+layout: docs
+section: datatypes
+title:  "Sink"
+---
+
+# {{page.title}}


### PR DESCRIPTION
Currentyly link to Sink page on: https://scalaz.github.io/scalaz-zio/datatypes/ is broken as there is no such page.

This PR adds empty Sink page.