### PR TITLE
wait for the fiber to update the ref in FiberSpec

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/FiberSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/FiberSpec.scala
@@ -1,5 +1,7 @@
 package scalaz.zio
 
+import duration._
+
 class FiberSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntime {
   def is =
     "FiberSpec".title ^ s2"""
@@ -11,7 +13,7 @@ class FiberSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRun
     for {
       ref   <- Ref.make(false)
       fiber <- IO.unit.bracket(_ => ref.set(true))(_ => IO.never).fork
-      _     <- fiber.toManaged.use(_ => IO.unit)
+      _     <- fiber.toManaged.use(_ => clock.sleep(20.millis))
       value <- ref.get
     } yield value must beTrue
   )

--- a/core/jvm/src/test/scala/scalaz/zio/FiberSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/FiberSpec.scala
@@ -11,8 +11,9 @@ class FiberSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRun
     for {
       ref   <- Ref.make(false)
       latch <- Promise.make[Nothing, Unit]
-      fiber <- IO.unit.bracket(_ => ref.set(true) *> latch.succeed(()))(_ => IO.never).fork
+      fiber <- IO.unit.bracket(_ => ref.set(true))(_ => latch.succeed(()) *> IO.never).fork
       _     <- fiber.toManaged.use(_ => latch.await)
+      _     <- fiber.await
       value <- ref.get
     } yield value must beTrue
   )

--- a/core/jvm/src/test/scala/scalaz/zio/FiberSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/FiberSpec.scala
@@ -11,8 +11,9 @@ class FiberSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRun
     for {
       ref   <- Ref.make(false)
       latch <- Promise.make[Nothing, Unit]
-      fiber <- IO.unit.bracket(_ => ref.set(true))(_ => latch.succeed(()) *> IO.never).fork
-      _     <- fiber.toManaged.use(_ => latch.await)
+      fiber <- (latch.succeed(()) *> IO.unit).bracket_(ref.set(true))(IO.never).fork
+      _     <- latch.await
+      _     <- fiber.toManaged.use(_ => IO.unit)
       _     <- fiber.await
       value <- ref.get
     } yield value must beTrue


### PR DESCRIPTION
Sometimes the ref doesn't change its value yet and the fiber is interrupted when we use UIO.unit, it will be faster