### PR TITLE
Add Schedule.ensuring, refine a few names, and polish

### DIFF
--- a/benchmarks/src/main/scala/scalaz/zio/ArrayFillBenchmark.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/ArrayFillBenchmark.scala
@@ -20,9 +20,9 @@ class ArrayFillBenchmarks {
     import IOBenchmarks.unsafeRun
 
     def arrayFill(array: Array[Int]): FunctionIO[Nothing, Int, Int] = {
-      val condition = FunctionIO.lift[Int, Boolean]((i: Int) => i < array.length)
+      val condition = FunctionIO.fromFunction[Int, Boolean]((i: Int) => i < array.length)
 
-      FunctionIO.whileDo[Nothing, Int](condition)(FunctionIO.impureVoid[Int, Int] { (i: Int) =>
+      FunctionIO.whileDo[Nothing, Int](condition)(FunctionIO.effectTotal[Int, Int] { (i: Int) =>
         array.update(i, i)
 
         i + 1

--- a/benchmarks/src/main/scala/scalaz/zio/KleisliIOBenchmarks.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/KleisliIOBenchmarks.scala
@@ -11,31 +11,31 @@ object ScalazIOArray {
     type IJIndexValue = (IndexValue, IndexValue)
 
     val lessThanEqual =
-      FunctionIO.lift[IJIndexValue, Boolean] {
+      FunctionIO.fromFunction[IJIndexValue, Boolean] {
         case ((_, ia), (_, ja)) => lessThanEqual0(ia, ja)
       }
 
-    val extractIJAndIncrementJ = FunctionIO.lift[IJIndexValue, IJIndex] {
+    val extractIJAndIncrementJ = FunctionIO.fromFunction[IJIndexValue, IJIndex] {
       case ((i, _), (j, _)) => (i, j + 1)
     }
 
-    val extractIAndIncrementI = FunctionIO.lift[IJIndex, Int](_._1 + 1)
+    val extractIAndIncrementI = FunctionIO.fromFunction[IJIndex, Int](_._1 + 1)
 
-    val innerLoopStart = FunctionIO.lift[Int, IJIndex]((i: Int) => (i, i + 1))
+    val innerLoopStart = FunctionIO.fromFunction[Int, IJIndex]((i: Int) => (i, i + 1))
 
     val outerLoopCheck: FunctionIO[Nothing, Int, Boolean] =
-      FunctionIO.lift((i: Int) => i < array.length - 1)
+      FunctionIO.fromFunction((i: Int) => i < array.length - 1)
 
     val innerLoopCheck: FunctionIO[Nothing, IJIndex, Boolean] =
-      FunctionIO.lift { case (_, j) => j < array.length }
+      FunctionIO.fromFunction { case (_, j) => j < array.length }
 
     val extractIJIndexValue: FunctionIO[Nothing, IJIndex, IJIndexValue] =
-      FunctionIO.impureVoid {
+      FunctionIO.effectTotal {
         case (i, j) => ((i, array(i)), (j, array(j)))
       }
 
     val swapIJ: FunctionIO[Nothing, IJIndexValue, IJIndexValue] =
-      FunctionIO.impureVoid {
+      FunctionIO.effectTotal {
         case v @ ((i, ia), (j, ja)) =>
           array.update(i, ja)
           array.update(j, ia)

--- a/core/jvm/src/test/scala/scalaz/zio/SerializableSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/SerializableSpec.scala
@@ -82,7 +82,7 @@ class SerializableSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends 
 
   def e6 = {
     import FunctionIO._
-    val v = lift[Int, Int](_ + 1)
+    val v = fromFunction[Int, Int](_ + 1)
     unsafeRun(
       for {
         returnKleisli <- serializeAndBack(v)

--- a/core/shared/src/main/scala/scalaz/zio/Fiber.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Fiber.scala
@@ -221,7 +221,7 @@ object Fiber {
   /**
    * Lifts an [[scalaz.zio.IO]] into a `Fiber`.
    */
-  final def lift[E, A](io: IO[E, A]): IO[Nothing, Fiber[E, A]] =
+  final def fromEffect[E, A](io: IO[E, A]): IO[Nothing, Fiber[E, A]] =
     io.run.map(done(_))
 
   /**

--- a/core/shared/src/main/scala/scalaz/zio/Fiber.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Fiber.scala
@@ -116,13 +116,25 @@ trait Fiber[+E, +A] { self =>
    * Same as `zip` but discards the output of the left hand side.
    */
   final def *>[E1 >: E, B](that: Fiber[E1, B]): Fiber[E1, B] =
-    zip(that).map(_._2)
+    (self zip that).map(_._2)
+
+  /**
+   * Named alias for `*>`.
+   */
+  final def zipRight[E1 >: E, B](that: Fiber[E1, B]): Fiber[E1, B] =
+    self *> that
 
   /**
    * Same as `zip` but discards the output of the right hand side.
    */
   final def <*[E1 >: E, B](that: Fiber[E1, B]): Fiber[E1, A] =
     zip(that).map(_._1)
+
+  /**
+   * Named alias for `<*`.
+   */
+  final def zipLeft[E1 >: E, B](that: Fiber[E1, B]): Fiber[E1, A] =
+    self <* that
 
   /**
    * Maps over the value the Fiber computes.

--- a/core/shared/src/main/scala/scalaz/zio/FunctionIO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/FunctionIO.scala
@@ -63,7 +63,7 @@ package scalaz.zio
  *   } yield ())
  *
  * // Program 2
- * val program2: UIO[Unit] = (readLine >>> FunctionIO.lift("Hello, " + _) >>> printLine)(())
+ * val program2: UIO[Unit] = (readLine >>> FunctionIO.fromFunction("Hello, " + _) >>> printLine)(())
  * }}}
  *
  * Similarly, the following two programs are equivalent:
@@ -96,7 +96,7 @@ sealed trait FunctionIO[+E, -A, +B] extends Serializable { self =>
   /**
    * Maps the output of this effectful function by the specified function.
    */
-  final def map[C](f: B => C): FunctionIO[E, A, C] = self >>> FunctionIO.lift(f)
+  final def map[C](f: B => C): FunctionIO[E, A, C] = self >>> FunctionIO.fromFunction(f)
 
   /**
    * Binds on the output of this effectful function.
@@ -186,7 +186,7 @@ sealed trait FunctionIO[+E, -A, +B] extends Serializable { self =>
    * Maps the output of this effectful function to the specified constant.
    */
   final def const[C](c: => C): FunctionIO[E, A, C] =
-    self >>> FunctionIO.lift[B, C](_ => c)
+    self >>> FunctionIO.fromFunction[B, C](_ => c)
 
   /**
    * Maps the output of this effectful function to `Unit`.
@@ -219,12 +219,12 @@ object FunctionIO extends Serializable {
   /**
    * Lifts a value into the monad formed by `FunctionIO`.
    */
-  final def succeed[B](b: B): FunctionIO[Nothing, Any, B] = lift((_: Any) => b)
+  final def succeed[B](b: B): FunctionIO[Nothing, Any, B] = fromFunction((_: Any) => b)
 
   /**
    * Lifts a non-strictly evaluated value into the monad formed by `FunctionIO`.
    */
-  final def succeedLazy[B](b: => B): FunctionIO[Nothing, Any, B] = lift((_: Any) => b)
+  final def succeedLazy[B](b: => B): FunctionIO[Nothing, Any, B] = fromFunction((_: Any) => b)
 
   /**
    * Returns a `FunctionIO` representing a failure with the specified `E`.
@@ -236,29 +236,29 @@ object FunctionIO extends Serializable {
    * Returns the identity effectful function, which performs no effects and
    * merely returns its input unmodified.
    */
-  final def identity[A]: FunctionIO[Nothing, A, A] = lift(a => a)
+  final def identity[A]: FunctionIO[Nothing, A, A] = fromFunction(a => a)
 
   /**
    * Lifts a pure `A => IO[E, B]` into `FunctionIO`.
    */
-  final def pure[E, A, B](f: A => IO[E, B]): FunctionIO[E, A, B] = new Pure(f)
+  final def fromFunctionM[E, A, B](f: A => IO[E, B]): FunctionIO[E, A, B] = new Pure(f)
 
   /**
    * Lifts a pure `A => B` into `FunctionIO`.
    */
-  final def lift[A, B](f: A => B): FunctionIO[Nothing, A, B] = new Impure(f)
+  final def fromFunction[A, B](f: A => B): FunctionIO[Nothing, A, B] = new Impure(f)
 
   /**
    * Returns an effectful function that merely swaps the elements in a `Tuple2`.
    */
   final def swap[E, A, B]: FunctionIO[E, (A, B), (B, A)] =
-    FunctionIO.lift[(A, B), (B, A)](_.swap)
+    FunctionIO.fromFunction[(A, B), (B, A)](_.swap)
 
   /**
    * Lifts an impure function into `FunctionIO`, converting throwables into the
    * specified error type `E`.
    */
-  final def impure[E, A, B](catcher: PartialFunction[Throwable, E])(f: A => B): FunctionIO[E, A, B] =
+  final def effect[E, A, B](catcher: PartialFunction[Throwable, E])(f: A => B): FunctionIO[E, A, B] =
     new Impure(
       (a: A) =>
         try f(a)
@@ -272,7 +272,7 @@ object FunctionIO extends Serializable {
    * Lifts an impure function into `FunctionIO`, assuming any throwables are
    * non-recoverable and do not need to be converted into errors.
    */
-  final def impureVoid[A, B](f: A => B): FunctionIO[Nothing, A, B] = new Impure(f)
+  final def effectTotal[A, B](f: A => B): FunctionIO[Nothing, A, B] = new Impure(f)
 
   /**
    * Returns a new effectful function that passes an `A` to the condition, and
@@ -281,7 +281,7 @@ object FunctionIO extends Serializable {
    */
   final def test[E, A](k: FunctionIO[E, A, Boolean]): FunctionIO[E, A, Either[A, A]] =
     (k &&& FunctionIO.identity[A]) >>>
-      FunctionIO.lift((t: (Boolean, A)) => if (t._1) Left(t._2) else Right(t._2))
+      FunctionIO.fromFunction((t: (Boolean, A)) => if (t._1) Left(t._2) else Right(t._2))
 
   /**
    * Returns a new effectful function that passes an `A` to the condition, and
@@ -345,7 +345,7 @@ object FunctionIO extends Serializable {
 
       case _ =>
         lazy val loop: FunctionIO[E, A, A] =
-          FunctionIO.pure(
+          FunctionIO.fromFunctionM(
             (a: A) => check.run(a).flatMap((b: Boolean) => if (b) body.run(a).flatMap(loop.run) else IO.succeed(a))
           )
 
@@ -356,13 +356,13 @@ object FunctionIO extends Serializable {
    * Returns an effectful function that extracts out the first element of a
    * tuple.
    */
-  final def _1[E, A, B]: FunctionIO[E, (A, B), A] = lift[(A, B), A](_._1)
+  final def _1[E, A, B]: FunctionIO[E, (A, B), A] = fromFunction[(A, B), A](_._1)
 
   /**
    * Returns an effectful function that extracts out the second element of a
    * tuple.
    */
-  final def _2[E, A, B]: FunctionIO[E, (A, B), B] = lift[(A, B), B](_._2)
+  final def _2[E, A, B]: FunctionIO[E, (A, B), B] = fromFunction[(A, B), B](_._2)
 
   /**
    * See @FunctionIO.flatMap
@@ -398,7 +398,7 @@ object FunctionIO extends Serializable {
         })
 
       case _ =>
-        FunctionIO.pure(
+        FunctionIO.fromFunctionM(
           (a: A) =>
             for {
               b <- l.run(a)
@@ -418,7 +418,7 @@ object FunctionIO extends Serializable {
           case Right(c) => Right(c)
         })
       case _ =>
-        FunctionIO.pure[E, Either[A, C], Either[B, C]] {
+        FunctionIO.fromFunctionM[E, Either[A, C], Either[B, C]] {
           case Left(a)  => k.run(a).map[Either[B, C]](Left[B, C])
           case Right(c) => IO.succeed[Either[B, C]](Right(c))
         }
@@ -435,7 +435,7 @@ object FunctionIO extends Serializable {
           case Right(a) => Right(k.apply0(a))
         })
       case _ =>
-        FunctionIO.pure[E, Either[C, A], Either[C, B]] {
+        FunctionIO.fromFunctionM[E, Either[C, A], Either[C, B]] {
           case Left(c)  => IO.succeed[Either[C, B]](Left(c))
           case Right(a) => k.run(a).map[Either[C, B]](Right[C, B])
         }
@@ -453,7 +453,7 @@ object FunctionIO extends Serializable {
         })
 
       case _ =>
-        FunctionIO.pure[E, Either[A, C], B]({
+        FunctionIO.fromFunctionM[E, Either[A, C], B]({
           case Left(a)  => l.run(a)
           case Right(c) => r.run(c)
         })

--- a/core/shared/src/main/scala/scalaz/zio/Managed.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Managed.scala
@@ -63,8 +63,20 @@ final case class Managed[-R, +E, +A](reserve: ZIO[R, E, Managed.Reservation[R, E
   final def *>[R1 <: R, E1 >: E, A1](that: Managed[R1, E1, A1]): Managed[R1, E1, A1] =
     flatMap(_ => that)
 
+  /**
+   * Named alias for `*>`.
+   */
+  final def zipRight[R1 <: R, E1 >: E, A1](that: Managed[R1, E1, A1]): Managed[R1, E1, A1] =
+    self *> that
+
   final def <*[R1 <: R, E1 >: E, A1](that: Managed[R1, E1, A1]): Managed[R1, E1, A] =
     flatMap(r => that.map(_ => r))
+
+  /**
+   * Named alias for `<*`.
+   */
+  final def zipLeft[R1 <: R, E1 >: E, A1](that: Managed[R1, E1, A1]): Managed[R1, E1, A] =
+    self <* that
 
   final def zipWith[R1 <: R, E1 >: E, A1, A2](that: Managed[R1, E1, A1])(f: (A, A1) => A2): Managed[R1, E1, A2] =
     flatMap(r => that.map(r1 => f(r, r1)))

--- a/core/shared/src/main/scala/scalaz/zio/Schedule.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Schedule.scala
@@ -200,10 +200,22 @@ trait Schedule[-R, -A, +B] extends Serializable { self =>
     (self && that).map(_._2)
 
   /**
+   * Named alias for `*>`.
+   */
+  final def zipRight[R1 <: R, A1 <: A, C](that: Schedule[R1, A1, C]): Schedule[R1, A1, C] =
+    self *> that
+
+  /**
    * The same as `&&`, but ignores the right output.
    */
   final def <*[R1 <: R, A1 <: A, C](that: Schedule[R1, A1, C]): Schedule[R1, A1, B] =
     (self && that).map(_._1)
+
+  /**
+   * Named alias for `<*`.
+   */
+  final def zipLeft[R1 <: R, A1 <: A, C](that: Schedule[R1, A1, C]): Schedule[R1, A1, B] =
+    self <* that
 
   /**
    * Returns a new schedule that continues as long as either schedule continues,

--- a/core/shared/src/main/scala/scalaz/zio/Schedule.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Schedule.scala
@@ -141,16 +141,18 @@ trait Schedule[-R, -A, +B] extends Serializable { self =>
     )
 
   /**
-   * Runs the specified finalizer as soon as the schedule is complete. Note 
+   * Runs the specified finalizer as soon as the schedule is complete. Note
    * that unlike `ZIO#ensuring`, this method does not guarantee the finalizer
-   * will be run. The `Schedule` may not initialize or the driver of the 
-   * schedule may not run to completion. However, if the `Schedule` ever 
+   * will be run. The `Schedule` may not initialize or the driver of the
+   * schedule may not run to completion. However, if the `Schedule` ever
    * decides not to continue, then the finalizer will be run.
    */
-  final def ensuring(finalizer: UIO[_]): Schedule[R, A, B] = 
-    reconsiderM((_, decision) =>
-      (if (decision.cont) UIO.unit else finalizer) *> 
-      UIO.succeed(decision))
+  final def ensuring(finalizer: UIO[_]): Schedule[R, A, B] =
+    reconsiderM(
+      (_, decision) =>
+        (if (decision.cont) UIO.unit else finalizer) *>
+          UIO.succeed(decision)
+    )
 
   /**
    * Returns a new schedule that continues this schedule so long as the predicate
@@ -556,7 +558,7 @@ object Schedule extends Serializable {
    * A schedule that recurs forever, mapping input values through the
    * specified function.
    */
-  final def lift[A, B](f: A => B): Schedule[Any, A, B] = identity[A].map(f)
+  final def fromFunction[A, B](f: A => B): Schedule[Any, A, B] = identity[A].map(f)
 
   /**
    * A schedule that never executes. Note that negating this schedule does not

--- a/core/shared/src/main/scala/scalaz/zio/Schedule.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Schedule.scala
@@ -141,6 +141,18 @@ trait Schedule[-R, -A, +B] extends Serializable { self =>
     )
 
   /**
+   * Runs the specified finalizer as soon as the schedule is complete. Note 
+   * that unlike `ZIO#ensuring`, this method does not guarantee the finalizer
+   * will be run. The `Schedule` may not initialize or the driver of the 
+   * schedule may not run to completion. However, if the `Schedule` ever 
+   * decides not to continue, then the finalizer will be run.
+   */
+  final def ensuring(finalizer: UIO[_]): Schedule[R, A, B] = 
+    reconsiderM((_, decision) =>
+      (if (decision.cont) UIO.unit else finalizer) *> 
+      UIO.succeed(decision))
+
+  /**
    * Returns a new schedule that continues this schedule so long as the predicate
    * is satisfied on the output value of the schedule.
    */

--- a/core/shared/src/main/scala/scalaz/zio/ZIO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/ZIO.scala
@@ -1231,6 +1231,19 @@ trait ZIOFunctions extends Serializable {
   final def unsandbox[R >: LowerR, E <: UpperE, A](v: ZIO[R, Cause[E], A]): ZIO[R, E, A] = v.catchAll[R, E, A](halt)
 
   /**
+   * Lifts a function `R => A` into a `ZIO[R, Nothing, A]`.
+   */
+  final def fromFunction[R >: LowerR, A](f: R => A): ZIO[R, Nothing, A] =
+    environment[R].map(f)
+
+  /**
+   * Lifts an effectful function whose effect requires no environment into
+   * an effect that requires the input to the function.
+   */
+  final def fromFunctionM[R >: LowerR, E, A](f: R => IO[E, A]): ZIO[R, E, A] =
+    environment[R].flatMap(f)
+
+  /**
    * Lifts an `Either` into a `ZIO` value.
    */
   final def fromEither[E <: UpperE, A](v: => Either[E, A]): IO[E, A] =

--- a/core/shared/src/main/scala/scalaz/zio/stream/Sink.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/Sink.scala
@@ -485,7 +485,7 @@ object Sink {
       def extract(state: State): ZIO[R, E, B]                         = b
     }
 
-  final def lift[A, B](f: A => B): Sink[Any, Unit, Nothing, A, B] =
+  final def fromFunction[A, B](f: A => B): Sink[Any, Unit, Nothing, A, B] =
     new SinkPure[Unit, Nothing, A, B] {
       type State = Option[A]
       val initialPure                                        = Step.more(None)

--- a/core/shared/src/main/scala/scalaz/zio/stream/Sink.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/Sink.scala
@@ -765,20 +765,26 @@ object Sink {
           }
       }
 
-    final def seq[E1 >: E, C](that: Sink[R, E1, A, A, C]): Sink[R, E1, A, A, (B, C)] =
+    final def zip[E1 >: E, C](that: Sink[R, E1, A, A, C]): Sink[R, E1, A, A, (B, C)] =
       flatMap(b => that.map(c => (b, c)))
 
-    final def seqWith[E1 >: E, C, D](that: Sink[R, E1, A, A, C])(f: (B, C) => D): Sink[R, E1, A, A, D] =
-      seq(that).map(f.tupled)
+    final def zipWith[E1 >: E, C, D](that: Sink[R, E1, A, A, C])(f: (B, C) => D): Sink[R, E1, A, A, D] =
+      zip(that).map(f.tupled)
 
     final def ~[E1 >: E, C](that: Sink[R, E1, A, A, C]): Sink[R, E1, A, A, (B, C)] =
-      seq(that)
+      zip(that)
 
     final def *>[E1 >: E, C](that: Sink[R, E1, A, A, C]): Sink[R, E1, A, A, C] =
-      seq(that).map(_._2)
+      zip(that).map(_._2)
+
+    final def zipRight[E1 >: E, C](that: Sink[R, E1, A, A, C]): Sink[R, E1, A, A, C] =
+      self *> that
 
     final def <*[E1 >: E, C](that: Sink[R, E1, A, A, C]): Sink[R, E1, A, A, B] =
-      seq(that).map(_._1)
+      zip(that).map(_._1)
+
+    final def zipLeft[E1 >: E, C](that: Sink[R, E1, A, A, C]): Sink[R, E1, A, A, B] =
+      self <* that
 
     final def repeatWith[S](z: S)(f: (S, B) => S): Sink[R, E, A, A, S] =
       new Sink[R, E, A, A, S] {

--- a/core/shared/src/main/scala/scalaz/zio/stream/Stream.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/Stream.scala
@@ -667,7 +667,7 @@ object Stream extends Serializable {
   /**
    * Lifts an effect producing an `A` into a stream producing that `A`.
    */
-  final def lift[R, E, A](fa: ZIO[R, E, A]): Stream[R, E, A] = new Stream[R, E, A] {
+  final def fromEffect[R, E, A](fa: ZIO[R, E, A]): Stream[R, E, A] = new Stream[R, E, A] {
     override def fold[R1 <: R, E1 >: E, A1 >: A, S]: Fold[R1, E1, A1, S] =
       IO.succeedLazy { (s, cont, f) =>
         if (cont(s)) fa.flatMap(f(s, _))

--- a/core/shared/src/main/scala/scalaz/zio/stream/Stream.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/Stream.scala
@@ -530,7 +530,7 @@ trait Stream[-R, +E, +A] extends Serializable { self =>
   /**
    * Adds an effect to consumption of every element of the stream.
    */
-  final def tap[R1 <: R, E1 >: E](f: A => ZIO[R1, E1, Unit]): Stream[R1, E1, A] =
+  final def tap[R1 <: R, E1 >: E](f: A => ZIO[R1, E1, _]): Stream[R1, E1, A] =
     new Stream[R1, E1, A] {
       override def fold[R2 <: R1, E2 >: E1, A1 >: A, S]: Fold[R2, E2, A1, S] =
         IO.succeedLazy { (s, cont, g) =>

--- a/core/shared/src/main/scala/scalaz/zio/stream/StreamChunk.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/StreamChunk.scala
@@ -66,7 +66,7 @@ trait StreamChunk[-R, +E, @specialized +A] { self =>
   final def foreach[R1 <: R, E1 >: E](f: A => ZIO[R1, E1, Unit]): ZIO[R1, E1, Unit] =
     foreachWhile[R1, E1](f(_).const(true))
 
-  final def tap[R1 <: R, E1 >: E](f0: A => ZIO[R1, E1, Unit]): StreamChunk[R1, E1, A] =
+  final def tap[R1 <: R, E1 >: E](f0: A => ZIO[R1, E1, _]): StreamChunk[R1, E1, A] =
     StreamChunk(chunks.tap[R1, E1] { as =>
       as.traverse_(f0)
     })

--- a/interop-future/jvm/src/main/scala/scalaz/zio/interop/Future.scala
+++ b/interop-future/jvm/src/main/scala/scalaz/zio/interop/Future.scala
@@ -115,11 +115,11 @@ package object future {
 
   implicit class FutureSyntax[T](val value: Future[T]) extends AnyVal {
     final def onSuccess[U](pf: PartialFunction[T, U])(implicit ec: ExecutionContext): Unit =
-      unsafeRun(ec, value.join.flatMap[Any, Throwable, Option[U]](t => IO.effect(pf.lift(t))).fork.void)
+      unsafeRun(ec, value.join.flatMap[Any, Throwable, Option[U]](t => IO.effect(pf lift t)).fork.void)
 
     final def onFailure[U](pf: PartialFunction[Throwable, U])(implicit ec: ExecutionContext): Unit =
       unsafeRun(ec, value.join.either.flatMap {
-        case Left(t)  => IO.effect(pf.lift(t))
+        case Left(t)  => IO.effect(pf lift t)
         case Right(_) => IO.unit
       }.fork.void)
 
@@ -204,7 +204,7 @@ package object future {
 
     final def andThen[U](pf: PartialFunction[Try[T], U])(implicit ec: ExecutionContext): Future[T] =
       unsafeRun(ec, value.join.either.flatMap { either =>
-        IO.effect(pf.lift(toTry(either))).either *> IO.succeed(either)
+        IO.effect(pf lift (toTry(either))).either *> IO.succeed(either)
       }.absolve.fork)
   }
 }


### PR DESCRIPTION
Added `Schedule#ensuring` (suggestion courtesy of @wi101, who also wrote the tests), improved the poorly-named `lift` methods to reflect new style guides, and added a few of the `FunctionIO` methods to `ZIO`.