### PR TITLE
Add flatmap alias

### DIFF
--- a/core/shared/src/main/scala/scalaz/zio/ZIO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/ZIO.scala
@@ -129,6 +129,15 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   }
 
   /**
+   * Alias for `flatMap`.
+   *
+   * {{{
+   * val parsed = readFile("foo.txt") >>= parseFile
+   * }}}
+   */
+  final def >>=[R1 <: R, E1 >: E, B](k: A => ZIO[R1, E1, B]): ZIO[R1, E1, B] = flatMap(k)
+
+  /**
    * Returns an effect that forks this effect into its own separate fiber,
    * returning the fiber immediately, without waiting for it to compute its
    * value.


### PR DESCRIPTION
Short `flatMap` alias comes in handy in some situations, eg:

```
val name: UIO[String] = UIO.succeed("John")
def salute(name: String): UIO[String] = UIO.succeed(s"Hello $name, how are you?")

import scalaz.zio.console._
val io: ZIO[Console, Nothing, Unit] = name >>= salute >>= putStrLn
```