### PR TITLE
Simplify IO.blocking and fix subtle race condition

### DIFF
--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -1057,10 +1057,9 @@ object IO extends Serializable {
 
       val interruptThread: IO[Nothing, Unit] =
         IO.sync(withMutex(thread.get match {
-            case None         => IO.unit
-            case Some(thread) => IO.sync(thread.interrupt())
-          }))
-          .flatten
+          case None         => ()
+          case Some(thread) => thread.interrupt()
+        }))
 
       val awaitInterruption: IO[Nothing, Unit] = IO.sync(barrier.get())
 

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -1073,11 +1073,12 @@ object IO extends Serializable {
 
                           try Right(effect)
                           catch {
-                            case e: InterruptedException =>
-                              Thread.interrupted
-                              Left(e)
-                            case t: Throwable => Left(t)
-                          } finally withMutex { thread.set(None); barrier.set(()) }
+                            case t: Throwable =>
+                              Thread.interrupted // Clear interrupt status
+                              Left(t)
+                          } finally {
+                            withMutex { thread.set(None); barrier.set(()) }
+                          }
                         })
                         .fork
               a <- fiber.join.absolve


### PR DESCRIPTION
Due to the nested `IO`, there was a subtle race condition that could result in the interrupt status being set on the thread even after it had completed executing the blocking task. Fixed that and simplified the code further in the process.