### PR TITLE
Have unyielding executor reuse threads instead of spawning new for every call

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -10,7 +10,6 @@ import scalaz.zio.Exit.Cause
 import scalaz.zio.Exit.Cause.{ Die, Fail, Then }
 import scalaz.zio.duration._
 import scalaz.zio.internal.Executor
-import scalaz.zio.internal.Executor.MeteredExecutor
 
 import scala.annotation.tailrec
 import scala.util.{ Failure, Success }
@@ -965,7 +964,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec {
 
   def testUnyieldingThreadCaching = {
     val currentNumLiveWorkers =
-      IO.sync0(_.executor(Executor.Unyielding).asInstanceOf[MeteredExecutor].metrics.workersCount)
+      IO.sync0(_.executor(Executor.Unyielding).metrics.get.workersCount)
 
     unsafeRunSync(for {
       thread1  <- IO.sync(Thread.currentThread()).unyielding

--- a/core/shared/src/main/scala/scalaz/zio/internal/ExecutionMetrics.scala
+++ b/core/shared/src/main/scala/scalaz/zio/internal/ExecutionMetrics.scala
@@ -27,4 +27,9 @@ trait ExecutionMetrics {
    * The number of tasks that have been dequeued, over all time.
    */
   def dequeuedCount: Long
+
+  /**
+   * The number of current live worker threads.
+   */
+  def workersCount: Int
 }

--- a/core/shared/src/main/scala/scalaz/zio/internal/Executor.scala
+++ b/core/shared/src/main/scala/scalaz/zio/internal/Executor.scala
@@ -159,7 +159,7 @@ object Executor extends Serializable {
     new Executor {
       def role = role0
 
-      def metrics = Some(new ExecutionMetrics {
+      private[this] def metrics0 = new ExecutionMetrics {
         def concurrency: Int = es.getMaximumPoolSize()
 
         def capacity: Int = {
@@ -178,9 +178,11 @@ object Executor extends Serializable {
         def enqueuedCount: Long = es.getTaskCount()
 
         def dequeuedCount: Long = enqueuedCount - size.toLong
-      })
+      }
 
-      def yieldOpCount = yieldOpCount0(metrics.value)
+      def metrics = Some(metrics0)
+
+      def yieldOpCount = yieldOpCount0(metrics0)
 
       def submit(runnable: Runnable): Boolean =
         try {

--- a/core/shared/src/test/scala/scalaz/zio/internal/ExecutorSpec.scala
+++ b/core/shared/src/test/scala/scalaz/zio/internal/ExecutorSpec.scala
@@ -12,6 +12,7 @@ final class TestExecutor(val role: Executor.Role, val submitResult: Boolean) ext
   def shutdown(): Unit                    = ()
   def submit(runnable: Runnable): Boolean = submitResult
   def yieldOpCount: Int                   = 1
+  def metrics: None.type                  = None
 }
 
 final class CheckPrintThrowable extends Throwable {


### PR DESCRIPTION
`corePoolSize  = Int.MaxValue` made unyielding Executor _always_ spawn a new thread and never reuse existing threads, due to `ExecutorService.execute`'s first conditional:

```java
        if (workerCountOf(c) < corePoolSize) {
            if (addWorker(command, true))
                return;
            c = ctl.get();
        }
```

Fixed with a regression test.