### PR TITLE
[DNM] Benchmark for 'map' method

### DIFF
--- a/benchmarks/src/main/scala/scalaz/zio/MapDispatchBenchmark.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/MapDispatchBenchmark.scala
@@ -1,0 +1,191 @@
+package scalaz.zio
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import scalaz.zio.IO.Tags
+import scalaz.zio.MapDispatchBenchmark._
+
+import scala.annotation.switch
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+class MapDispatchBenchmark {
+
+  val fm: TestIO          = new FlatMap
+  val point: TestIO       = new Point
+  val strict: TestIO      = new Strict
+  val syncEf: TestIO      = new SyncEffect
+  val asyncEffect: TestIO = new AsyncEffect
+  val v                   = new MapVisitor
+  val a: Int              = 42
+
+  @Benchmark
+  def fmMapWithSwitch: Int =
+    fm.mapWithSwitch()
+
+  @Benchmark
+  def fmSubclass(): Int =
+    fm.mapSubclassing()
+
+  @Benchmark
+  def fmVisitor(): Int =
+    fm.acceptMapVisitor(v)
+
+  @Benchmark
+  def asyncEffectMapWithSwitch: Int =
+    asyncEffect.mapWithSwitch()
+
+  @Benchmark
+  def asyncEffectSubclass(): Int =
+    asyncEffect.mapSubclassing()
+
+  @Benchmark
+  def asyncEffectVisitor(): Int =
+    asyncEffect.acceptMapVisitor(v)
+
+  @Benchmark
+  def allMapWithSwitch: Int =
+    asyncEffect.mapWithSwitch() +
+      fm.mapWithSwitch() +
+      syncEf.mapWithSwitch() +
+      strict.mapWithSwitch() +
+      point.mapWithSwitch()
+
+  @Benchmark
+  def allSubclass(): Int =
+    asyncEffect.mapSubclassing() +
+      fm.mapSubclassing() +
+      syncEf.mapSubclassing() +
+      strict.mapSubclassing() +
+      point.mapSubclassing()
+
+  @Benchmark
+  def allVisitor(): Int =
+    asyncEffect.acceptMapVisitor(v) +
+      fm.acceptMapVisitor(v) +
+      syncEf.acceptMapVisitor(v) +
+      strict.acceptMapVisitor(v) +
+      point.acceptMapVisitor(v)
+
+}
+
+object MapDispatchBenchmark {
+
+  sealed trait TestIO { self =>
+    def tag: Int
+
+    def mapSubclassing(): Int
+
+    final def mapWithSwitch(): Int = (self.tag: @switch) match {
+      case IO.Tags.Point =>
+        self.asInstanceOf[Point]
+        1
+
+      case IO.Tags.Strict =>
+        self.asInstanceOf[Strict]
+        2
+
+      case IO.Tags.Fail =>
+        self.asInstanceOf[TestIO]
+        3
+
+      case _ => 4
+    }
+
+    def acceptMapVisitor(v: MapVisitor): Int
+  }
+
+  final class FlatMap extends TestIO {
+    override def tag: Int                             = Tags.FlatMap
+    override def mapSubclassing(): Int          = 1
+    override def acceptMapVisitor(v: MapVisitor): Int = v.visitFlatMap
+  }
+
+  final class Point extends TestIO {
+    override def tag: Int                             = Tags.Point
+    override def mapSubclassing(): Int          = 2
+    override def acceptMapVisitor(v: MapVisitor): Int = v.visitPoint
+  }
+
+  final class Strict extends TestIO {
+    override def tag: Int                             = Tags.Strict
+    override def mapSubclassing(): Int          = 3
+    override def acceptMapVisitor(v: MapVisitor): Int = v.visitStrict
+  }
+
+  final class SyncEffect extends TestIO {
+    override def tag: Int                             = Tags.SyncEffect
+    override def mapSubclassing(): Int          = 4
+    override def acceptMapVisitor(v: MapVisitor): Int = v.visitSyncEffect
+  }
+
+  final class AsyncEffect extends TestIO {
+    override def tag: Int                             = Tags.AsyncEffect
+    override def mapSubclassing(): Int          = 4
+    override def acceptMapVisitor(v: MapVisitor): Int = v.visitAsyncEffect
+  }
+
+  final class Redeem extends TestIO {
+    override def tag: Int                             = Tags.Redeem
+    override def mapSubclassing(): Int          = 4
+    override def acceptMapVisitor(v: MapVisitor): Int = v.visitOther()
+  }
+
+  final class Fork extends TestIO {
+    override def tag: Int                             = Tags.Fork
+    override def mapSubclassing(): Int          = 4
+    override def acceptMapVisitor(v: MapVisitor): Int = v.visitOther()
+  }
+
+  final class Uninterruptible extends TestIO {
+    override def tag: Int                             = Tags.Uninterruptible
+    override def mapSubclassing(): Int          = 4
+    override def acceptMapVisitor(v: MapVisitor): Int = v.visitOther()
+  }
+
+  final class Supervise extends TestIO {
+    override def tag: Int                             = Tags.Supervise
+    override def mapSubclassing(): Int          = 4
+    override def acceptMapVisitor(v: MapVisitor): Int = v.visitOther()
+  }
+
+  final class Fail extends TestIO {
+    override def tag: Int                             = Tags.Fail
+    override def mapSubclassing(): Int          = 4
+    override def acceptMapVisitor(v: MapVisitor): Int = v.visitOther()
+  }
+
+  final class Ensuring extends TestIO {
+    override def tag: Int                             = Tags.Ensuring
+    override def mapSubclassing(): Int          = 4
+    override def acceptMapVisitor(v: MapVisitor): Int = v.visitOther()
+  }
+
+  final object Descriptor extends TestIO {
+    override def tag: Int                             = Tags.Descriptor
+    override def mapSubclassing(): Int          = 4
+    override def acceptMapVisitor(v: MapVisitor): Int = v.visitOther()
+  }
+
+  final class Lock extends TestIO {
+    override def tag: Int                             = Tags.Lock
+    override def mapSubclassing(): Int          = 4
+    override def acceptMapVisitor(v: MapVisitor): Int = v.visitOther()
+  }
+
+  final object Yield extends TestIO {
+    override def tag: Int                             = Tags.Yield
+    override def mapSubclassing(): Int          = 4
+    override def acceptMapVisitor(v: MapVisitor): Int = v.visitOther()
+  }
+
+  class MapVisitor {
+    def visitFlatMap()     = 1
+    def visitPoint()       = 2
+    def visitStrict()      = 3
+    def visitSyncEffect()  = 4
+    def visitAsyncEffect() = 4
+    def visitOther()       = 4
+  }
+}

