### PR TITLE
Uncurried versions of 'bracket' and 'bracketExit'

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/IOSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/IOSpec.scala
@@ -45,6 +45,9 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
    Check `zipPar` method does not swallow exit causes of loser. $testZipParInterupt
    Check `zipPar` method does not report failure when interrupting loser after it succeeded. $testZipParSucceed
    Check `orElse` method does not recover from defects. $testOrElseDefectHandling
+   Check uncurried `bracket`. $testUncurriedBracket
+   Check uncurried `bracket_`. $testUncurriedBracket_
+   Check uncurried `bracketExit`. $testUncurriedBracketExit
     """
 
   def functionIOGen: Gen[String => Task[Int]] =
@@ -237,4 +240,81 @@ class IOSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntim
           .and(fail must_=== Exit.succeed(()))
     }
   }
+
+  def testUncurriedBracket =
+    unsafeRun {
+      for {
+        release  <- Ref.make(false)
+        result   <- ZIO.bracket(IO.succeed(42), (_: Int) => release.set(true), (a: Int) => ZIO.succeedLazy(a + 1))
+        released <- release.get
+      } yield (result must_=== 43) and (released must_=== true)
+    }
+
+  def testUncurriedBracket_ =
+    unsafeRun {
+      for {
+        release  <- Ref.make(false)
+        result   <- IO.succeed(42).bracket_(release.set(true), ZIO.succeedLazy(0))
+        released <- release.get
+      } yield (result must_=== 0) and (released must_=== true)
+    }
+
+  def testUncurriedBracketExit =
+    unsafeRun {
+      for {
+        release <- Ref.make(false)
+        result <- ZIO.bracketExit(
+                   IO.succeed(42),
+                   (_: Int, _: Exit[_, _]) => release.set(true),
+                   (_: Int) => IO.succeed(0L)
+                 )
+        released <- release.get
+      } yield (result must_=== 0L) and (released must_=== true)
+    }
+
+  object UncurriedBracketCompilesRegardlessOrderOfEAndRTypes {
+    class A
+    class B
+    class R
+    class R1 extends R
+    class R2 extends R1
+    class E
+    class E1 extends E
+
+    def infersEType1: ZIO[R, E, B] = {
+      val acquire: ZIO[R, E, A]            = ???
+      val release: A => ZIO[R, Nothing, _] = ???
+      val use: A => ZIO[R, E1, B]          = ???
+      ZIO.bracket(acquire, release, use)
+    }
+
+    def infersEType2: ZIO[R, E, B] = {
+      val acquire: ZIO[R, E1, A]           = ???
+      val release: A => ZIO[R, Nothing, _] = ???
+      val use: A => ZIO[R, E, B]           = ???
+      ZIO.bracket(acquire, release, use)
+    }
+
+    def infersRType1: ZIO[R2, E, B] = {
+      val acquire: ZIO[R, E, A]             = ???
+      val release: A => ZIO[R1, Nothing, _] = ???
+      val use: A => ZIO[R2, E, B]           = ???
+      ZIO.bracket(acquire, release, use)
+    }
+
+    def infersRType2: ZIO[R2, E, B] = {
+      val acquire: ZIO[R2, E, A]            = ???
+      val release: A => ZIO[R1, Nothing, _] = ???
+      val use: A => ZIO[R, E, B]            = ???
+      ZIO.bracket(acquire, release, use)
+    }
+
+    def infersRType3: ZIO[R2, E, B] = {
+      val acquire: ZIO[R1, E, A]            = ???
+      val release: A => ZIO[R2, Nothing, _] = ???
+      val use: A => ZIO[R, E, B]            = ???
+      ZIO.bracket(acquire, release, use)
+    }
+  }
+
 }

--- a/core/shared/src/main/scala/scalaz/zio/ZIO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/ZIO.scala
@@ -409,6 +409,18 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
     new ZIO.BracketAcquire_(self)
 
   /**
+   * Uncurried version of [[bracket_]]. Doesn't offer curried syntax and
+   * can have different type-inference characteristics. It doesn't allocate
+   * intermediate [[scalaz.zio.ZIO.BracketAcquire_]] and
+   * [[scalaz.zio.ZIO.BracketRelease_]] objects.
+   */
+  final def bracket_[R1 <: R, E1 >: E, B](
+    release: ZIO[R1, Nothing, _],
+    use: ZIO[R1, E1, B]
+  ): ZIO[R1, E1, B] =
+    ZIO.bracket(self, (_: A) => release, (_: A) => use)
+
+  /**
    * Returns an effect that, if this effect _starts_ execution, then the
    * specified `finalizer` is guaranteed to begin execution, whether this effect
    * succeeds, fails, or is interrupted.
@@ -1318,6 +1330,25 @@ trait ZIOFunctions extends Serializable {
     new ZIO.BracketAcquire[R, E, A](acquire)
 
   /**
+   * Uncurried version of [[bracket]]. Doesn't offer curried syntax and
+   * can have different type-inference characteristics. It doesn't allocate
+   * intermediate [[scalaz.zio.ZIO.BracketAcquire]] and
+   * [[scalaz.zio.ZIO.BracketRelease]] objects.
+   */
+  final def bracket[R >: LowerR, E <: UpperE, A, B](
+    acquire: ZIO[R, E, A],
+    release: A => ZIO[R, Nothing, _],
+    use: A => ZIO[R, E, B]
+  ): ZIO[R, E, B] =
+    Ref.make[UIO[Any]](ZIO.unit).flatMap { m =>
+      (for {
+        r <- environment[R]
+        a <- acquire.flatMap(a => m.set(release(a).provide(r)).const(a)).uninterruptible
+        b <- use(a)
+      } yield b).ensuring(flatten(m.get))
+    }
+
+  /**
    * Acquires a resource, uses the resource, and then releases the resource.
    * Neither the acquisition nor the release will be interrupted, and the
    * resource is guaranteed to be released, so long as the `acquire` effect
@@ -1326,6 +1357,27 @@ trait ZIOFunctions extends Serializable {
    */
   final def bracketExit[R >: LowerR, E <: UpperE, A](acquire: ZIO[R, E, A]): ZIO.BracketExitAcquire[R, E, A] =
     new ZIO.BracketExitAcquire(acquire)
+
+  /**
+   * Uncurried version of [[bracketExit]]. Doesn't offer curried syntax and
+   * can have different type-inference characteristics. It doesn't allocate
+   * intermediate [[scalaz.zio.ZIO.BracketAcquire]] and
+   * [[scalaz.zio.ZIO.BracketRelease]] objects.
+   */
+  final def bracketExit[R >: LowerR, E <: UpperE, E1 >: E, E2 >: E <: E1, A, B](
+    acquire: ZIO[R, E, A],
+    release: (A, Exit[E1, B]) => ZIO[R, Nothing, _],
+    use: A => ZIO[R, E2, B]
+  ): ZIO[R, E2, B] =
+    Ref.make[UIO[Any]](ZIO.unit).flatMap { m =>
+      (for {
+        r <- environment[R]
+        f <- acquire
+              .flatMap(a => use(a).fork.tap(f => m.set(f.interrupt.flatMap(release(a, _).provide(r)))))
+              .uninterruptible
+        b <- f.join
+      } yield b).ensuring(flatten(m.get))
+    }
 
   /**
    * Applies the function `f` to each element of the `Iterable[A]` and
@@ -1583,7 +1635,7 @@ object ZIO extends ZIO_R_Any {
   }
   class BracketRelease_[R, E](acquire: ZIO[R, E, _], release: ZIO[R, Nothing, _]) {
     def apply[R1 <: R, E1 >: E, B](use: ZIO[R1, E1, B]): ZIO[R1, E1, B] =
-      ZIO.bracket(acquire)(_ => release)(_ => use)
+      ZIO.bracket(acquire, (_: Any) => release, (_: Any) => use)
   }
 
   class BracketAcquire[R, E, A](acquire: ZIO[R, E, A]) {
@@ -1592,13 +1644,7 @@ object ZIO extends ZIO_R_Any {
   }
   class BracketRelease[R, E, A](acquire: ZIO[R, E, A], release: A => ZIO[R, Nothing, _]) {
     def apply[R1 <: R, E1 >: E, B](use: A => ZIO[R1, E1, B]): ZIO[R1, E1, B] =
-      Ref.make[UIO[Any]](ZIO.unit).flatMap { m =>
-        (for {
-          r <- environment[R1]
-          a <- acquire.flatMap(a => m.set(release(a).provide(r)).const(a)).uninterruptible
-          b <- use(a)
-        } yield b).ensuring(flatten(m.get))
-      }
+      ZIO.bracket(acquire, release, use)
   }
 
   class BracketExitAcquire[R, E, A](acquire: ZIO[R, E, A]) {
@@ -1611,20 +1657,8 @@ object ZIO extends ZIO_R_Any {
     acquire: ZIO[R, E, A],
     release: (A, Exit[E1, B]) => ZIO[R, Nothing, _]
   ) {
-    def apply[R1 <: R, E2 >: E, B1 <: B](use: A => ZIO[R1, E2, B1])(implicit ev: E2 <:< E1): ZIO[R1, E2, B1] =
-      Ref.make[UIO[Any]](ZIO.unit).flatMap { m =>
-        (for {
-          r <- environment[R]
-          f <- acquire
-                .flatMap(
-                  a =>
-                    use(a).fork
-                      .tap(f => m.set(f.interrupt.flatMap((e: Exit[E2, B1]) => release(a, e.mapError(ev)).provide(r))))
-                )
-                .uninterruptible
-          b <- f.join
-        } yield b).ensuring(flatten(m.get))
-      }
+    def apply[R1 <: R, E2 >: E <: E1, B1 <: B](use: A => ZIO[R1, E2, B1]): ZIO[R1, E2, B1] =
+      ZIO.bracketExit[R1, E, E1, E2, A, B1](acquire, release, use)
   }
 
   @inline

--- a/core/shared/src/main/scala/scalaz/zio/ZIO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/ZIO.scala
@@ -409,10 +409,9 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
     new ZIO.BracketAcquire_(self)
 
   /**
-   * Uncurried version of [[bracket_]]. Doesn't offer curried syntax and
-   * can have different type-inference characteristics. It doesn't allocate
-   * intermediate [[scalaz.zio.ZIO.BracketAcquire_]] and
-   * [[scalaz.zio.ZIO.BracketRelease_]] objects.
+   * Uncurried version. Doesn't offer curried syntax and have worse
+   * type-inference characteristics, but it doesn't allocate intermediate
+   * [[scalaz.zio.ZIO.BracketAcquire_]] and [[scalaz.zio.ZIO.BracketRelease_]] objects.
    */
   final def bracket_[R1 <: R, E1 >: E, B](
     release: ZIO[R1, Nothing, _],
@@ -427,7 +426,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    *
    * Finalizers offer very powerful guarantees, but they are low-level, and
    * should generally not be used for releasing resources. For higher-level
-   * logic built on `ensuring`, see [[ZIO#bracket]].
+   * logic built on `ensuring`, see `ZIO#bracket`.
    */
   final def ensuring(finalizer: UIO[_]): ZIO[R, E, A] =
     new ZIO.Ensuring(self, finalizer)
@@ -1330,12 +1329,11 @@ trait ZIOFunctions extends Serializable {
     new ZIO.BracketAcquire[R, E, A](acquire)
 
   /**
-   * Uncurried version of [[bracket]]. Doesn't offer curried syntax and
-   * can have different type-inference characteristics. It doesn't allocate
-   * intermediate [[scalaz.zio.ZIO.BracketAcquire]] and
-   * [[scalaz.zio.ZIO.BracketRelease]] objects.
+   * Uncurried version. Doesn't offer curried syntax and have worse type-inference
+   * characteristics, but guarantees no extra allocations of intermediate
+   * [[scalaz.zio.ZIO.BracketAcquire]] and [[scalaz.zio.ZIO.BracketRelease]] objects.
    */
-  final def bracket[R >: LowerR, E <: UpperE, A, B](
+  final def bracket[R >: LowerR, E <: UpperE, A, A1 >: A, A2 >: A, B](
     acquire: ZIO[R, E, A],
     release: A => ZIO[R, Nothing, _],
     use: A => ZIO[R, E, B]
@@ -1359,10 +1357,9 @@ trait ZIOFunctions extends Serializable {
     new ZIO.BracketExitAcquire(acquire)
 
   /**
-   * Uncurried version of [[bracketExit]]. Doesn't offer curried syntax and
-   * can have different type-inference characteristics. It doesn't allocate
-   * intermediate [[scalaz.zio.ZIO.BracketAcquire]] and
-   * [[scalaz.zio.ZIO.BracketRelease]] objects.
+   * Uncurried version. Doesn't offer curried syntax and have worse type-inference
+   * characteristics, but guarantees no extra allocations of intermediate
+   * [[scalaz.zio.ZIO.BracketExitAcquire]] and [[scalaz.zio.ZIO.BracketExitRelease]] objects.
    */
   final def bracketExit[R >: LowerR, E <: UpperE, E1 >: E, E2 >: E <: E1, A, B](
     acquire: ZIO[R, E, A],


### PR DESCRIPTION
I open this to have version of `bracket` suitable for hot-path in performance sensitive applications.