### PR TITLE
Add suspending methods fromEitherSync & fromTrySync. No longer suspend in fromTry.

### DIFF
--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -1289,13 +1289,25 @@ object IO extends Serializable {
     v.fold[IO[Unit, A]](IO.fail(()))(IO.succeed)
 
   /**
-   * Imports a `Try` into an `IO`.
+   * Lifts a `Try` into an `IO`.
    */
-  final def fromTry[A](effect: => scala.util.Try[A]): IO[Throwable, A] =
-    syncThrowable(effect).flatMap {
-      case scala.util.Success(v) => IO.succeed(v)
+  final def fromTry[A](v: scala.util.Try[A]): IO[Throwable, A] =
+    v match {
+      case scala.util.Success(a) => IO.succeed(a)
       case scala.util.Failure(t) => IO.fail(t)
     }
+
+  /**
+   * Imports an effect producing `Either` into an `IO`.
+   */
+  final def fromEitherSync[E, A](effect: => Either[E, A]): IO[E, A] =
+    sync(effect).flatMap(fromEither)
+
+  /**
+   * Imports an effect producing `Try` into an `IO`.
+   */
+  final def fromTrySync[A](effect: => scala.util.Try[A]): IO[Throwable, A] =
+    syncThrowable(effect).flatMap(fromTry)
 
   /**
    * Creates an `IO` value that represents the exit value of the specified

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -1277,19 +1277,19 @@ object IO extends Serializable {
   final def unsandbox[E, A](v: IO[Cause[E], A]): IO[E, A] = v.catchAll[E, A](IO.halt)
 
   /**
-   * Lifts an `Either` into an `IO`.
+   * Lifts an `Either` value into an `IO`.
    */
   final def fromEither[E, A](v: Either[E, A]): IO[E, A] =
     v.fold(IO.fail, IO.succeed)
 
   /**
-   * Lifts an `Option` into an `IO`.
+   * Lifts an `Option` value into an `IO`.
    */
   final def fromOption[A](v: Option[A]): IO[Unit, A] =
     v.fold[IO[Unit, A]](IO.fail(()))(IO.succeed)
 
   /**
-   * Lifts a `Try` into an `IO`.
+   * Lifts a `Try` value into an `IO`.
    */
   final def fromTry[A](v: scala.util.Try[A]): IO[Throwable, A] =
     v match {
@@ -1298,13 +1298,13 @@ object IO extends Serializable {
     }
 
   /**
-   * Imports an effect producing `Either` into an `IO`.
+   * Imports a synchronous effect producing `Either` into an `IO`.
    */
   final def fromEitherSync[E, A](effect: => Either[E, A]): IO[E, A] =
     sync(effect).flatMap(fromEither)
 
   /**
-   * Imports an effect producing `Try` into an `IO`.
+   * Imports a synchronous effect producing `Try` into an `IO`.
    */
   final def fromTrySync[A](effect: => scala.util.Try[A]): IO[Throwable, A] =
     syncThrowable(effect).flatMap(fromTry)

--- a/interop-monix/shared/src/main/scala/zio/interop/monix.scala
+++ b/interop-monix/shared/src/main/scala/zio/interop/monix.scala
@@ -10,7 +10,7 @@ object monixio {
       Task.fromFuture(scheduler)(Task(task.runToFuture))
 
     def fromCoeval[A](coeval: eval.Coeval[A]): Task[A] =
-      IO.fromTry(coeval.runTry())
+      IO.fromTrySync(coeval.runTry())
   }
 
   implicit class IOThrowableOps[A](private val io: Task[A]) extends AnyVal {

--- a/interop-shared/shared/src/main/scala/scalaz/zio/interop/task.scala
+++ b/interop-shared/shared/src/main/scala/scalaz/zio/interop/task.scala
@@ -32,7 +32,7 @@ object Task {
                 case Failure(t) => cb(IO.fail(t))
               }(ec)
             }
-          )(IO.fromTry(_))
+          )(IO.fromTry)
       )
     }
 }


### PR DESCRIPTION
Motivation: Sometimes suspension in fromEither is desirable, chiefly to avoid leaking any potential defects when the IO value is *constructed*. e.g.

```scala
final case class Strategy(f: IO[Nothing, Unit])

def computeStrategy(options: Options): Strategy =
  Strategy(IO.fromEither(seeminglyPureFunction(options)).redeem(...))
```

If `seeminglyPureFunction` in fact throws, it will throw during the construction of `Strategy`, not during the evaluation of `f`. This can potentially leak outside of RTS:

```scala
final class App extends scalaz.zio.App {
   def run(args: List[String]) = {
     val strategy = computeStrategy(args)
     strategy.f
   }
}
```

The error here will be thrown _before_ the `unsafeRun` in main.

To avoid warts arising from strict evaluation and reliably catch all errors you might want to always suspend in operators that come before the first `.flatMap` boundary. This adds syntactic sugar for this case. `fromTry` is also changed for symmetry.
