### PR TITLE
Allow using an environment in RefM's modify and Managed's release

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/RefMSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RefMSpec.scala
@@ -70,7 +70,7 @@ class RefMSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRunt
     unsafeRun(
       for {
         refM  <- RefM.make(current)
-        r     <- refM.modify[String](_ => IO.effectTotal(("hello", update)))
+        r     <- refM.modify(_ => IO.effectTotal(("hello", update)))
         value <- refM.get
       } yield (r must beTheSameAs("hello")) and (value must beTheSameAs(update))
     )
@@ -79,9 +79,9 @@ class RefMSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRunt
     unsafeRun(
       for {
         refM   <- RefM.make[State](Active)
-        r1     <- refM.modifySome[String]("doesn't change the state") { case Active => IO.succeed("changed" -> Changed) }
+        r1     <- refM.modifySome("doesn't change the state") { case Active => IO.succeed("changed" -> Changed) }
         value1 <- refM.get
-        r2 <- refM.modifySome[String]("doesn't change the state") {
+        r2 <- refM.modifySome("doesn't change the state") {
                case Active  => IO.succeed("changed" -> Changed)
                case Changed => IO.succeed("closed"  -> Closed)
              }
@@ -96,7 +96,7 @@ class RefMSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRunt
     unsafeRun(
       for {
         refM  <- RefM.make[State](Active)
-        r     <- refM.modifySome[String]("State doesn't change") { case Closed => IO.succeed("active" -> Active) }
+        r     <- refM.modifySome("State doesn't change") { case Closed => IO.succeed("active" -> Active) }
         value <- refM.get
       } yield (r must beTheSameAs("State doesn't change")) and (value must beTheSameAs(Active))
     )

--- a/core/shared/src/main/scala/scalaz/zio/ZIO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/ZIO.scala
@@ -1397,8 +1397,8 @@ trait ZIOFunctions extends Serializable {
   /**
    * Folds an `Iterable[A]` using an effectful function `f`, working sequentially.
    */
-  final def foldLeft[E, S, A](in: Iterable[A])(zero: S)(f: (S, A) => IO[E, S]): IO[E, S] =
-    in.foldLeft(IO.succeed(zero): IO[E, S]) { (acc, el) =>
+  final def foldLeft[R >: LowerR, E, S, A](in: Iterable[A])(zero: S)(f: (S, A) => ZIO[R, E, S]): ZIO[R, E, S] =
+    in.foldLeft(IO.succeed(zero): ZIO[R, E, S]) { (acc, el) =>
       acc.flatMap(f(_, el))
     }
 

--- a/core/shared/src/main/scala/scalaz/zio/ZIO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/ZIO.scala
@@ -1129,7 +1129,7 @@ trait ZIOFunctions extends Serializable {
 
   /**
    * Returns a lazily constructed effect, whose construction may itself require
-   * effects. This is a shortcut for `flatten(effectTotal(io)).
+   * effects. This is a shortcut for `flatten(effectTotal(io))`.
    */
   final def suspend[R >: LowerR, E <: UpperE, A](io: => ZIO[R, E, A]): ZIO[R, E, A] =
     flatten(effectTotal(io))


### PR DESCRIPTION
`RefM`'s `update/modify` and `Managed`'s `release` were fixed to `UIO`.
This PR allows using `ZIO[R, Nothing, A]` instead.