### PR TITLE
Fix semantics of `provide` and improve type inference

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -142,6 +142,9 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
     interruption of raced                   $testInterruptedOfRaceInterruptsContestents
     cancelation is guaranteed               $testCancelationIsGuaranteed
     interruption of unending bracket        $testInterruptionOfUnendingBracket
+
+  RTS environment
+    provide is modular                      $testProvideIsModular
   """
   }
 
@@ -715,6 +718,16 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
     (0 to 100).map { _ =>
       unsafeRun(io) must_=== 42
     }.reduce(_ and _)
+  }
+
+  def testProvideIsModular = {
+    val zio =
+      (for {
+        v1 <- ZIO.environment[Int]
+        v2 <- ZIO.environment[Int].provide(2)
+        v3 <- ZIO.environment[Int]
+      } yield (v1, v2, v3)).provide(4)
+    unsafeRun(zio) must_=== ((4, 2, 4))
   }
 
   def testAsyncPureIsInterruptible = {

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -705,9 +705,10 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
       exitLatch  <- Promise.make[Nothing, Int]
       bracketed = IO
         .succeed(21)
-        .bracketExit((r: Int, exit: Exit[_, _]) =>
-          if (exit.interrupted) exitLatch.succeed(r)
-          else IO.die(new Error("Unexpected case"))
+        .bracketExit(
+          (r: Int, exit: Exit[_, _]) =>
+            if (exit.interrupted) exitLatch.succeed(r)
+            else IO.die(new Error("Unexpected case"))
         )(a => startLatch.succeed(a) *> IO.never *> IO.succeed(1))
       fiber      <- bracketed.fork
       startValue <- startLatch.await

--- a/core/jvm/src/test/scala/scalaz/zio/SemaphoreSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/SemaphoreSpec.scala
@@ -51,7 +51,7 @@ class SemaphoreSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Tes
   def e5 = {
     val n = 1L
     unsafeRun(for {
-      s <- Semaphore.make(n).peek(_.acquire)
+      s <- Semaphore.make(n).tap(_.acquire)
       _ <- s.release.fork
       _ <- s.acquire
     } yield () must_=== (()))

--- a/core/shared/src/main/scala/scalaz/zio/FiberLocal.scala
+++ b/core/shared/src/main/scala/scalaz/zio/FiberLocal.scala
@@ -57,7 +57,7 @@ final class FiberLocal[A] private (private val state: Ref[State[A]]) extends Ser
    * Guarantees that fiber-local data is properly freed via `bracket`.
    */
   final def locally[R, E, B](value: A)(use: ZIO[R, E, B]): ZIO[R, E, B] =
-    set(value).bracket[R, E, B](_ => empty)(_ => use)
+    set(value).bracket_(empty)(use)
 
 }
 

--- a/core/shared/src/main/scala/scalaz/zio/Managed.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Managed.scala
@@ -31,7 +31,7 @@ final case class Managed[-R, +E, +A](reserve: ZIO[R, E, Managed.Reservation[R, E
   import Managed.Reservation
 
   def use[R1 <: R, E1 >: E, B](f: A => ZIO[R1, E1, B]): ZIO[R1, E1, B] =
-    reserve.bracket[R1, E1, B](_.release)(_.acquire.flatMap(f))
+    reserve.bracket(_.release)(_.acquire.flatMap(f))
 
   final def use_[R1 <: R, E1 >: E, B](f: ZIO[R1, E1, B]): ZIO[R1, E1, B] =
     use(_ => f)

--- a/core/shared/src/main/scala/scalaz/zio/Schedule.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Schedule.scala
@@ -295,7 +295,7 @@ trait Schedule[-R, -A, +B] extends Serializable { self =>
    * that log failures, decisions, or computed values.
    */
   final def onDecision[A1 <: A](f: (A1, Schedule.Decision[State, B]) => UIO[Unit]): Schedule[R, A1, B] =
-    updated(update => (a, s) => update(a, s).peek(step => f(a, step)))
+    updated(update => (a, s) => update(a, s).tap(step => f(a, step)))
 
   /**
    * Returns a new schedule with the specified effectful modification

--- a/core/shared/src/main/scala/scalaz/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Semaphore.scala
@@ -73,7 +73,7 @@ final class Semaphore private (private val state: Ref[State]) extends Serializab
    * Ported from @mpilquist work in cats-effects (https://github.com/typelevel/cats-effect/pull/403)
    */
   final def acquireN(n: Long): UIO[Unit] =
-    assertNonNegative(n) *> IO.bracketExit[Any, Nothing, Acquisition, Unit](prepare(n))(cleanup)(_.awaitAcquire)
+    assertNonNegative(n) *> IO.bracketExit(prepare(n))(cleanup)(_.awaitAcquire)
 
   /**
    * Ported from @mpilquist work in cats-effects (https://github.com/typelevel/cats-effect/pull/403)

--- a/core/shared/src/main/scala/scalaz/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Semaphore.scala
@@ -62,7 +62,7 @@ final class Semaphore private (private val state: Ref[State]) extends Serializab
   final def release: UIO[Unit] = releaseN(1)
 
   final def withPermit[R, E, A](task: ZIO[R, E, A]): ZIO[R, E, A] =
-    prepare(1L).bracket[R, E, A](_.release)(_.awaitAcquire *> task)
+    prepare(1L).bracket(_.release)(_.awaitAcquire *> task)
 
   /**
    * Acquires a specified number of permits.

--- a/core/shared/src/main/scala/scalaz/zio/package.scala
+++ b/core/shared/src/main/scala/scalaz/zio/package.scala
@@ -26,9 +26,12 @@ package object zio extends EitherCompat {
   type Task[+A]   = ZIO[Any, Throwable, A]
   type UIO[+A]    = ZIO[Any, Nothing, A]
 
-  implicit class ZIOInvarant[R, E, A](self: ZIO[R, E, A]) {
+  implicit class ZIOInvarant[R, E, A](val self: ZIO[R, E, A]) extends AnyVal {
     final def bracket: ZIO.BracketAcquire[R, E, A] =
       new ZIO.BracketAcquire(self)
+
+    final def bracketExit: ZIO.BracketExitAcquire[R, E, A] =
+      new ZIO.BracketExitAcquire(self)
   }
 
   val JustExceptions: PartialFunction[Throwable, Exception] = {

--- a/core/shared/src/main/scala/scalaz/zio/package.scala
+++ b/core/shared/src/main/scala/scalaz/zio/package.scala
@@ -26,6 +26,11 @@ package object zio extends EitherCompat {
   type Task[+A]   = ZIO[Any, Throwable, A]
   type UIO[+A]    = ZIO[Any, Nothing, A]
 
+  implicit class ZIOInvarant[R, E, A](self: ZIO[R, E, A]) {
+    final def bracket: ZIO.BracketAcquire[R, E, A] =
+      new ZIO.BracketAcquire(self)
+  }
+
   val JustExceptions: PartialFunction[Throwable, Exception] = {
     case e: Exception => e
   }


### PR DESCRIPTION
This is mainly to fix semantics of `provide` which was incorrectly using "last one wins" instead of "scoped provision". However, I also improved type inference.