### PR TITLE
Uncurried version of bracket and bracketExit without allocations

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -142,6 +142,9 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
     interruption of raced                   $testInterruptedOfRaceInterruptsContestents
     cancelation is guaranteed               $testCancelationIsGuaranteed
     interruption of unending bracket        $testInterruptionOfUnendingBracket
+
+  RTS environment
+    provide is modular                      $testProvideIsModular
   """
   }
 
@@ -715,6 +718,16 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
     (0 to 100).map { _ =>
       unsafeRun(io) must_=== 42
     }.reduce(_ and _)
+  }
+
+  def testProvideIsModular = {
+    val zio =
+      (for {
+        v1 <- ZIO.environment[Int]
+        v2 <- ZIO.environment[Int].provide(2)
+        v3 <- ZIO.environment[Int]
+      } yield (v1, v2, v3)).provide(4)
+    unsafeRun(zio) must_=== ((4, 2, 4))
   }
 
   def testAsyncPureIsInterruptible = {

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -705,9 +705,10 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
       exitLatch  <- Promise.make[Nothing, Int]
       bracketed = IO
         .succeed(21)
-        .bracketExit((r: Int, exit: Exit[_, _]) =>
-          if (exit.interrupted) exitLatch.succeed(r)
-          else IO.die(new Error("Unexpected case"))
+        .bracketExit(
+          (r: Int, exit: Exit[_, _]) =>
+            if (exit.interrupted) exitLatch.succeed(r)
+            else IO.die(new Error("Unexpected case"))
         )(a => startLatch.succeed(a) *> IO.never *> IO.succeed(1))
       fiber      <- bracketed.fork
       startValue <- startLatch.await

--- a/core/jvm/src/test/scala/scalaz/zio/SemaphoreSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/SemaphoreSpec.scala
@@ -51,7 +51,7 @@ class SemaphoreSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Tes
   def e5 = {
     val n = 1L
     unsafeRun(for {
-      s <- Semaphore.make(n).peek(_.acquire)
+      s <- Semaphore.make(n).tap(_.acquire)
       _ <- s.release.fork
       _ <- s.acquire
     } yield () must_=== (()))

--- a/core/shared/src/main/scala/scalaz/zio/FiberLocal.scala
+++ b/core/shared/src/main/scala/scalaz/zio/FiberLocal.scala
@@ -57,7 +57,7 @@ final class FiberLocal[A] private (private val state: Ref[State[A]]) extends Ser
    * Guarantees that fiber-local data is properly freed via `bracket`.
    */
   final def locally[R, E, B](value: A)(use: ZIO[R, E, B]): ZIO[R, E, B] =
-    set(value).bracket[R, E, B](_ => empty)(_ => use)
+    set(value).bracket_(empty)(use)
 
 }
 

--- a/core/shared/src/main/scala/scalaz/zio/Managed.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Managed.scala
@@ -31,7 +31,7 @@ final case class Managed[-R, +E, +A](reserve: ZIO[R, E, Managed.Reservation[R, E
   import Managed.Reservation
 
   def use[R1 <: R, E1 >: E, B](f: A => ZIO[R1, E1, B]): ZIO[R1, E1, B] =
-    reserve.bracket[R1, E1, B](_.release)(_.acquire.flatMap(f))
+    reserve.bracket(_.release)(_.acquire.flatMap(f))
 
   final def use_[R1 <: R, E1 >: E, B](f: ZIO[R1, E1, B]): ZIO[R1, E1, B] =
     use(_ => f)

--- a/core/shared/src/main/scala/scalaz/zio/Schedule.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Schedule.scala
@@ -295,7 +295,7 @@ trait Schedule[-R, -A, +B] extends Serializable { self =>
    * that log failures, decisions, or computed values.
    */
   final def onDecision[A1 <: A](f: (A1, Schedule.Decision[State, B]) => UIO[Unit]): Schedule[R, A1, B] =
-    updated(update => (a, s) => update(a, s).peek(step => f(a, step)))
+    updated(update => (a, s) => update(a, s).tap(step => f(a, step)))
 
   /**
    * Returns a new schedule with the specified effectful modification

--- a/core/shared/src/main/scala/scalaz/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Semaphore.scala
@@ -73,7 +73,7 @@ final class Semaphore private (private val state: Ref[State]) extends Serializab
    * Ported from @mpilquist work in cats-effects (https://github.com/typelevel/cats-effect/pull/403)
    */
   final def acquireN(n: Long): UIO[Unit] =
-    assertNonNegative(n) *> IO.bracketExit[Any, Nothing, Acquisition, Unit](prepare(n))(cleanup)(_.awaitAcquire)
+    assertNonNegative(n) *> IO.bracketExit(prepare(n))(cleanup)(_.awaitAcquire)
 
   /**
    * Ported from @mpilquist work in cats-effects (https://github.com/typelevel/cats-effect/pull/403)

--- a/core/shared/src/main/scala/scalaz/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Semaphore.scala
@@ -62,7 +62,7 @@ final class Semaphore private (private val state: Ref[State]) extends Serializab
   final def release: UIO[Unit] = releaseN(1)
 
   final def withPermit[R, E, A](task: ZIO[R, E, A]): ZIO[R, E, A] =
-    prepare(1L).bracket[R, E, A](_.release)(_.awaitAcquire *> task)
+    prepare(1L).bracket(_.release)(_.awaitAcquire *> task)
 
   /**
    * Acquires a specified number of permits.

--- a/core/shared/src/main/scala/scalaz/zio/ZIO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/ZIO.scala
@@ -1475,6 +1475,14 @@ object UIO extends ZIOFunctions {
 object ZIO extends ZIO_R_Any {
   def apply[A](a: => A): Task[A] = effect(a)
 
+  implicit class ZIOInvariant[R, E, A](val self: ZIO[R, E, A]) extends AnyVal {
+    final def bracket: ZIO.BracketAcquire[R, E, A] =
+      new ZIO.BracketAcquire(self)
+
+    final def bracketExit: ZIO.BracketExitAcquire[R, E, A] =
+      new ZIO.BracketExitAcquire(self)
+  }
+
   class TimeoutTo[R, E, A, B](self: ZIO[R, E, A], b: B) {
     def apply[B1 >: B](f: A => B1)(duration: Duration): ZIO[R with Clock, E, B1] =
       self

--- a/core/shared/src/main/scala/scalaz/zio/package.scala
+++ b/core/shared/src/main/scala/scalaz/zio/package.scala
@@ -26,9 +26,12 @@ package object zio extends EitherCompat {
   type Task[+A]   = ZIO[Any, Throwable, A]
   type UIO[+A]    = ZIO[Any, Nothing, A]
 
-  implicit class ZIOInvarant[R, E, A](self: ZIO[R, E, A]) {
+  implicit class ZIOInvarant[R, E, A](val self: ZIO[R, E, A]) extends AnyVal {
     final def bracket: ZIO.BracketAcquire[R, E, A] =
       new ZIO.BracketAcquire(self)
+
+    final def bracketExit: ZIO.BracketExitAcquire[R, E, A] =
+      new ZIO.BracketExitAcquire(self)
   }
 
   val JustExceptions: PartialFunction[Throwable, Exception] = {

--- a/core/shared/src/main/scala/scalaz/zio/package.scala
+++ b/core/shared/src/main/scala/scalaz/zio/package.scala
@@ -26,14 +26,6 @@ package object zio extends EitherCompat {
   type Task[+A]   = ZIO[Any, Throwable, A]
   type UIO[+A]    = ZIO[Any, Nothing, A]
 
-  implicit class ZIOInvarant[R, E, A](val self: ZIO[R, E, A]) extends AnyVal {
-    final def bracket: ZIO.BracketAcquire[R, E, A] =
-      new ZIO.BracketAcquire(self)
-
-    final def bracketExit: ZIO.BracketExitAcquire[R, E, A] =
-      new ZIO.BracketExitAcquire(self)
-  }
-
   val JustExceptions: PartialFunction[Throwable, Exception] = {
     case e: Exception => e
   }

--- a/core/shared/src/main/scala/scalaz/zio/package.scala
+++ b/core/shared/src/main/scala/scalaz/zio/package.scala
@@ -26,6 +26,11 @@ package object zio extends EitherCompat {
   type Task[+A]   = ZIO[Any, Throwable, A]
   type UIO[+A]    = ZIO[Any, Nothing, A]
 
+  implicit class ZIOInvarant[R, E, A](self: ZIO[R, E, A]) {
+    final def bracket: ZIO.BracketAcquire[R, E, A] =
+      new ZIO.BracketAcquire(self)
+  }
+
   val JustExceptions: PartialFunction[Throwable, Exception] = {
     case e: Exception => e
   }

--- a/interop-cats/jvm/src/main/scala/scalaz/zio/interop/catsjvm.scala
+++ b/interop-cats/jvm/src/main/scala/scalaz/zio/interop/catsjvm.scala
@@ -193,7 +193,7 @@ private class CatsEffect
   override final def bracketCase[A, B](
     acquire: Task[A]
   )(use: A => Task[B])(release: (A, ExitCase[Throwable]) => Task[Unit]): Task[B] =
-    IO.bracketExit[Any, Throwable, A, B](acquire) { (a, exit) =>
+    IO.bracketExit(acquire) { (a, exit: Exit[Throwable, _]) =>
       val exitCase = exitToExitCase(exit)
       release(a, exitCase).orDie
     }(use)

--- a/interop-shared/shared/src/main/scala/scalaz/zio/interop/package.scala
+++ b/interop-shared/shared/src/main/scala/scalaz/zio/interop/package.scala
@@ -35,6 +35,6 @@ package object interop {
      * This resource will get automatically closed, because it implements `AutoCloseable`.
      */
     def bracketAuto[E1 >: E, B](use: A => IO[E1, B]): IO[E1, B] =
-      io.bracket[Any, E1, B](_.closeIO())(use)
+      io.bracket(_.closeIO())(use)
   }
 }


### PR DESCRIPTION
I'm not sure about keeping having this method overloaded. This doesn't help compiler. For example without renaming I had to add annotations inside parameters list when implementing `BracketRelease_#apply`.