### PR TITLE
Decrease minimum duration of a timed test from 6 seconds to 60 ms (speeds up tests)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,7 @@
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
 import Scalaz._
 import xerial.sbt.Sonatype._
+import explicitdeps.ExplicitDepsPlugin.autoImport.moduleFilterRemoveValue
 
 name := "scalaz-zio"
 

--- a/core/jvm/src/test/scala/scalaz/zio/AbstractRTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/AbstractRTSSpec.scala
@@ -1,11 +1,14 @@
 package scalaz.zio
 
-import scala.concurrent.duration._
 import org.specs2.Specification
-import org.specs2.specification.{ AroundEach, AroundTimeout }
+import org.specs2.concurrent.ExecutionEnv
 import org.specs2.execute.{ AsResult, Failure, Result, Skipped }
-
+import org.specs2.matcher.Expectations
+import org.specs2.matcher.TerminationMatchers.terminate
+import org.specs2.specification.{ Around, AroundEach, AroundTimeout }
 import scalaz.zio.internal.impls.Env
+
+import scala.concurrent.duration._
 
 abstract class AbstractRTSSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     extends Specification
@@ -20,5 +23,17 @@ abstract class AbstractRTSSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
     AsResult.safely(upTo(DefaultTimeout)(r)) match {
       case Skipped(m, e) if m contains "TIMEOUT" => Failure(m, e)
       case other                                 => other
+    }
+
+  override final def aroundTimeout(to: Duration)(implicit ee: ExecutionEnv): Around =
+    new Around {
+      def around[T: AsResult](t: => T): Result = {
+        lazy val result = t
+        val termination = terminate(retries = 1000, sleep = (to.toMicros / 1000).micros)
+          .orSkip(_ => "TIMEOUT: " + to)(Expectations.createExpectable(result))
+
+        if (!termination.toResult.isSkipped) AsResult(result)
+        else termination.toResult
+      }
     }
 }


### PR DESCRIPTION
The `upTo` function in specs2 is written such that it checks whether the computation has finished with period of (timeout / 10); meaning that with a timeout of 60 seconds, it will first check only after 6 seconds has passed, which pins the minimum duration of a test to 6 seconds invariably. This makes it quite inconvenient to run the test suit while developing. Here I just decrease the minimum duration to 60 ms.
The import in sbt is required for sbt with global coursier plugin enabled