--- a/benchmarks/src/main/scala/scalaz/zio/MapDispatchBenchmark.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/MapDispatchBenchmark.scala
@@ -20,7 +20,12 @@ class MapDispatchBenchmark {
   val v                   = new MapVisitor
   val a: Int              = 42
 
-  @Benchmark
+  val fmCl: TestIOClass          = new ClassFlatMap
+  val pointCl: TestIOClass       = new ClassPoint
+  val strictCl: TestIOClass      = new ClassStrict
+  val syncEfCl: TestIOClass      = new ClassSyncEffect
+  val asyncEffectCl: TestIOClass = new ClassAsyncEffect
+  /*@Benchmark
   def fmMapWithSwitch: Int =
     fm.mapWithSwitch()
 
@@ -42,7 +47,7 @@ class MapDispatchBenchmark {
 
   @Benchmark
   def asyncEffectVisitor(): Int =
-    asyncEffect.acceptMapVisitor(v)
+    asyncEffect.acceptMapVisitor(v)*/
 
   @Benchmark
   def allMapWithSwitch: Int =
@@ -52,7 +57,7 @@ class MapDispatchBenchmark {
       strict.mapWithSwitch() +
       point.mapWithSwitch()
 
-  @Benchmark
+  /*@Benchmark
   def allSubclass(): Int =
     asyncEffect.mapSubclassing() +
       fm.mapSubclassing() +
@@ -66,7 +71,15 @@ class MapDispatchBenchmark {
       fm.acceptMapVisitor(v) +
       syncEf.acceptMapVisitor(v) +
       strict.acceptMapVisitor(v) +
-      point.acceptMapVisitor(v)
+      point.acceptMapVisitor(v)*/
+
+  @Benchmark
+  def allMapWithSwitchClass: Int =
+    asyncEffectCl.mapWithSwitch() +
+      fmCl.mapWithSwitch() +
+      syncEfCl.mapWithSwitch() +
+      strictCl.mapWithSwitch() +
+      pointCl.mapWithSwitch()
 
 }
 
@@ -188,4 +201,53 @@ object MapDispatchBenchmark {
     def visitAsyncEffect() = 4
     def visitOther()       = 4
   }
+
+  abstract class TestIOClass(storedTag0: Int) {
+    final val storedTag = storedTag0
+
+    final def mapWithSwitch(): Int = (storedTag: @switch) match {
+      case IO.Tags.Point =>
+        this.asInstanceOf[ClassPoint]
+        1
+
+      case IO.Tags.Strict =>
+        this.asInstanceOf[ClassStrict]
+        2
+
+      case IO.Tags.Fail =>
+        this.asInstanceOf[TestIOClass]
+        3
+
+      case _ => 4
+    }
+  }
+
+  final class ClassFlatMap extends TestIOClass(Tags.FlatMap) {}
+
+  final class ClassPoint extends TestIOClass(Tags.Point){}
+
+  final class ClassStrict extends TestIOClass(Tags.Strict){}
+
+  final class ClassSyncEffect extends TestIOClass(Tags.SyncEffect){}
+
+  final class ClassAsyncEffect extends TestIOClass(Tags.AsyncEffect){}
+
+  final class ClassRedeem extends TestIOClass(Tags.Redeem){}
+
+  final class ClassFork extends TestIOClass(Tags.Fork){}
+
+  final class ClassUninterruptible extends TestIOClass(Tags.Uninterruptible){}
+
+  final class ClassSupervise extends TestIOClass(Tags.Supervise){}
+
+  final class ClassFail extends TestIOClass(Tags.Fail){}
+
+  final class ClassEnsuring extends TestIOClass(Tags.Ensuring){}
+
+  final class Descriptor extends TestIOClass(Tags.Descriptor){}
+
+  final class ClassLock extends TestIOClass(Tags.Lock){}
+
+  final class Yield extends TestIOClass(Tags.Yield){}
+  
 }

