### PR TITLE
Merged parameters lists for 'bracket' to help type inference.

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/IOSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/IOSpec.scala
@@ -210,17 +210,17 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
 
   def acquireTypeInferenceOnE = {
     type Resource = Unit
-    val acquire: ZIO[Any, RuntimeException, Resource] = ???
+    val acquire: ZIO[Any, RuntimeException, Resource]  = ???
     val release: Resource => ZIO[Any, Nothing, String] = ???
-    val use: Resource => ZIO[Any, Exception, Int] = ???
+    val use: Resource => ZIO[Any, Exception, Int]      = ???
     acquire.bracket(release, use): ZIO[Any, Throwable, Int]
     ZIO.bracket(acquire, release, use): ZIO[Any, Throwable, Int]
   }
 
   def acquireTypeInferenceOnE2 = {
     type Resource = Unit
-    val acquire: ZIO[Any, Exception, Resource] = ???
-    val release: Resource => ZIO[Any, Nothing, String] = ???
+    val acquire: ZIO[Any, Exception, Resource]           = ???
+    val release: Resource => ZIO[Any, Nothing, String]   = ???
     val use: Resource => ZIO[Any, RuntimeException, Int] = ???
     acquire.bracket(release, use): ZIO[Any, Throwable, Int]
     ZIO.bracket(acquire, release, use): ZIO[Any, Throwable, Int]
@@ -228,27 +228,27 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
 
   def zioAcquireTypeInferenceOnR = {
     type Resource = Unit
-    val acquire: ZIO[Unit, Nothing, Resource] = ???
+    val acquire: ZIO[Unit, Nothing, Resource]          = ???
     val release: Resource => ZIO[Any, Nothing, String] = ???
-    val use: Resource => ZIO[Any, Nothing, Int] = ???
+    val use: Resource => ZIO[Any, Nothing, Int]        = ???
     acquire.bracket(release, use): ZIO[Unit, Nothing, Int]
     ZIO.bracket(acquire, release, use): ZIO[Unit, Nothing, Int]
   }
 
   def zioAcquireTypeInferenceOnR2 = {
     type Resource = Unit
-    val acquire: ZIO[Any, Nothing, Resource] = ???
+    val acquire: ZIO[Any, Nothing, Resource]            = ???
     val release: Resource => ZIO[Unit, Nothing, String] = ???
-    val use: Resource => ZIO[Any, Nothing, Int] = ???
+    val use: Resource => ZIO[Any, Nothing, Int]         = ???
     acquire.bracket(release, use): ZIO[Unit, Nothing, Int]
     ZIO.bracket(acquire, release, use): ZIO[Unit, Nothing, Int]
   }
 
   def zioAcquireTypeInferenceOnR3 = {
     type Resource = Unit
-    val acquire: ZIO[Any, Nothing, Resource] = ???
+    val acquire: ZIO[Any, Nothing, Resource]           = ???
     val release: Resource => ZIO[Any, Nothing, String] = ???
-    val use: Resource => ZIO[Unit, Nothing, Int] = ???
+    val use: Resource => ZIO[Unit, Nothing, Int]       = ???
     acquire.bracket(release, use): ZIO[Unit, Nothing, Int]
     ZIO.bracket(acquire, release, use): ZIO[Unit, Nothing, Int]
   }

--- a/core/jvm/src/test/scala/scalaz/zio/IOSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/IOSpec.scala
@@ -207,4 +207,49 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
       race2 <- IO.raceAll(io, ios)
     } yield race1 must ===(race2))
   }
