### PR TITLE
Add IO.blocking

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -963,7 +963,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec {
     for {
       done  <- Ref(false)
       start <- IO.succeed(internal.OneShot.make[Unit])
-      fiber <- IO.blocking { start.set(()); while (true) { scala.io.StdIn.readLine() } }.ensuring(done.set(true)).fork
+      fiber <- IO.blocking { start.set(()); Thread.sleep(Long.MaxValue) }.ensuring(done.set(true)).fork
       _     <- IO.succeed(start.get())
       _     <- fiber.interrupt
       value <- done.get

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -962,7 +962,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec {
   def testBlockingIOIsInterruptible = unsafeRun(
     for {
       done  <- Ref(false)
-      fiber <- IO.blocking(while(true){scala.io.StdIn.readLine()}).ensuring(done.set(true)).fork
+      fiber <- IO.blocking(while (true) { scala.io.StdIn.readLine() }).ensuring(done.set(true)).fork
       _     <- fiber.interrupt
       value <- done.get
     } yield value must_=== true

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -123,6 +123,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec {
     check interruption regression 1         $testInterruptionRegression1
 
   RTS interruption
+    blocking IO is interruptible            $testBlockingIOIsInterruptible
     sync forever is interruptible           $testInterruptSyncForever
     interrupt of never                      $testNeverIsInterruptible
     asyncPure is interruptible              $testAsyncPureIsInterruptible
@@ -957,6 +958,15 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec {
     )
 
   }
+
+  def testBlockingIOIsInterruptible = unsafeRun(
+    for {
+      done  <- Ref(false)
+      fiber <- IO.blocking(while(true){scala.io.StdIn.readLine()}).ensuring(done.set(true)).fork
+      _     <- fiber.interrupt
+      value <- done.get
+    } yield value must_=== true
+  )
 
   def testInterruptSyncForever = unsafeRun(
     for {

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -1032,35 +1032,40 @@ object IO extends Serializable {
 
   /**
    * Imports a synchronous effect that does blocking IO into a pure value.
-   * 
+   *
    * If the returned `IO` is interrupted, the blocked thread running the synchronous effect
    * will be interrupted via `Thread.interrupt`.
    */
-  final def blocking[A](effect: => A): IO[Nothing, A] = IO.flatten(IO.sync {
-    import java.util.concurrent.locks.ReentrantLock 
-    import java.util.concurrent.atomic.AtomicReference
+  final def blocking[A](effect: => A): IO[Nothing, A] =
+    IO.flatten(IO.sync {
+      import java.util.concurrent.locks.ReentrantLock
+      import java.util.concurrent.atomic.AtomicReference
 
-    val lock   = new ReentrantLock()
-    val thread = new AtomicReference[Thread](null)
+      val lock   = new ReentrantLock()
+      val thread = new AtomicReference[Thread](null)
 
-    def withLock[B](b: => B): B = try { lock.lock(); b } finally lock.unlock()
+      def withLock[B](b: => B): B =
+        try {
+          lock.lock(); b
+        } finally lock.unlock()
 
-    for {
-      onInterrupt <- Ref[IO[Nothing, Unit]](IO.unit)
-      a <- (for {
-        fiber <- (IO.unyielding(IO.sync[Option[A]] { 
-          withLock(thread.set(Thread.currentThread()))
-  
-          try Some(effect)
-          catch {
-            case _ : InterruptedException => None
-          } finally withLock(thread.set(null))
-        }) <* onInterrupt.set(IO.sync(withLock(if (thread.get ne null) thread.get.interrupt())))).uninterruptible.fork
-        o <- fiber.join
-        a <- o.fold[IO[Nothing, A]](IO.interrupt)(IO.succeed(_))
-      } yield a).ensuring(IO.flatten(onInterrupt.get))
-    } yield a
-  })
+      for {
+        onInterrupt <- Ref[IO[Nothing, Unit]](IO.unit)
+        a <- (for {
+              fiber <- (IO.unyielding(IO.sync[Option[A]] {
+                        withLock(thread.set(Thread.currentThread()))
+
+                        try Some(effect)
+                        catch {
+                          case _: InterruptedException => None
+                        } finally withLock(thread.set(null))
+                      }) <* onInterrupt
+                        .set(IO.sync(withLock(if (thread.get ne null) thread.get.interrupt())))).uninterruptible.fork
+              o <- fiber.join
+              a <- o.fold[IO[Nothing, A]](IO.interrupt)(IO.succeed(_))
+            } yield a).ensuring(IO.flatten(onInterrupt.get))
+      } yield a
+    })
 
   /**
    * Imports a synchronous effect into a pure `IO` value.


### PR DESCRIPTION
Adds an `IO.blocking` function that keeps the effect on the blocking thread pool and allows interruption. Fixes #241, #75 