--- a/benchmarks/src/main/scala/scalaz/zio/MapDispatchBenchmark.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/MapDispatchBenchmark.scala
@@ -12,66 +12,53 @@ import scala.annotation.switch
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 class MapDispatchBenchmark {
 
-  val fm: TestIO          = new FlatMap
-  val point: TestIO       = new Point
-  val strict: TestIO      = new Strict
-  val syncEf: TestIO      = new SyncEffect
-  val asyncEffect: TestIO = new AsyncEffect
-  val v                   = new MapVisitor
-  val a: Int              = 42
+  val fmDefSwitch: TestIODefSwitch          = new FlatMapDefSwitch
+  val pointDefSwitch: TestIODefSwitch       = new PointDefSwitch
+  val strictDefSwitch: TestIODefSwitch      = new StrictDefSwitch
+  val syncEfDefSwitch: TestIODefSwitch      = new SyncEffectDefSwitch
+  val asyncEffectDefSwitch: TestIODefSwitch = new AsyncEffectDefSwitch
 
-  val fmCl: TestIOClass          = new ClassFlatMap
-  val pointCl: TestIOClass       = new ClassPoint
-  val strictCl: TestIOClass      = new ClassStrict
-  val syncEfCl: TestIOClass      = new ClassSyncEffect
-  val asyncEffectCl: TestIOClass = new ClassAsyncEffect
-  /*@Benchmark
-  def fmMapWithSwitch: Int =
-    fm.mapWithSwitch()
+  val fmValSwitch: TestIOValSwitch          = new FlatMapValSwitch
+  val pointValSwitch: TestIOValSwitch       = new PointValSwitch
+  val strictValSwitch: TestIOValSwitch      = new StrictValSwitch
+  val syncEfValSwitch: TestIOValSwitch      = new SyncEffectValSwitch
+  val asyncEffectValSwitch: TestIOValSwitch = new AsyncEffectValSwitch
 
-  @Benchmark
-  def fmSubclass(): Int =
-    fm.mapSubclassing()
+  val fmCl: TestIOAbstractClass          = new AbstractClassFlatMap
+  val pointCl: TestIOAbstractClass       = new AbstractClassPoint
+  val strictCl: TestIOAbstractClass      = new AbstractClassStrict
+  val syncEfCl: TestIOAbstractClass      = new AbstractClassSyncEffect
+  val asyncEffectCl: TestIOAbstractClass = new AbstractClassAsyncEffect
 
-  @Benchmark
-  def fmVisitor(): Int =
-    fm.acceptMapVisitor(v)
-
-  @Benchmark
-  def asyncEffectMapWithSwitch: Int =
-    asyncEffect.mapWithSwitch()
+  val fmSub: TestIOSubclassing          = new FlatMapSubclassing
+  val pointSub: TestIOSubclassing       = new PointSubclassing
+  val strictSub: TestIOSubclassing      = new StrictSubclassing
+  val syncEfSub: TestIOSubclassing      = new SyncEffectSubclassing
+  val asyncEffectSub: TestIOSubclassing = new AsyncEffectSubclassing
 
   @Benchmark
-  def asyncEffectSubclass(): Int =
-    asyncEffect.mapSubclassing()
+  def allMapWithDefSwitch: Int =
+    asyncEffectDefSwitch.mapWithSwitch() +
+      fmDefSwitch.mapWithSwitch() +
+      syncEfDefSwitch.mapWithSwitch() +
+      strictDefSwitch.mapWithSwitch() +
+      pointDefSwitch.mapWithSwitch()
 
   @Benchmark
-  def asyncEffectVisitor(): Int =
-    asyncEffect.acceptMapVisitor(v)*/
+  def allMapWithValSwitch: Int =
+    asyncEffectDefSwitch.mapWithSwitch() +
+      fmDefSwitch.mapWithSwitch() +
+      syncEfDefSwitch.mapWithSwitch() +
+      strictDefSwitch.mapWithSwitch() +
+      pointDefSwitch.mapWithSwitch()
 
   @Benchmark
-  def allMapWithSwitch: Int =
-    asyncEffect.mapWithSwitch() +
-      fm.mapWithSwitch() +
-      syncEf.mapWithSwitch() +
-      strict.mapWithSwitch() +
-      point.mapWithSwitch()
-
-  /*@Benchmark
   def allSubclass(): Int =
-    asyncEffect.mapSubclassing() +
-      fm.mapSubclassing() +
-      syncEf.mapSubclassing() +
-      strict.mapSubclassing() +
-      point.mapSubclassing()
-
-  @Benchmark
-  def allVisitor(): Int =
-    asyncEffect.acceptMapVisitor(v) +
-      fm.acceptMapVisitor(v) +
-      syncEf.acceptMapVisitor(v) +
-      strict.acceptMapVisitor(v) +
-      point.acceptMapVisitor(v)*/
+    asyncEffectSub.mapSubclassing() +
+      fmSub.mapSubclassing() +
+      syncEfSub.mapSubclassing() +
+      strictSub.mapSubclassing() +
+      pointSub.mapSubclassing()
 
   @Benchmark
   def allMapWithSwitchClass: Int =
@@ -85,169 +72,284 @@ class MapDispatchBenchmark {
 
 object MapDispatchBenchmark {
 
-  sealed trait TestIO { self =>
+  sealed trait TestIODefSwitch { self =>
     def tag: Int
-
-    def mapSubclassing(): Int
 
     final def mapWithSwitch(): Int = (self.tag: @switch) match {
       case IO.Tags.Point =>
-        self.asInstanceOf[Point]
+        self.asInstanceOf[PointDefSwitch]
         1
 
       case IO.Tags.Strict =>
-        self.asInstanceOf[Strict]
+        self.asInstanceOf[StrictDefSwitch]
         2
 
       case IO.Tags.Fail =>
-        self.asInstanceOf[TestIO]
+        self.asInstanceOf[TestIODefSwitch]
         3
 
       case _ => 4
     }
-
-    def acceptMapVisitor(v: MapVisitor): Int
   }
 
-  final class FlatMap extends TestIO {
-    override def tag: Int                             = Tags.FlatMap
-    override def mapSubclassing(): Int          = 1
-    override def acceptMapVisitor(v: MapVisitor): Int = v.visitFlatMap
+  final class FlatMapDefSwitch extends TestIODefSwitch {
+    override def tag: Int = Tags.FlatMap
   }
 
-  final class Point extends TestIO {
-    override def tag: Int                             = Tags.Point
-    override def mapSubclassing(): Int          = 2
-    override def acceptMapVisitor(v: MapVisitor): Int = v.visitPoint
+  final class PointDefSwitch extends TestIODefSwitch {
+    override def tag: Int = Tags.Point
   }
 
-  final class Strict extends TestIO {
-    override def tag: Int                             = Tags.Strict
-    override def mapSubclassing(): Int          = 3
-    override def acceptMapVisitor(v: MapVisitor): Int = v.visitStrict
+  final class StrictDefSwitch extends TestIODefSwitch {
+    override def tag: Int = Tags.Strict
   }
 
-  final class SyncEffect extends TestIO {
-    override def tag: Int                             = Tags.SyncEffect
-    override def mapSubclassing(): Int          = 4
-    override def acceptMapVisitor(v: MapVisitor): Int = v.visitSyncEffect
+  final class SyncEffectDefSwitch extends TestIODefSwitch {
+    override def tag: Int = Tags.SyncEffect
   }
 
-  final class AsyncEffect extends TestIO {
-    override def tag: Int                             = Tags.AsyncEffect
-    override def mapSubclassing(): Int          = 4
-    override def acceptMapVisitor(v: MapVisitor): Int = v.visitAsyncEffect
+  final class AsyncEffectDefSwitch extends TestIODefSwitch {
+    override def tag: Int = Tags.AsyncEffect
   }
 
-  final class Redeem extends TestIO {
-    override def tag: Int                             = Tags.Redeem
-    override def mapSubclassing(): Int          = 4
-    override def acceptMapVisitor(v: MapVisitor): Int = v.visitOther()
+  final class RedeemDefSwitch extends TestIODefSwitch {
+    override def tag: Int = Tags.Redeem
   }
 
-  final class Fork extends TestIO {
-    override def tag: Int                             = Tags.Fork
-    override def mapSubclassing(): Int          = 4
-    override def acceptMapVisitor(v: MapVisitor): Int = v.visitOther()
+  final class ForkDefSwitch extends TestIODefSwitch {
+    override def tag: Int = Tags.Fork
   }
 
-  final class Uninterruptible extends TestIO {
-    override def tag: Int                             = Tags.Uninterruptible
-    override def mapSubclassing(): Int          = 4
-    override def acceptMapVisitor(v: MapVisitor): Int = v.visitOther()
+  final class UninterruptibleDefSwitch extends TestIODefSwitch {
+    override def tag: Int = Tags.Uninterruptible
   }
 
-  final class Supervise extends TestIO {
-    override def tag: Int                             = Tags.Supervise
-    override def mapSubclassing(): Int          = 4
-    override def acceptMapVisitor(v: MapVisitor): Int = v.visitOther()
+  final class SuperviseDefSwitch extends TestIODefSwitch {
+    override def tag: Int = Tags.Supervise
   }
 
-  final class Fail extends TestIO {
-    override def tag: Int                             = Tags.Fail
-    override def mapSubclassing(): Int          = 4
-    override def acceptMapVisitor(v: MapVisitor): Int = v.visitOther()
+  final class FailDefSwitch extends TestIODefSwitch {
+    override def tag: Int = Tags.Fail
   }
 
-  final class Ensuring extends TestIO {
-    override def tag: Int                             = Tags.Ensuring
-    override def mapSubclassing(): Int          = 4
-    override def acceptMapVisitor(v: MapVisitor): Int = v.visitOther()
+  final class EnsuringDefSwitch extends TestIODefSwitch {
+    override def tag: Int = Tags.Ensuring
   }
 
-  final object Descriptor extends TestIO {
-    override def tag: Int                             = Tags.Descriptor
-    override def mapSubclassing(): Int          = 4
-    override def acceptMapVisitor(v: MapVisitor): Int = v.visitOther()
+  final object DescriptorDefSwitch extends TestIODefSwitch {
+    override def tag: Int = Tags.Descriptor
   }
 
-  final class Lock extends TestIO {
-    override def tag: Int                             = Tags.Lock
-    override def mapSubclassing(): Int          = 4
-    override def acceptMapVisitor(v: MapVisitor): Int = v.visitOther()
+  final class LockDefSwitch extends TestIODefSwitch {
+    override def tag: Int = Tags.Lock
   }
 
-  final object Yield extends TestIO {
-    override def tag: Int                             = Tags.Yield
-    override def mapSubclassing(): Int          = 4
-    override def acceptMapVisitor(v: MapVisitor): Int = v.visitOther()
+  final object YieldDefSwitch extends TestIODefSwitch {
+    override def tag: Int = Tags.Yield
   }
 
-  class MapVisitor {
-    def visitFlatMap()     = 1
-    def visitPoint()       = 2
-    def visitStrict()      = 3
-    def visitSyncEffect()  = 4
-    def visitAsyncEffect() = 4
-    def visitOther()       = 4
+  sealed trait TestIOValSwitch { self =>
+    val tag: Int
+
+    final def mapWithSwitch(): Int = (self.tag: @switch) match {
+      case IO.Tags.Point =>
+        self.asInstanceOf[PointDefSwitch]
+        1
+
+      case IO.Tags.Strict =>
+        self.asInstanceOf[StrictDefSwitch]
+        2
+
+      case IO.Tags.Fail =>
+        self.asInstanceOf[TestIODefSwitch]
+        3
+
+      case _ => 4
+    }
   }
 
-  abstract class TestIOClass(storedTag0: Int) {
+  final class FlatMapValSwitch extends TestIOValSwitch {
+    override final val tag: Int = Tags.FlatMap
+  }
+
+  final class PointValSwitch extends TestIOValSwitch {
+    override final val tag: Int = Tags.Point
+  }
+
+  final class StrictValSwitch extends TestIOValSwitch {
+    override final val tag: Int = Tags.Strict
+  }
+
+  final class SyncEffectValSwitch extends TestIOValSwitch {
+    override final val tag: Int = Tags.SyncEffect
+  }
+
+  final class AsyncEffectValSwitch extends TestIOValSwitch {
+    override final val tag: Int = Tags.AsyncEffect
+  }
+
+  final class RedeemValSwitch extends TestIOValSwitch {
+    override final val tag: Int = Tags.Redeem
+  }
+
+  final class ForkValSwitch extends TestIOValSwitch {
+    override final val tag: Int = Tags.Fork
+  }
+
+  final class UninterruptibleValSwitch extends TestIOValSwitch {
+    override final val tag: Int = Tags.Uninterruptible
+  }
+
+  final class SuperviseValSwitch extends TestIOValSwitch {
+    override final val tag: Int = Tags.Supervise
+  }
+
+  final class FailValSwitch extends TestIOValSwitch {
+    override final val tag: Int = Tags.Fail
+  }
+
+  final class EnsuringValSwitch extends TestIOValSwitch {
+    override final val tag: Int = Tags.Ensuring
+  }
+
+  final object DescriptorValSwitch extends TestIOValSwitch {
+    override final val tag: Int = Tags.Descriptor
+  }
+
+  final class LockValSwitch extends TestIOValSwitch {
+    override final val tag: Int = Tags.Lock
+  }
+
+  final object YieldValSwitch extends TestIOValSwitch {
+    override final val tag: Int = Tags.Yield
+  }
+
+  sealed trait TestIOSubclassing {
+    def mapSubclassing(): Int
+  }
+
+  final class FlatMapSubclassing extends TestIOSubclassing {
+    override def mapSubclassing(): Int = 1
+  }
+
+  final class PointSubclassing extends TestIOSubclassing {
+    override def mapSubclassing(): Int = 2
+  }
+
+  final class StrictSubclassing extends TestIOSubclassing {
+    override def mapSubclassing(): Int = 3
+  }
+
+  final class SyncEffectSubclassing extends TestIOSubclassing {
+    override def mapSubclassing(): Int = 4
+  }
+
+  final class AsyncEffectSubclassing extends TestIOSubclassing {
+
+    override def mapSubclassing(): Int = 4
+
+  }
+
+  final class RedeemSubclassing extends TestIOSubclassing {
+
+    override def mapSubclassing(): Int = 4
+
+  }
+
+  final class ForkSubclassing extends TestIOSubclassing {
+
+    override def mapSubclassing(): Int = 4
+
+  }
+
+  final class UninterruptibleSubclassing extends TestIOSubclassing {
+
+    override def mapSubclassing(): Int = 4
+
+  }
+
+  final class SuperviseSubclassing extends TestIOSubclassing {
+
+    override def mapSubclassing(): Int = 4
+
+  }
+
+  final class FailSubclassing extends TestIOSubclassing {
+
+    override def mapSubclassing(): Int = 4
+
+  }
+
+  final class EnsuringSubclassing extends TestIOSubclassing {
+
+    override def mapSubclassing(): Int = 4
+
+  }
+
+  final object DescriptorSubclassing extends TestIOSubclassing {
+
+    override def mapSubclassing(): Int = 4
+
+  }
+
+  final class LockSubclassing extends TestIOSubclassing {
+
+    override def mapSubclassing(): Int = 4
+
+  }
+
+  final object YieldSubclassing extends TestIOSubclassing {
+
+    override def mapSubclassing(): Int = 4
+
+  }
+
+  abstract class TestIOAbstractClass(storedTag0: Int) {
     final val storedTag = storedTag0
 
     final def mapWithSwitch(): Int = (storedTag: @switch) match {
       case IO.Tags.Point =>
-        this.asInstanceOf[ClassPoint]
+        this.asInstanceOf[AbstractClassPoint]
         1
 
       case IO.Tags.Strict =>
-        this.asInstanceOf[ClassStrict]
+        this.asInstanceOf[AbstractClassStrict]
         2
 
       case IO.Tags.Fail =>
-        this.asInstanceOf[TestIOClass]
+        this.asInstanceOf[TestIOAbstractClass]
         3
 
       case _ => 4
     }
   }
 
-  final class ClassFlatMap extends TestIOClass(Tags.FlatMap) {}
+  final class AbstractClassFlatMap extends TestIOAbstractClass(Tags.FlatMap)
 
-  final class ClassPoint extends TestIOClass(Tags.Point){}
+  final class AbstractClassPoint extends TestIOAbstractClass(Tags.Point)
 
-  final class ClassStrict extends TestIOClass(Tags.Strict){}
+  final class AbstractClassStrict extends TestIOAbstractClass(Tags.Strict)
 
-  final class ClassSyncEffect extends TestIOClass(Tags.SyncEffect){}
+  final class AbstractClassSyncEffect extends TestIOAbstractClass(Tags.SyncEffect)
 
-  final class ClassAsyncEffect extends TestIOClass(Tags.AsyncEffect){}
+  final class AbstractClassAsyncEffect extends TestIOAbstractClass(Tags.AsyncEffect)
 
-  final class ClassRedeem extends TestIOClass(Tags.Redeem){}
+  final class AbstractClassRedeem extends TestIOAbstractClass(Tags.Redeem)
 
-  final class ClassFork extends TestIOClass(Tags.Fork){}
+  final class AbstractClassFork extends TestIOAbstractClass(Tags.Fork)
 
-  final class ClassUninterruptible extends TestIOClass(Tags.Uninterruptible){}
+  final class AbstractClassUninterruptible extends TestIOAbstractClass(Tags.Uninterruptible)
 
-  final class ClassSupervise extends TestIOClass(Tags.Supervise){}
+  final class AbstractClassSupervise extends TestIOAbstractClass(Tags.Supervise)
 
-  final class ClassFail extends TestIOClass(Tags.Fail){}
+  final class AbstractClassFail extends TestIOAbstractClass(Tags.Fail)
 
-  final class ClassEnsuring extends TestIOClass(Tags.Ensuring){}
+  final class AbstractClassEnsuring extends TestIOAbstractClass(Tags.Ensuring)
 
-  final class Descriptor extends TestIOClass(Tags.Descriptor){}
+  final class Descriptor extends TestIOAbstractClass(Tags.Descriptor)
 
-  final class ClassLock extends TestIOClass(Tags.Lock){}
+  final class AbstractClassLock extends TestIOAbstractClass(Tags.Lock)
 
-  final class Yield extends TestIOClass(Tags.Yield){}
-  
+  final class Yield extends TestIOAbstractClass(Tags.Yield)
+
 }

--- a/benchmarks/src/main/scala/scalaz/zio/MapDispatchBenchmark.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/MapDispatchBenchmark.scala
@@ -3,7 +3,6 @@ import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
 import scalaz.zio.IO.Tags
-import scalaz.zio.MapDispatchBenchmark._
 
 import scala.annotation.switch
 
@@ -12,344 +11,346 @@ import scala.annotation.switch
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 class MapDispatchBenchmark {
 
-  val fmDefSwitch: TestIODefSwitch          = new FlatMapDefSwitch
-  val pointDefSwitch: TestIODefSwitch       = new PointDefSwitch
-  val strictDefSwitch: TestIODefSwitch      = new StrictDefSwitch
-  val syncEfDefSwitch: TestIODefSwitch      = new SyncEffectDefSwitch
-  val asyncEffectDefSwitch: TestIODefSwitch = new AsyncEffectDefSwitch
+  private[this] val fmDefSwitch: TestIODefSwitch          = new FlatMapDefSwitch
+  private[this] val pointDefSwitch: TestIODefSwitch       = new PointDefSwitch
+  private[this] val strictDefSwitch: TestIODefSwitch      = new StrictDefSwitch
+  private[this] val syncEfDefSwitch: TestIODefSwitch      = new SyncEffectDefSwitch
+  private[this] val asyncEffectDefSwitch: TestIODefSwitch = new AsyncEffectDefSwitch
+  private[this] val defArray: Array[TestIODefSwitch] =
+    Array(fmDefSwitch, pointDefSwitch, strictDefSwitch, syncEfDefSwitch, asyncEffectDefSwitch)
 
-  val fmValSwitch: TestIOValSwitch          = new FlatMapValSwitch
-  val pointValSwitch: TestIOValSwitch       = new PointValSwitch
-  val strictValSwitch: TestIOValSwitch      = new StrictValSwitch
-  val syncEfValSwitch: TestIOValSwitch      = new SyncEffectValSwitch
-  val asyncEffectValSwitch: TestIOValSwitch = new AsyncEffectValSwitch
+  private[this] val fmValSwitch: TestIOValSwitch          = new FlatMapValSwitch
+  private[this] val pointValSwitch: TestIOValSwitch       = new PointValSwitch
+  private[this] val strictValSwitch: TestIOValSwitch      = new StrictValSwitch
+  private[this] val syncEfValSwitch: TestIOValSwitch      = new SyncEffectValSwitch
+  private[this] val asyncEffectValSwitch: TestIOValSwitch = new AsyncEffectValSwitch
+  private[this] val valArray: Array[TestIOValSwitch] =
+    Array(fmValSwitch, pointValSwitch, strictValSwitch, syncEfValSwitch, asyncEffectValSwitch)
 
-  val fmCl: TestIOAbstractClass          = new AbstractClassFlatMap
-  val pointCl: TestIOAbstractClass       = new AbstractClassPoint
-  val strictCl: TestIOAbstractClass      = new AbstractClassStrict
-  val syncEfCl: TestIOAbstractClass      = new AbstractClassSyncEffect
-  val asyncEffectCl: TestIOAbstractClass = new AbstractClassAsyncEffect
+  private[this] val fmCl: TestIOAbstractClass          = new AbstractClassFlatMap
+  private[this] val pointCl: TestIOAbstractClass       = new AbstractClassPoint
+  private[this] val strictCl: TestIOAbstractClass      = new AbstractClassStrict
+  private[this] val syncEfCl: TestIOAbstractClass      = new AbstractClassSyncEffect
+  private[this] val asyncEffectCl: TestIOAbstractClass = new AbstractClassAsyncEffect
+  private[this] val clArray: Array[TestIOAbstractClass] =
+    Array(fmCl, pointCl, strictCl, syncEfCl, asyncEffectCl)
 
-  val fmSub: TestIOSubclassing          = new FlatMapSubclassing
-  val pointSub: TestIOSubclassing       = new PointSubclassing
-  val strictSub: TestIOSubclassing      = new StrictSubclassing
-  val syncEfSub: TestIOSubclassing      = new SyncEffectSubclassing
-  val asyncEffectSub: TestIOSubclassing = new AsyncEffectSubclassing
+  private[this] val fmSub: TestIOSubclassing          = new FlatMapSubclassing
+  private[this] val pointSub: TestIOSubclassing       = new PointSubclassing
+  private[this] val strictSub: TestIOSubclassing      = new StrictSubclassing
+  private[this] val syncEfSub: TestIOSubclassing      = new SyncEffectSubclassing
+  private[this] val asyncEffectSub: TestIOSubclassing = new AsyncEffectSubclassing
+  private[this] val subArray: Array[TestIOSubclassing] =
+    Array(fmSub, pointSub, strictSub, syncEfSub, asyncEffectSub)
 
   @Benchmark
   def allMapWithDefSwitch: Int =
-    asyncEffectDefSwitch.mapWithSwitch() +
-      fmDefSwitch.mapWithSwitch() +
-      syncEfDefSwitch.mapWithSwitch() +
-      strictDefSwitch.mapWithSwitch() +
-      pointDefSwitch.mapWithSwitch()
+    defArray(0).mapWithSwitch() +
+      defArray(1).mapWithSwitch() +
+      defArray(2).mapWithSwitch() +
+      defArray(3).mapWithSwitch() +
+      defArray(4).mapWithSwitch()
 
   @Benchmark
   def allMapWithValSwitch: Int =
-    asyncEffectDefSwitch.mapWithSwitch() +
-      fmDefSwitch.mapWithSwitch() +
-      syncEfDefSwitch.mapWithSwitch() +
-      strictDefSwitch.mapWithSwitch() +
-      pointDefSwitch.mapWithSwitch()
+    valArray(0).mapWithSwitch() +
+      valArray(1).mapWithSwitch() +
+      valArray(2).mapWithSwitch() +
+      valArray(3).mapWithSwitch() +
+      valArray(4).mapWithSwitch()
 
   @Benchmark
   def allSubclass(): Int =
-    asyncEffectSub.mapSubclassing() +
-      fmSub.mapSubclassing() +
-      syncEfSub.mapSubclassing() +
-      strictSub.mapSubclassing() +
-      pointSub.mapSubclassing()
+    subArray(0).mapSubclassing() +
+      subArray(1).mapSubclassing() +
+      subArray(2).mapSubclassing() +
+      subArray(3).mapSubclassing() +
+      subArray(4).mapSubclassing()
 
   @Benchmark
   def allMapWithSwitchClass: Int =
-    asyncEffectCl.mapWithSwitch() +
-      fmCl.mapWithSwitch() +
-      syncEfCl.mapWithSwitch() +
-      strictCl.mapWithSwitch() +
-      pointCl.mapWithSwitch()
+    clArray(0).mapWithSwitch() +
+      clArray(1).mapWithSwitch() +
+      clArray(2).mapWithSwitch() +
+      clArray(3).mapWithSwitch() +
+      clArray(4).mapWithSwitch()
+}
+
+sealed trait TestIODefSwitch { self =>
+  def tag: Int
+
+  final def mapWithSwitch(): Int = (self.tag: @switch) match {
+    case IO.Tags.Point =>
+      self.asInstanceOf[PointDefSwitch]
+      1
+
+    case IO.Tags.Strict =>
+      self.asInstanceOf[StrictDefSwitch]
+      2
+
+    case IO.Tags.Fail =>
+      self.asInstanceOf[TestIODefSwitch]
+      3
+
+    case _ => 4
+  }
+}
+
+final class FlatMapDefSwitch extends TestIODefSwitch {
+  override def tag: Int = Tags.FlatMap
+}
+
+final class PointDefSwitch extends TestIODefSwitch {
+  override def tag: Int = Tags.Point
+}
+
+final class StrictDefSwitch extends TestIODefSwitch {
+  override def tag: Int = Tags.Strict
+}
+
+final class SyncEffectDefSwitch extends TestIODefSwitch {
+  override def tag: Int = Tags.SyncEffect
+}
+
+final class AsyncEffectDefSwitch extends TestIODefSwitch {
+  override def tag: Int = Tags.AsyncEffect
+}
+
+final class RedeemDefSwitch extends TestIODefSwitch {
+  override def tag: Int = Tags.Redeem
+}
+
+final class ForkDefSwitch extends TestIODefSwitch {
+  override def tag: Int = Tags.Fork
+}
+
+final class UninterruptibleDefSwitch extends TestIODefSwitch {
+  override def tag: Int = Tags.Uninterruptible
+}
+
+final class SuperviseDefSwitch extends TestIODefSwitch {
+  override def tag: Int = Tags.Supervise
+}
+
+final class FailDefSwitch extends TestIODefSwitch {
+  override def tag: Int = Tags.Fail
+}
+
+final class EnsuringDefSwitch extends TestIODefSwitch {
+  override def tag: Int = Tags.Ensuring
+}
+
+final object DescriptorDefSwitch extends TestIODefSwitch {
+  override def tag: Int = Tags.Descriptor
+}
+
+final class LockDefSwitch extends TestIODefSwitch {
+  override def tag: Int = Tags.Lock
+}
+
+final object YieldDefSwitch extends TestIODefSwitch {
+  override def tag: Int = Tags.Yield
+}
+
+sealed trait TestIOValSwitch { self =>
+  val tag: Int
+
+  final def mapWithSwitch(): Int = (self.tag: @switch) match {
+    case IO.Tags.Point =>
+      self.asInstanceOf[PointValSwitch]
+      1
+
+    case IO.Tags.Strict =>
+      self.asInstanceOf[StrictValSwitch]
+      2
+
+    case IO.Tags.Fail =>
+      self.asInstanceOf[TestIOValSwitch]
+      3
+
+    case _ => 4
+  }
+}
+
+final class FlatMapValSwitch extends TestIOValSwitch {
+  override final val tag: Int = Tags.FlatMap
+}
+
+final class PointValSwitch extends TestIOValSwitch {
+  override final val tag: Int = Tags.Point
+}
+
+final class StrictValSwitch extends TestIOValSwitch {
+  override final val tag: Int = Tags.Strict
+}
+
+final class SyncEffectValSwitch extends TestIOValSwitch {
+  override final val tag: Int = Tags.SyncEffect
+}
+
+final class AsyncEffectValSwitch extends TestIOValSwitch {
+  override final val tag: Int = Tags.AsyncEffect
+}
+
+final class RedeemValSwitch extends TestIOValSwitch {
+  override final val tag: Int = Tags.Redeem
+}
+
+final class ForkValSwitch extends TestIOValSwitch {
+  override final val tag: Int = Tags.Fork
+}
+
+final class UninterruptibleValSwitch extends TestIOValSwitch {
+  override final val tag: Int = Tags.Uninterruptible
+}
+
+final class SuperviseValSwitch extends TestIOValSwitch {
+  override final val tag: Int = Tags.Supervise
+}
+
+final class FailValSwitch extends TestIOValSwitch {
+  override final val tag: Int = Tags.Fail
+}
+
+final class EnsuringValSwitch extends TestIOValSwitch {
+  override final val tag: Int = Tags.Ensuring
+}
+
+final object DescriptorValSwitch extends TestIOValSwitch {
+  override final val tag: Int = Tags.Descriptor
+}
+
+final class LockValSwitch extends TestIOValSwitch {
+  override final val tag: Int = Tags.Lock
+}
+
+final object YieldValSwitch extends TestIOValSwitch {
+  override final val tag: Int = Tags.Yield
+}
+
+sealed trait TestIOSubclassing {
+  def mapSubclassing(): Int
+}
+
+final class FlatMapSubclassing extends TestIOSubclassing {
+  override def mapSubclassing(): Int = 1
+}
+
+final class PointSubclassing extends TestIOSubclassing {
+  override def mapSubclassing(): Int = 2
+}
+
+final class StrictSubclassing extends TestIOSubclassing {
+  override def mapSubclassing(): Int = 3
+}
+
+final class SyncEffectSubclassing extends TestIOSubclassing {
+  override def mapSubclassing(): Int = 4
+}
+
+final class AsyncEffectSubclassing extends TestIOSubclassing {
+
+  override def mapSubclassing(): Int = 4
 
 }
 
-object MapDispatchBenchmark {
+final class RedeemSubclassing extends TestIOSubclassing {
 
-  sealed trait TestIODefSwitch { self =>
-    def tag: Int
-
-    final def mapWithSwitch(): Int = (self.tag: @switch) match {
-      case IO.Tags.Point =>
-        self.asInstanceOf[PointDefSwitch]
-        1
-
-      case IO.Tags.Strict =>
-        self.asInstanceOf[StrictDefSwitch]
-        2
-
-      case IO.Tags.Fail =>
-        self.asInstanceOf[TestIODefSwitch]
-        3
-
-      case _ => 4
-    }
-  }
-
-  final class FlatMapDefSwitch extends TestIODefSwitch {
-    override def tag: Int = Tags.FlatMap
-  }
-
-  final class PointDefSwitch extends TestIODefSwitch {
-    override def tag: Int = Tags.Point
-  }
-
-  final class StrictDefSwitch extends TestIODefSwitch {
-    override def tag: Int = Tags.Strict
-  }
-
-  final class SyncEffectDefSwitch extends TestIODefSwitch {
-    override def tag: Int = Tags.SyncEffect
-  }
-
-  final class AsyncEffectDefSwitch extends TestIODefSwitch {
-    override def tag: Int = Tags.AsyncEffect
-  }
-
-  final class RedeemDefSwitch extends TestIODefSwitch {
-    override def tag: Int = Tags.Redeem
-  }
-
-  final class ForkDefSwitch extends TestIODefSwitch {
-    override def tag: Int = Tags.Fork
-  }
-
-  final class UninterruptibleDefSwitch extends TestIODefSwitch {
-    override def tag: Int = Tags.Uninterruptible
-  }
-
-  final class SuperviseDefSwitch extends TestIODefSwitch {
-    override def tag: Int = Tags.Supervise
-  }
-
-  final class FailDefSwitch extends TestIODefSwitch {
-    override def tag: Int = Tags.Fail
-  }
-
-  final class EnsuringDefSwitch extends TestIODefSwitch {
-    override def tag: Int = Tags.Ensuring
-  }
-
-  final object DescriptorDefSwitch extends TestIODefSwitch {
-    override def tag: Int = Tags.Descriptor
-  }
-
-  final class LockDefSwitch extends TestIODefSwitch {
-    override def tag: Int = Tags.Lock
-  }
-
-  final object YieldDefSwitch extends TestIODefSwitch {
-    override def tag: Int = Tags.Yield
-  }
-
-  sealed trait TestIOValSwitch { self =>
-    val tag: Int
-
-    final def mapWithSwitch(): Int = (self.tag: @switch) match {
-      case IO.Tags.Point =>
-        self.asInstanceOf[PointDefSwitch]
-        1
-
-      case IO.Tags.Strict =>
-        self.asInstanceOf[StrictDefSwitch]
-        2
-
-      case IO.Tags.Fail =>
-        self.asInstanceOf[TestIODefSwitch]
-        3
-
-      case _ => 4
-    }
-  }
-
-  final class FlatMapValSwitch extends TestIOValSwitch {
-    override final val tag: Int = Tags.FlatMap
-  }
-
-  final class PointValSwitch extends TestIOValSwitch {
-    override final val tag: Int = Tags.Point
-  }
-
-  final class StrictValSwitch extends TestIOValSwitch {
-    override final val tag: Int = Tags.Strict
-  }
-
-  final class SyncEffectValSwitch extends TestIOValSwitch {
-    override final val tag: Int = Tags.SyncEffect
-  }
-
-  final class AsyncEffectValSwitch extends TestIOValSwitch {
-    override final val tag: Int = Tags.AsyncEffect
-  }
-
-  final class RedeemValSwitch extends TestIOValSwitch {
-    override final val tag: Int = Tags.Redeem
-  }
-
-  final class ForkValSwitch extends TestIOValSwitch {
-    override final val tag: Int = Tags.Fork
-  }
-
-  final class UninterruptibleValSwitch extends TestIOValSwitch {
-    override final val tag: Int = Tags.Uninterruptible
-  }
-
-  final class SuperviseValSwitch extends TestIOValSwitch {
-    override final val tag: Int = Tags.Supervise
-  }
-
-  final class FailValSwitch extends TestIOValSwitch {
-    override final val tag: Int = Tags.Fail
-  }
-
-  final class EnsuringValSwitch extends TestIOValSwitch {
-    override final val tag: Int = Tags.Ensuring
-  }
-
-  final object DescriptorValSwitch extends TestIOValSwitch {
-    override final val tag: Int = Tags.Descriptor
-  }
-
-  final class LockValSwitch extends TestIOValSwitch {
-    override final val tag: Int = Tags.Lock
-  }
-
-  final object YieldValSwitch extends TestIOValSwitch {
-    override final val tag: Int = Tags.Yield
-  }
-
-  sealed trait TestIOSubclassing {
-    def mapSubclassing(): Int
-  }
-
-  final class FlatMapSubclassing extends TestIOSubclassing {
-    override def mapSubclassing(): Int = 1
-  }
-
-  final class PointSubclassing extends TestIOSubclassing {
-    override def mapSubclassing(): Int = 2
-  }
-
-  final class StrictSubclassing extends TestIOSubclassing {
-    override def mapSubclassing(): Int = 3
-  }
-
-  final class SyncEffectSubclassing extends TestIOSubclassing {
-    override def mapSubclassing(): Int = 4
-  }
-
-  final class AsyncEffectSubclassing extends TestIOSubclassing {
-
-    override def mapSubclassing(): Int = 4
-
-  }
-
-  final class RedeemSubclassing extends TestIOSubclassing {
-
-    override def mapSubclassing(): Int = 4
-
-  }
-
-  final class ForkSubclassing extends TestIOSubclassing {
-
-    override def mapSubclassing(): Int = 4
-
-  }
-
-  final class UninterruptibleSubclassing extends TestIOSubclassing {
-
-    override def mapSubclassing(): Int = 4
-
-  }
-
-  final class SuperviseSubclassing extends TestIOSubclassing {
-
-    override def mapSubclassing(): Int = 4
-
-  }
-
-  final class FailSubclassing extends TestIOSubclassing {
-
-    override def mapSubclassing(): Int = 4
-
-  }
-
-  final class EnsuringSubclassing extends TestIOSubclassing {
-
-    override def mapSubclassing(): Int = 4
-
-  }
-
-  final object DescriptorSubclassing extends TestIOSubclassing {
-
-    override def mapSubclassing(): Int = 4
-
-  }
-
-  final class LockSubclassing extends TestIOSubclassing {
-
-    override def mapSubclassing(): Int = 4
-
-  }
-
-  final object YieldSubclassing extends TestIOSubclassing {
-
-    override def mapSubclassing(): Int = 4
-
-  }
-
-  abstract class TestIOAbstractClass(storedTag0: Int) {
-    final val storedTag = storedTag0
-
-    final def mapWithSwitch(): Int = (storedTag: @switch) match {
-      case IO.Tags.Point =>
-        this.asInstanceOf[AbstractClassPoint]
-        1
-
-      case IO.Tags.Strict =>
-        this.asInstanceOf[AbstractClassStrict]
-        2
-
-      case IO.Tags.Fail =>
-        this.asInstanceOf[TestIOAbstractClass]
-        3
-
-      case _ => 4
-    }
-  }
-
-  final class AbstractClassFlatMap extends TestIOAbstractClass(Tags.FlatMap)
-
-  final class AbstractClassPoint extends TestIOAbstractClass(Tags.Point)
-
-  final class AbstractClassStrict extends TestIOAbstractClass(Tags.Strict)
-
-  final class AbstractClassSyncEffect extends TestIOAbstractClass(Tags.SyncEffect)
-
-  final class AbstractClassAsyncEffect extends TestIOAbstractClass(Tags.AsyncEffect)
-
-  final class AbstractClassRedeem extends TestIOAbstractClass(Tags.Redeem)
-
-  final class AbstractClassFork extends TestIOAbstractClass(Tags.Fork)
-
-  final class AbstractClassUninterruptible extends TestIOAbstractClass(Tags.Uninterruptible)
-
-  final class AbstractClassSupervise extends TestIOAbstractClass(Tags.Supervise)
-
-  final class AbstractClassFail extends TestIOAbstractClass(Tags.Fail)
-
-  final class AbstractClassEnsuring extends TestIOAbstractClass(Tags.Ensuring)
-
-  final class Descriptor extends TestIOAbstractClass(Tags.Descriptor)
-
-  final class AbstractClassLock extends TestIOAbstractClass(Tags.Lock)
-
-  final class Yield extends TestIOAbstractClass(Tags.Yield)
+  override def mapSubclassing(): Int = 4
 
 }
+
+final class ForkSubclassing extends TestIOSubclassing {
+
+  override def mapSubclassing(): Int = 4
+
+}
+
+final class UninterruptibleSubclassing extends TestIOSubclassing {
+
+  override def mapSubclassing(): Int = 4
+
+}
+
+final class SuperviseSubclassing extends TestIOSubclassing {
+
+  override def mapSubclassing(): Int = 4
+
+}
+
+final class FailSubclassing extends TestIOSubclassing {
+
+  override def mapSubclassing(): Int = 4
+
+}
+
+final class EnsuringSubclassing extends TestIOSubclassing {
+
+  override def mapSubclassing(): Int = 4
+
+}
+
+final object DescriptorSubclassing extends TestIOSubclassing {
+
+  override def mapSubclassing(): Int = 4
+
+}
+
+final class LockSubclassing extends TestIOSubclassing {
+
+  override def mapSubclassing(): Int = 4
+
+}
+
+final object YieldSubclassing extends TestIOSubclassing {
+
+  override def mapSubclassing(): Int = 4
+
+}
+
+abstract class TestIOAbstractClass(val storedTag0: Int) {
+
+  final def mapWithSwitch(): Int = (storedTag0: @switch) match {
+    case IO.Tags.Point =>
+      this.asInstanceOf[AbstractClassPoint]
+      1
+
+    case IO.Tags.Strict =>
+      this.asInstanceOf[AbstractClassStrict]
+      2
+
+    case IO.Tags.Fail =>
+      this.asInstanceOf[TestIOAbstractClass]
+      3
+
+    case _ => 4
+  }
+}
+
+final class AbstractClassFlatMap extends TestIOAbstractClass(Tags.FlatMap)
+
+final class AbstractClassPoint extends TestIOAbstractClass(Tags.Point)
+
+final class AbstractClassStrict extends TestIOAbstractClass(Tags.Strict)
+
+final class AbstractClassSyncEffect extends TestIOAbstractClass(Tags.SyncEffect)
+
+final class AbstractClassAsyncEffect extends TestIOAbstractClass(Tags.AsyncEffect)
+
+final class AbstractClassRedeem extends TestIOAbstractClass(Tags.Redeem)
+
+final class AbstractClassFork extends TestIOAbstractClass(Tags.Fork)
+
+final class AbstractClassUninterruptible extends TestIOAbstractClass(Tags.Uninterruptible)
+
+final class AbstractClassSupervise extends TestIOAbstractClass(Tags.Supervise)
+
+final class AbstractClassFail extends TestIOAbstractClass(Tags.Fail)
+
+final class AbstractClassEnsuring extends TestIOAbstractClass(Tags.Ensuring)
+
+final class Descriptor extends TestIOAbstractClass(Tags.Descriptor)
+
+final class AbstractClassLock extends TestIOAbstractClass(Tags.Lock)
+
+final class Yield extends TestIOAbstractClass(Tags.Yield)

--- a/core/shared/src/main/scala/scalaz/zio/internal/Env.scala
+++ b/core/shared/src/main/scala/scalaz/zio/internal/Env.scala
@@ -5,6 +5,7 @@ import scalaz.zio._
 import scalaz.zio.Exit.Cause
 import java.util.concurrent.atomic.AtomicLong
 
+crash compilation
 /**
  * An environment provides the capability to execute different types
  * of tasks.


### PR DESCRIPTION
#525 - benchmark of different approaches to `map` method.
I created hierarchy that mimics `IO` and benchmarked `map` method implement various approaches:
* *WithSwitch uses `(self.tag @switch) match { ...` - what is currently implemented
* *Subclass is a classic dynamic polymorphic call
* *Visitor uses visitor pattern.

3 warm up iterations, 20 iterations (10 seconds), results are as follows:
```
[info] Benchmark                                      Mode  Cnt  Score   Error  Units
[info] MapDispatchBenchmark.allMapWithSwitch          avgt   20  5.148 ± 0.010  ns/op
[info] MapDispatchBenchmark.allSubclass               avgt   20  5.133 ± 0.009  ns/op
[info] MapDispatchBenchmark.allVisitor                avgt   20  5.388 ± 0.007  ns/op
[info] MapDispatchBenchmark.asyncEffectMapWithSwitch  avgt   20  3.117 ± 0.007  ns/op
[info] MapDispatchBenchmark.asyncEffectSubclass       avgt   20  3.116 ± 0.007  ns/op
[info] MapDispatchBenchmark.asyncEffectVisitor        avgt   20  3.386 ± 0.006  ns/op
[info] MapDispatchBenchmark.fmMapWithSwitch           avgt   20  3.127 ± 0.043  ns/op
[info] MapDispatchBenchmark.fmSubclass                avgt   20  3.112 ± 0.006  ns/op
[info] MapDispatchBenchmark.fmVisitor                 avgt   20  3.386 ± 0.007  ns/op
```

I'm not surprised that visitor is a little bit slower because it uses one extra function calls.
I'm surprised and I don't understand why using `(seft.tag @switch) match { ...` is not really slower than regular dynamic polymorphic call because `self.tag` is a polymorphic call alone and then `@switch` is used - so again one extra thing in comparison to subclassing.