+
+  def acquireTypeInferenceOnE = {
+    type Resource = Unit
+    val acquire: ZIO[Any, RuntimeException, Resource] = ???
+    val release: Resource => ZIO[Any, Nothing, String] = ???
+    val use: Resource => ZIO[Any, Exception, Int] = ???
+    acquire.bracket(release, use): ZIO[Any, Throwable, Int]
+    ZIO.bracket(acquire, release, use): ZIO[Any, Throwable, Int]
+  }
+
+  def acquireTypeInferenceOnE2 = {
+    type Resource = Unit
+    val acquire: ZIO[Any, Exception, Resource] = ???
+    val release: Resource => ZIO[Any, Nothing, String] = ???
+    val use: Resource => ZIO[Any, RuntimeException, Int] = ???
+    acquire.bracket(release, use): ZIO[Any, Throwable, Int]
+    ZIO.bracket(acquire, release, use): ZIO[Any, Throwable, Int]
+  }
+
+  def zioAcquireTypeInferenceOnR = {
+    type Resource = Unit
+    val acquire: ZIO[Unit, Nothing, Resource] = ???
+    val release: Resource => ZIO[Any, Nothing, String] = ???
+    val use: Resource => ZIO[Any, Nothing, Int] = ???
+    acquire.bracket(release, use): ZIO[Unit, Nothing, Int]
+    ZIO.bracket(acquire, release, use): ZIO[Unit, Nothing, Int]
+  }
+
+  def zioAcquireTypeInferenceOnR2 = {
+    type Resource = Unit
+    val acquire: ZIO[Any, Nothing, Resource] = ???
+    val release: Resource => ZIO[Unit, Nothing, String] = ???
+    val use: Resource => ZIO[Any, Nothing, Int] = ???
+    acquire.bracket(release, use): ZIO[Unit, Nothing, Int]
+    ZIO.bracket(acquire, release, use): ZIO[Unit, Nothing, Int]
+  }
+
+  def zioAcquireTypeInferenceOnR3 = {
+    type Resource = Unit
+    val acquire: ZIO[Any, Nothing, Resource] = ???
+    val release: Resource => ZIO[Any, Nothing, String] = ???
+    val use: Resource => ZIO[Unit, Nothing, Int] = ???
+    acquire.bracket(release, use): ZIO[Unit, Nothing, Int]
+    ZIO.bracket(acquire, release, use): ZIO[Unit, Nothing, Int]
+  }
 }

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -413,13 +413,13 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
     unsafeRun(for {
       ref <- Ref.make[List[String]](Nil)
       log = makeLogger(ref)
-      f <- ZIO.unit.bracket(
-            _ => log("start 1") *> clock.sleep(10.millis) *> log("release 1"),
-            _ => ZIO.unit)
-          .bracket(
-            _ => log("start 2") *> clock.sleep(10.millis) *> log("release 2"),
-            _ => ZIO.unit
-          ).fork
+      f <- ZIO.unit
+            .bracket(_ => log("start 1") *> clock.sleep(10.millis) *> log("release 1"), _ => ZIO.unit)
+            .bracket(
+              _ => log("start 2") *> clock.sleep(10.millis) *> log("release 2"),
+              _ => ZIO.unit
+            )
+            .fork
       _ <- (ref.get <* clock.sleep(1.millis)).repeat(Schedule.doUntil[List[String]](_.contains("start 1")))
       _ <- f.interrupt
       _ <- (ref.get <* clock.sleep(1.millis)).repeat(Schedule.doUntil[List[String]](_.contains("release 2")))

--- a/core/shared/src/main/scala/scalaz/zio/FiberLocal.scala
+++ b/core/shared/src/main/scala/scalaz/zio/FiberLocal.scala
@@ -57,7 +57,7 @@ final class FiberLocal[A] private (private val state: Ref[State[A]]) extends Ser
    * Guarantees that fiber-local data is properly freed via `bracket`.
    */
   final def locally[R, E, B](value: A)(use: ZIO[R, E, B]): ZIO[R, E, B] =
-    set(value).bracket[R, E, B](_ => empty)(_ => use)
+    set(value).bracket(_ => empty, _ => use)
 
 }
 

--- a/core/shared/src/main/scala/scalaz/zio/Managed.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Managed.scala
@@ -31,7 +31,7 @@ final case class Managed[-R, +E, +A](reserve: ZIO[R, E, Managed.Reservation[R, E
   import Managed.Reservation
 
   def use[R1 <: R, E1 >: E, B](f: A => ZIO[R1, E1, B]): ZIO[R1, E1, B] =
-    reserve.bracket[R1, E1, B](_.release)(_.acquire.flatMap(f))
+    reserve.bracket(_.release, _.acquire.flatMap(f))
 
   final def use_[R1 <: R, E1 >: E, B](f: ZIO[R1, E1, B]): ZIO[R1, E1, B] =
     use(_ => f)

--- a/core/shared/src/main/scala/scalaz/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Semaphore.scala
@@ -62,7 +62,7 @@ final class Semaphore private (private val state: Ref[State]) extends Serializab
   final def release: UIO[Unit] = releaseN(1)
 
   final def withPermit[R, E, A](task: ZIO[R, E, A]): ZIO[R, E, A] =
-    prepare(1L).bracket[R, E, A](_.release)(_.awaitAcquire *> task)
+    prepare(1L).bracket(_.release, _.awaitAcquire *> task)
 
   /**
    * Acquires a specified number of permits.

--- a/core/shared/src/main/scala/scalaz/zio/ZIO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/ZIO.scala
@@ -1260,7 +1260,8 @@ trait ZIOFunctions extends Serializable {
   final def bracket[R >: LowerR, E <: UpperE, A, B](
     acquire: ZIO[R, E, A],
     release: A => ZIO[R, Nothing, _],
-    use: A => ZIO[R, E, B]): ZIO[R, E, B] =
+    use: A => ZIO[R, E, B]
+  ): ZIO[R, E, B] =
     Ref.make[UIO[Any]](ZIO.unit).flatMap { m =>
       (for {
         r <- environment[R]
@@ -1268,51 +1269,6 @@ trait ZIOFunctions extends Serializable {
         b <- use(a)
       } yield b).ensuring(flatten(m.get))
     }
-
-  def acquireTypeInferenceOnE = {
-    type Resource = Unit
-    val acquire: ZIO[Any, RuntimeException, Resource] = ???
-    val release: Resource => ZIO[Any, Nothing, String] = ???
-    val use: Resource => ZIO[Any, Exception, Int] = ???
-    acquire.bracket(release, use): ZIO[Any, Throwable, Int]
-    ZIO.bracket(acquire,release, use): ZIO[Any, Throwable, Int]
-  }
-
-  def acquireTypeInferenceOnE2 = {
-    type Resource = Unit
-    val acquire: ZIO[Any, Exception, Resource] = ???
-    val release: Resource => ZIO[Any, Nothing, String] = ???
-    val use: Resource => ZIO[Any, RuntimeException, Int] = ???
-    acquire.bracket(release,use): ZIO[Any, Throwable, Int]
-    ZIO.bracket(acquire,release,use): ZIO[Any, Throwable, Int]
-  }
-
-  def zioAcquireTypeInferenceOnR = {
-    type Resource = Unit
-    val acquire: ZIO[Unit, Nothing, Resource] = ???
-    val release: Resource => ZIO[Any, Nothing, String] = ???
-    val use: Resource => ZIO[Any, Nothing, Int] = ???
-    acquire.bracket(release,use): ZIO[Unit, Nothing, Int]
-    ZIO.bracket(acquire,release,use): ZIO[Unit, Nothing, Int]
-  }
-
-  def zioAcquireTypeInferenceOnR2 = {
-    type Resource = Unit
-    val acquire: ZIO[Any, Nothing, Resource] = ???
-    val release: Resource => ZIO[Unit, Nothing, String] = ???
-    val use: Resource => ZIO[Any, Nothing, Int] = ???
-    acquire.bracket(release,use): ZIO[Unit, Nothing, Int]
-    ZIO.bracket(acquire,release,use): ZIO[Unit, Nothing, Int]
-  }
-
-  def zioAcquireTypeInferenceOnR3 = {
-    type Resource = Unit
-    val acquire: ZIO[Any, Nothing, Resource] = ???
-    val release: Resource => ZIO[Any, Nothing, String] = ???
-    val use: Resource => ZIO[Unit, Nothing, Int] = ???
-    acquire.bracket(release,use): ZIO[Unit, Nothing, Int]
-    ZIO.bracket(acquire,release,use): ZIO[Unit, Nothing, Int]
-  }
 
   /**
    * Acquires a resource, uses the resource, and then releases the resource.

--- a/interop-cats/jvm/src/main/scala/scalaz/zio/interop/catsjvm.scala
+++ b/interop-cats/jvm/src/main/scala/scalaz/zio/interop/catsjvm.scala
@@ -188,7 +188,7 @@ private class CatsEffect
   override final def bracket[A, B](acquire: Task[A])(use: A => Task[B])(
     release: A => Task[Unit]
   ): Task[B] =
-    IO.bracket(acquire)(release(_).orDie)(use)
+    acquire.bracket(release(_).orDie, use)
 
   override final def bracketCase[A, B](
     acquire: Task[A]

--- a/interop-shared/shared/src/main/scala/scalaz/zio/interop/package.scala
+++ b/interop-shared/shared/src/main/scala/scalaz/zio/interop/package.scala
@@ -35,6 +35,6 @@ package object interop {
      * This resource will get automatically closed, because it implements `AutoCloseable`.
      */
     def bracketAuto[E1 >: E, B](use: A => IO[E1, B]): IO[E1, B] =
-      io.bracket[Any, E1, B](_.closeIO())(use)
+      io.bracket(_.closeIO(), use)
   }
 }

--- a/microsite/src/main/tut/datatypes/io.md
+++ b/microsite/src/main/tut/datatypes/io.md
@@ -148,7 +148,7 @@ def groupData(u: Unit): IO[IOException, Unit] = IO.unit
 ```
 
 ```tut:silent
-val z: IO[IOException, Unit] = openFile("data.json").bracket(closeFile(_)) { file =>
+val z: IO[IOException, Unit] = openFile("data.json").bracket(closeFile(_), file => {
   for {
     data    <- decodeData(file)
     grouped <- groupData(data)


### PR DESCRIPTION
Addressing https://github.com/scalaz/scalaz-zio/issues/586 by merging parameters lists.
I advocate for this one instead of creating `AcquirePartial` class with `apply` method because of performance is objective and multiple parameters list vs multiple parameters in one list subjective.