### PR TITLE
Accept ZIO[R, E, A] for Runtime#unsafeRunToFuture

### DIFF
--- a/core/shared/src/main/scala/scalaz/zio/Runtime.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Runtime.scala
@@ -85,7 +85,7 @@ trait Runtime[+R] {
    *
    * This method is effectful and should only be used at the edges of your program.
    */
-  final def unsafeRunToFuture[E <: Throwable, A](io: IO[E, A]): scala.concurrent.Future[A] =
+  final def unsafeRunToFuture[E <: Throwable, A](io: ZIO[R, E, A]): scala.concurrent.Future[A] =
     unsafeRun(io.toFuture)
 }
 


### PR DESCRIPTION
#654 made `toFuture` polymorphic in `R`. This propagates that change to `unsafeRunToFuture`.