### PR TITLE
Fix Task class package in interop-cats sample

### DIFF
--- a/microsite/src/main/tut/interop/catseffect.md
+++ b/microsite/src/main/tut/interop/catseffect.md
@@ -27,7 +27,7 @@ The following example shows how to use ZIO with Doobie (a library for JDBC acces
 ```scala
 import doobie.imports._
 import fs2.Stream
-import scalaz.zio.interop.Task
+import scalaz.zio.Task
 import scalaz.zio.interop.catz._
 
 val xa: Transactor[Task] = Transactor.fromDriverManager[Task](...)


### PR DESCRIPTION
There seems to be an error in the documentation https://github.com/scalaz/scalaz-zio/issues/605