### PR TITLE
Refactor Managed to allow for interruptible acquisitions

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/ManagedSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/ManagedSpec.scala
@@ -2,14 +2,19 @@ package scalaz.zio
 
 import org.specs2.ScalaCheck
 import scala.collection.mutable
+import duration._
 
 class ManagedSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends AbstractRTSSpec with GenIO with ScalaCheck {
   def is = "ManagedSpec".title ^ s2"""
-  Invokes cleanups in reverse order of acquisition. $invokesCleanupsInReverse
-  Properly performs parallel acquire and release. $parallelAcquireAndRelease
+  Managed.make
+    Invokes cleanups in reverse order of acquisition. $invokesCleanupsInReverse
+    Properly performs parallel acquire and release. $parallelAcquireAndRelease
+    Constructs an uninterruptible Managed value. $uninterruptible
+  Managed.traverse
+    Invokes cleanups in reverse order of acquisition. $traverse
   """
 
-  def invokesCleanupsInReverse = {
+  private def invokesCleanupsInReverse = {
     val effects = new mutable.ListBuffer[Int]
     def res(x: Int) =
       Managed.make(IO.sync { effects += x; () })(_ => IO.sync { effects += x; () })
@@ -29,7 +34,7 @@ class ManagedSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Abstr
     effects must be_===(List(1, 2, 3, 3, 2, 1))
   }
 
-  def parallelAcquireAndRelease = {
+  private def parallelAcquireAndRelease = {
     val cleanups = new mutable.ListBuffer[String]
 
     def managed(v: String): Managed[Nothing, String] =
@@ -41,5 +46,29 @@ class ManagedSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Abstr
 
     result must haveSize(2)
     result.size === cleanups.size
+  }
+
+  private def traverse = {
+    val effects = new mutable.ListBuffer[Int]
+    def res(x: Int) =
+      Managed.make(IO.sync { effects += x; () })(_ => IO.sync { effects += x; () })
+
+    val resources = Managed.foreach(List(1, 2, 3))(res)
+
+    unsafeRun(resources.use(_ => IO.unit))
+
+    effects must be_===(List(1, 2, 3, 3, 2, 1))
+  }
+
+  private def uninterruptible = {
+    val program = for {
+      never              <- Promise.make[Nothing, Unit]
+      reachedAcquisition <- Promise.make[Nothing, Unit]
+      managedFiber       <- Managed.make(reachedAcquisition.succeed(()) *> never.await)(_ => IO.unit).use_(IO.unit).fork
+      _                  <- reachedAcquisition.await
+      interruption       <- managedFiber.interrupt.timeout(5.seconds).attempt
+    } yield interruption
+
+    unsafeRun(program) must be_===(Right(None))
   }
 }

--- a/core/shared/src/main/scala/scalaz/zio/Managed.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Managed.scala
@@ -11,44 +11,37 @@ package scalaz.zio
  * has been consumed, the resource will not be valid anymore and may fail with
  * some checked error, as per the type of the functions provided by the resource.
  */
-sealed abstract class Managed[+E, +R] extends Serializable { self =>
-  type R0 <: R
+final case class Managed[+E, +R](reserve: IO[E, Managed.Reservation[E, R]]) { self =>
+  import Managed.Reservation
 
-  protected def acquire: IO[E, R0]
-
-  protected def release: R0 => IO[Nothing, _]
-
-  def use[E1 >: E, A](f: R => IO[E1, A]): IO[E1, A]
+  def use[E1 >: E, A](f: R => IO[E1, A]): IO[E1, A] =
+    reserve.bracket[E1, A](_.release)(_.acquire.flatMap(f))
 
   final def use_[E1 >: E, A](f: IO[E1, A]): IO[E1, A] =
     use(_ => f)
 
   final def map[R1](f0: R => R1): Managed[E, R1] =
-    new Managed[E, R1] {
-      type R0 = R1
-
-      protected def acquire: IO[E, R1] = IO.never
-
-      protected def release: R1 => IO[Nothing, Unit] = _ => IO.unit
-
-      final def use[E1 >: E, A](f: R1 => IO[E1, A]): IO[E1, A] =
-        self.use(r => f(f0(r)))
+    Managed[E, R1] {
+      self.reserve.map(token => token.copy(acquire = token.acquire.map(f0)))
     }
 
   final def flatMap[E1 >: E, R1](f0: R => Managed[E1, R1]): Managed[E1, R1] =
-    new Managed[E1, R1] {
-      type R0 = R1
-
-      protected def acquire: IO[E1, R1] = IO.never
-
-      protected def release: R1 => IO[Nothing, Unit] = _ => IO.unit
-
-      final def use[E2 >: E1, A](f: R1 => IO[E2, A]): IO[E2, A] =
-        self.use { r =>
-          f0(r).use { r1 =>
-            f(r1)
-          }
-        }
+    Managed[E1, R1] {
+      Ref.make[IO[Nothing, Any]](IO.unit).map { finalizers =>
+        Reservation(
+          acquire = for {
+            resR <- self.reserve
+                     .flatMap(res => finalizers.update(fs => res.release *> fs).const(res))
+                     .uninterruptible
+            r <- resR.acquire
+            resR1 <- f0(r).reserve
+                      .flatMap(res => finalizers.update(fs => res.release *> fs).const(res))
+                      .uninterruptible
+            r1 <- resR1.acquire
+          } yield r1,
+          release = IO.flatten(finalizers.get)
+        )
+      }
     }
 
   final def *>[E1 >: E, R1](that: Managed[E1, R1]): Managed[E1, R1] =
@@ -64,22 +57,19 @@ sealed abstract class Managed[+E, +R] extends Serializable { self =>
     zipWith(that)((_, _))
 
   final def zipWithPar[E1 >: E, R1, R2](that: Managed[E1, R1])(f0: (R, R1) => R2): Managed[E1, R2] =
-    new Managed[E1, R2] {
-      type R0 = R2
+    Managed[E1, R2] {
+      Ref.make[IO[Nothing, Any]](IO.unit).map { finalizers =>
+        Reservation(
+          acquire = {
+            val left =
+              self.reserve.flatMap(res => finalizers.update(fs => res.release *> fs).const(res)).uninterruptible
+            val right =
+              that.reserve.flatMap(res => finalizers.update(fs => res.release *> fs).const(res)).uninterruptible
 
-      protected def acquire: IO[E1, R2] = IO.never
-
-      protected def release: R2 => IO[Nothing, Unit] = _ => IO.unit
-
-      def use[E2 >: E1, A](f: R2 => IO[E2, A]): IO[E2, A] = {
-        val acquireBoth = self.acquire.zipPar(that.acquire)
-
-        def releaseBoth(pair: (self.R0, that.R0)): IO[Nothing, Unit] =
-          self.release(pair._1).zipPar(that.release(pair._2)) *> IO.unit
-
-        acquireBoth.bracket[E2, A](releaseBoth) {
-          case (r, r1) => f(f0(r, r1))
-        }
+            left.flatMap(_.acquire).zipWithPar(right.flatMap(_.acquire))(f0)
+          },
+          release = IO.flatten(finalizers.get)
+        )
       }
     }
 
@@ -88,86 +78,44 @@ sealed abstract class Managed[+E, +R] extends Serializable { self =>
 }
 
 object Managed {
+  final case class Reservation[+E, +A](acquire: IO[E, A], release: IO[Nothing, _])
 
   /**
    * Lifts an `IO[E, R]`` into `Managed[E, R]`` with a release action.
    */
-  final def make[E, R](a: IO[E, R])(r: R => IO[Nothing, _]): Managed[E, R] =
-    new Managed[E, R] {
-      type R0 = R
-
-      protected def acquire: IO[E, R] = a
-
-      protected def release: R => IO[Nothing, _] = r
-
-      final def use[E1 >: E, A](f: R => IO[E1, A]): IO[E1, A] =
-        acquire.bracket[E1, A](release)(f)
-    }
+  final def make[E, R](acquire: IO[E, R])(release: R => IO[Nothing, _]): Managed[E, R] =
+    Managed(acquire.map(r => Reservation(IO.succeed(r), release(r))))
 
   /**
    * Lifts an IO[E, R] into Managed[E, R] with no release action. Use
    * with care.
    */
   final def liftIO[E, R](fa: IO[E, R]): Managed[E, R] =
-    new Managed[E, R] {
-      type R0 = R
-
-      protected def acquire: IO[E, R] = fa
-
-      protected def release: R => IO[Nothing, _] = _ => IO.unit
-
-      def use[E1 >: E, A](f: R => IO[E1, A]): IO[E1, A] =
-        fa.flatMap(f)
-    }
+    Managed(IO.succeed(Reservation(fa, IO.unit)))
 
   /**
    * Unwraps a `Managed` that is inside an `IO`.
    */
   final def unwrap[E, R](fa: IO[E, Managed[E, R]]): Managed[E, R] =
-    new Managed[E, R] {
-      type R0 = R
-
-      protected def acquire: IO[E, R] = IO.never
-
-      protected def release: R => IO[Nothing, Unit] = _ => IO.unit
-
-      final def use[E1 >: E, A](f: R => IO[E1, A]): IO[E1, A] =
-        fa.flatMap(_.use(f))
-    }
+    Managed(fa.flatMap(_.reserve))
 
   /**
    * Lifts a strict, pure value into a Managed.
    */
   final def succeed[R](r: R): Managed[Nothing, R] =
-    new Managed[Nothing, R] {
-      type R0 = R
-
-      protected def acquire: IO[Nothing, R] = IO.succeed(r)
-
-      protected def release: R => IO[Nothing, _] = _ => IO.unit
-
-      final def use[Nothing, A](f: R => IO[Nothing, A]): IO[Nothing, A] = f(r)
-    }
+    Managed(IO.succeed(Reservation(IO.succeed(r), IO.unit)))
 
   /**
    * Lifts a by-name, pure value into a Managed.
    */
   final def succeedLazy[R](r: => R): Managed[Nothing, R] =
-    new Managed[Nothing, R] {
-      type R0 = R
+    Managed(IO.succeed(Reservation(IO.succeedLazy(r), IO.unit)))
 
-      protected def acquire: IO[Nothing, R] = IO.succeedLazy(r)
-
-      protected def release: R => IO[Nothing, _] = _ => IO.unit
-
-      final def use[Nothing, A](f: R => IO[Nothing, A]): IO[Nothing, A] = f(r)
-    }
-
-  final def traverse[E, R, A](as: Iterable[A])(f: A => Managed[E, R]): Managed[E, List[R]] =
+  final def foreach[E, R, A](as: Iterable[A])(f: A => Managed[E, R]): Managed[E, List[R]] =
     as.foldRight[Managed[E, List[R]]](succeed(Nil)) { (a, m) =>
       f(a).zipWith(m)(_ :: _)
     }
 
-  final def sequence[E, R, A](ms: Iterable[Managed[E, R]]): Managed[E, List[R]] =
-    traverse(ms)(identity)
+  final def collectAll[E, R, A](ms: Iterable[Managed[E, R]]): Managed[E, List[R]] =
+    foreach(ms)(identity)
 }


### PR DESCRIPTION
Resolves #543.

This approach is pretty lean; the downside is that it's kind of wasteful in Ref allocations for repeated binds. We might be able to optimize this if we use an initial encoding for Managed. This can be left for subsequent PRs however as the current implementation is pretty much the same due to the use of `IO.bracket`.