### PR TITLE
Migrate get/option from extension methods

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/PromiseSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/PromiseSpec.scala
@@ -1,7 +1,5 @@
 package scalaz.zio
 
-import scalaz.zio.syntax._
-
 class PromiseSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends AbstractRTSSpec {
 
   def is = "PromiseSpec".title ^ s2"""

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -342,14 +342,14 @@ sealed abstract class IO[+E, +A] extends Serializable { self =>
     self.redeem[Nothing, Either[E, A]](IO.succeedLeft, IO.succeedRight)
 
   /**
-    * Unwraps the optional success of this effect, but can fail with unit value.
-    */
+   * Unwraps the optional success of this effect, but can fail with unit value.
+   */
   final def get[E1 >: E, B](implicit ev1: E1 =:= Nothing, ev2: A <:< Option[B]): IO[Unit, B] =
     IO.absolve(self.leftMap(ev1).map(_.toRight(())))
 
   /**
-    * Executes this action, skipping the error but returning optionally the success.
-    */
+   * Executes this action, skipping the error but returning optionally the success.
+   */
   final def option: IO[Nothing, Option[A]] =
     self.attempt.map {
       case Right(value) => Some(value)

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -351,10 +351,7 @@ sealed abstract class IO[+E, +A] extends Serializable { self =>
    * Executes this action, skipping the error but returning optionally the success.
    */
   final def option: IO[Nothing, Option[A]] =
-    self.attempt.map {
-      case Right(value) => Some(value)
-      case _            => None
-    }
+    self.redeem0(_ => IO.succeed(None), a => IO.succeed(Some(a)))
 
   /**
    * When this action represents acquisition of a resource (for example,

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -348,6 +348,15 @@ sealed abstract class IO[+E, +A] extends Serializable { self =>
     IO.absolve(self.leftMap(ev1).map(_.toRight(())))
 
   /**
+    * Executes this action, skipping the error but returning optionally the success.
+    */
+  final def option: IO[Nothing, Option[A]] =
+    self.attempt.map {
+      case Right(value) => Some(value)
+      case _            => None
+    }
+
+  /**
    * When this action represents acquisition of a resource (for example,
    * opening a file, launching a thread, etc.), `bracket` can be used to ensure
    * the acquisition is not interrupted and the resource is released.

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -342,6 +342,12 @@ sealed abstract class IO[+E, +A] extends Serializable { self =>
     self.redeem[Nothing, Either[E, A]](IO.succeedLeft, IO.succeedRight)
 
   /**
+    * Unwraps the optional success of this effect, but can fail with unit value.
+    */
+  final def get[E1 >: E, B](implicit ev1: E1 =:= Nothing, ev2: A <:< Option[B]): IO[Unit, B] =
+    IO.absolve(self.leftMap(ev1).map(_.toRight(())))
+
+  /**
    * When this action represents acquisition of a resource (for example,
    * opening a file, launching a thread, etc.), `bracket` can be used to ensure
    * the acquisition is not interrupted and the resource is released.

--- a/core/shared/src/main/scala/scalaz/zio/Promise.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Promise.scala
@@ -54,8 +54,7 @@ class Promise[E, A] private (private val state: AtomicReference[State[E, A]]) ex
     })
 
   /**
-   * Retrieves immediately the completion of this promise if it's available,
-   * and fails immediately with `Unit` otherwise
+   * Completes immediately this promise and returns optionally it's result.
    */
   final def poll: IO[Nothing, Option[IO[E, A]]] =
     IO.sync(state.get).flatMap {

--- a/core/shared/src/main/scala/scalaz/zio/syntax/IOSyntax.scala
+++ b/core/shared/src/main/scala/scalaz/zio/syntax/IOSyntax.scala
@@ -41,10 +41,6 @@ object IOSyntax {
     def collectAll: IO[E, List[A]]                     = IO.collectAll(ios)
   }
 
-  final class IOGetSyntax[A](val io: IO[Nothing, Option[A]]) extends AnyVal {
-    def get: IO[Unit, A] = io.map(_.toRight(())).absolve
-  }
-
   final class IOOptionSyntax[A](val io: IO[Unit, A]) extends AnyVal {
     def option: IO[Nothing, Option[A]] = io.attempt.map {
       case Right(value) => Some(value)

--- a/core/shared/src/main/scala/scalaz/zio/syntax/IOSyntax.scala
+++ b/core/shared/src/main/scala/scalaz/zio/syntax/IOSyntax.scala
@@ -41,13 +41,6 @@ object IOSyntax {
     def collectAll: IO[E, List[A]]                     = IO.collectAll(ios)
   }
 
-  final class IOOptionSyntax[A](val io: IO[Unit, A]) extends AnyVal {
-    def option: IO[Nothing, Option[A]] = io.attempt.map {
-      case Right(value) => Some(value)
-      case _            => None
-    }
-  }
-
   final class IOSyntax[E, A](val io: IO[E, A]) extends AnyVal {
     def raceAll(ios: Iterable[IO[E, A]]): IO[E, A] = IO.raceAll(io, ios)
     def supervise: IO[E, A]                        = IO.supervise(io)

--- a/core/shared/src/main/scala/scalaz/zio/syntax/syntax.scala
+++ b/core/shared/src/main/scala/scalaz/zio/syntax/syntax.scala
@@ -14,7 +14,6 @@ package object syntax {
     new IOUnsandboxSyntax(io)
   implicit final def ioUnitSyntax[E](io: IO[E, Unit]): IOUnitSyntax[E]                       = new IOUnitSyntax(io)
   implicit final def ioIterableSyntax[E, A](ios: Iterable[IO[E, A]]): IOIterableSyntax[E, A] = new IOIterableSyntax(ios)
-  implicit final def ioGetSyntax[A](io: IO[Nothing, Option[A]]): IOGetSyntax[A]              = new IOGetSyntax(io)
   implicit final def ioOptionSyntax[A](io: IO[Unit, A]): IOOptionSyntax[A]                   = new IOOptionSyntax(io)
   implicit final def ioSyntax[E, A](io: IO[E, A]): IOSyntax[E, A]                            = new IOSyntax(io)
   implicit final def ioTuple2Syntax[E, A, B](ios: (IO[E, A], IO[E, B])): IOTuple2[E, A, B]   = new IOTuple2(ios)

--- a/core/shared/src/main/scala/scalaz/zio/syntax/syntax.scala
+++ b/core/shared/src/main/scala/scalaz/zio/syntax/syntax.scala
@@ -14,7 +14,6 @@ package object syntax {
     new IOUnsandboxSyntax(io)
   implicit final def ioUnitSyntax[E](io: IO[E, Unit]): IOUnitSyntax[E]                       = new IOUnitSyntax(io)
   implicit final def ioIterableSyntax[E, A](ios: Iterable[IO[E, A]]): IOIterableSyntax[E, A] = new IOIterableSyntax(ios)
-  implicit final def ioOptionSyntax[A](io: IO[Unit, A]): IOOptionSyntax[A]                   = new IOOptionSyntax(io)
   implicit final def ioSyntax[E, A](io: IO[E, A]): IOSyntax[E, A]                            = new IOSyntax(io)
   implicit final def ioTuple2Syntax[E, A, B](ios: (IO[E, A], IO[E, B])): IOTuple2[E, A, B]   = new IOTuple2(ios)
   implicit final def ioTuple3Syntax[E, A, B, C](ios: (IO[E, A], IO[E, B], IO[E, C])): IOTuple3[E, A, B, C] =


### PR DESCRIPTION
My initial (partial) take on #489.

Please notice, I wasn't able to use only `=:=` evidence with `get` migration and make the compiler happy.

Looking for feedback and then I'd to proceed with further migrations.

cc @sideeffffect as the author of the task