### PR TITLE
Add Cause.FinalizerErrors constructor to distinguish between direct causes of failure and errors accummulated during finalization

### DIFF
--- a/core/shared/src/main/scala/scalaz/zio/FiberFailure.scala
+++ b/core/shared/src/main/scala/scalaz/zio/FiberFailure.scala
@@ -16,6 +16,8 @@ final case class FiberFailure(cause: Cause[Any]) extends Throwable {
       case Cause.Interrupt          => "The fiber was terminated by an interruption"
       case Cause.Then(left, right)  => "Both fibers terminated in sequence: \n" + message(left) + "\n" + message(right)
       case Cause.Both(left, right)  => "Both fibers terminated in parallel: \n" + message(left) + "\n" + message(right)
+      case Cause.FinalizerErrors(c) =>
+        "Further errors occurred during finalization after fiber failure: \n" + message(c)
     }
   }
 }

--- a/interop-cats/jvm/src/main/scala/scalaz/zio/interop/catsjvm.scala
+++ b/interop-cats/jvm/src/main/scala/scalaz/zio/interop/catsjvm.scala
@@ -131,7 +131,13 @@ private class CatsEffect extends CatsMonadError[Throwable] with Effect[Task] wit
     case Exit.Failure(cause) =>
       cause.failureOrCause match {
         case Left(t) => ExitCase.Error(t)
-        case _       => ExitCase.Error(FiberFailure(cause))
+        case Right(defect) =>
+          defect.defects match {
+            case firstCausingDefect :: _ =>
+              ExitCase.Error(firstCausingDefect)
+            case Nil =>
+              ExitCase.Error(FiberFailure(cause))
+          }
       }
   }
 


### PR DESCRIPTION
This re-addresses https://github.com/scalaz/scalaz-zio/issues/170

Another option was to add a `fromFinalizer: Boolean` flag on `Die` constructor, but this misses the cases with inner interruption or failed races in finalizer https://github.com/scalaz/scalaz-zio/compare/master...kaishh:feature/distinguish-direct-causes-vs-cleanup

I think it's worth thinking about including the `FiberId` into Cause and possibly even more information (e.g. @pshirshov suggested including tree of parent fibers) – if so, the constructors of `Cause` would have to be hidden to allow evolution