### PR TITLE
Fix remainder handling in ZStream#transduce (#678)

### DIFF
--- a/core/shared/src/main/scala/scalaz/zio/stream/ZStream.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/ZStream.scala
@@ -520,33 +520,36 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
     new ZStream[R1, E1, C] {
       override def fold[R2 <: R1, E2 >: E1, C1 >: C, S2]: Fold[R2, E2, C1, S2] =
         IO.succeedLazy { (s2, cont, f) =>
-          def feed(s1: sink.State, s2: S2, a: Chunk[A1]): ZIO[R2, E2, ZSink.Step[(sink.State, S2), A1]] =
+          def feed(s1: sink.State, s2: S2, a: Chunk[A1]): ZIO[R2, E2, (sink.State, S2, Boolean)] =
             sink.stepChunk(s1, a).flatMap { step =>
-              if (ZSink.Step.cont(step)) IO.succeed(ZSink.Step.leftMap(step)((_, s2)))
-              else {
+              if (ZSink.Step.cont(step)) {
+                IO.succeed((ZSink.Step.state(step), s2, true))
+              } else {
                 sink.extract(ZSink.Step.state(step)).flatMap { c =>
                   f(s2, c).flatMap { s2 =>
-                    if (cont(s2))
-                      sink.initial.flatMap(initStep => feed(ZSink.Step.state(initStep), s2, ZSink.Step.leftover(step)))
-                    else IO.succeed(ZSink.Step.more((s1, s2)))
+                    val remaining = ZSink.Step.leftover(step)
+                    if (cont(s2) && !remaining.isEmpty)
+                      sink.initial.flatMap(initStep => feed(ZSink.Step.state(initStep), s2, remaining))
+                    else IO.succeed((s1, s2, false))
                   }
                 }
               }
             }
 
           sink.initial.flatMap { initStep =>
-            val s1 = ZSink.Step.leftMap(initStep)((_, s2))
+            val s1 = (ZSink.Step.state(initStep), s2, false)
 
-            self.fold[R2, E2, A, ZSink.Step[(sink.State, S2), A1]].flatMap { f0 =>
-              f0(s1, step => cont(ZSink.Step.state(step)._2), { (s, a) =>
-                val (s1, s2) = ZSink.Step.state(s)
+            self.fold[R2, E2, A, (sink.State, S2, Boolean)].flatMap { f0 =>
+              f0(s1, stepState => cont(stepState._2), { (s, a) =>
+                val (s1, s2, _) = s
                 feed(s1, s2, Chunk(a))
-              }).flatMap { step =>
-                val (s1, s2) = ZSink.Step.state(step)
-
-                sink
-                  .extract(s1)
-                  .foldM(_ => IO.succeed(s2), c => f(s2, c))
+              }).flatMap { feedResult =>
+                val (s1, s2, extractNeeded) = feedResult
+                if (extractNeeded) {
+                  sink.extract(s1).flatMap(f(s2, _))
+                } else {
+                  IO.succeed(s2)
+                }
               }
             }
           }

--- a/core/shared/src/main/scala/scalaz/zio/stream/ZStream.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stream/ZStream.scala
@@ -528,9 +528,13 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
                 sink.extract(ZSink.Step.state(step)).flatMap { c =>
                   f(s2, c).flatMap { s2 =>
                     val remaining = ZSink.Step.leftover(step)
-                    if (cont(s2) && !remaining.isEmpty)
-                      sink.initial.flatMap(initStep => feed(ZSink.Step.state(initStep), s2, remaining))
-                    else IO.succeed((s1, s2, false))
+                    sink.initial.flatMap { initStep =>
+                      if (cont(s2) && !remaining.isEmpty) {
+                        feed(ZSink.Step.state(initStep), s2, remaining)
+                      } else {
+                        IO.succeed((ZSink.Step.state(initStep), s2, false))
+                      }
+                    }
                   }
                 }
               }


### PR DESCRIPTION
Fix for #678.

If the sink indicates done, only run the sink again if there is a remainder to pass to it.

In the case of the sink requesting more, the `extract` has to be done only after the upstream fold completes, so it can't be done inside `feed`. A boolean flag now indicates when such a final extract is needed (I didn't find this to be a particularly elegant solution, but it's the only idea I had that worked).

I also changed `feed` to return just the state, without a `Step`, since all the caller did with the `Step` was get its state. Seemed simpler.