### PR TITLE
resolves scalaz/scalaz-zio#621: Add TestScheduler to  package

### DIFF
--- a/testkit/jvm/src/main/scala/scalaz/zio/testkit/TestScheduler.scala
+++ b/testkit/jvm/src/main/scala/scalaz/zio/testkit/TestScheduler.scala
@@ -1,0 +1,79 @@
+package scalaz.zio.testkit
+
+import scalaz.zio._
+import scalaz.zio.clock._
+import scalaz.zio.duration.{ Duration, _ }
+import scalaz.zio.internal.Scheduler.CancelToken
+import scalaz.zio.internal.{ Scheduler => IScheduler }
+import scalaz.zio.scheduler.Scheduler
+import scalaz.zio.testkit.TestScheduler._
+
+/**
+ * Implementation of Scheduler.Service for testing. The passed Ref[TestClock.Data] will be used to determine when
+ * to run the scheduled runnables. Make sure to call shutdown() to force execution of all remaining tasks.
+ */
+final case class TestScheduler(ref: Ref[TestClock.Data]) extends Scheduler.Service[Any] with DefaultRuntime {
+
+  private[this] val ConstFalse = () => false
+
+  override def scheduler: ZIO[Any, Nothing, IScheduler] =
+    for {
+      tasksRef   <- Ref.make[List[(Long, Promise[Nothing, Unit], Runnable)]](Nil)
+      shouldExit <- Ref.make(false)
+
+      runTask = for {
+        currentTime <- ref.get.map(_.nanoTime)
+        dequeued <- tasksRef.modify { tasks =>
+                     tasks.partition(_._1 <= currentTime)
+                   }.map(_.map(x => (x._2, x._3)))
+        _ <- ZIO.foreach(dequeued) { task =>
+              task._1.done(ZIO.succeed(())) flatMap { notInterupted =>
+                if (notInterupted) ZIO.effectTotal(task._2.run())
+                else ZIO.unit
+              }
+            }
+      } yield ()
+      executor <- runWhile(runTask, shouldExit).provide(Environment).fork
+
+      scheduler = new IScheduler {
+        override def schedule(task: Runnable, duration: Duration): CancelToken =
+          duration match {
+            case Duration.Infinity =>
+              ConstFalse
+            case Duration.Zero =>
+              task.run()
+              ConstFalse
+            case duration: Duration.Finite =>
+              val promise = unsafeRun(for {
+                currentTime <- ref.get.map(_.nanoTime)
+                targetTime  = currentTime + duration.toNanos
+                promise     <- Promise.make[Nothing, Unit]
+                _           <- tasksRef.update(tasks => (targetTime, promise, task) :: tasks)
+              } yield promise)
+              () => unsafeRun(promise.done(ZIO.succeed(())))
+          }
+
+        override def size: Int =
+          unsafeRun(tasksRef.get.map(_.size))
+
+        override def shutdown(): Unit =
+          unsafeRun(shouldExit.update(_ => true) *> executor.join)
+      }
+    } yield scheduler
+}
+
+object TestScheduler {
+
+  private[TestScheduler] def runWhile(
+    task: UIO[Unit],
+    ref: Ref[Boolean],
+    pause: Duration = 10.milliseconds
+  ): ZIO[Clock, Nothing, Unit] =
+    for {
+      _    <- task
+      exit <- ref.get
+      _ <- if (exit) task *> ZIO.unit // make sure everything is finished
+          else sleep(pause) *> runWhile(task, ref, pause)
+    } yield ()
+
+}

--- a/testkit/jvm/src/test/scala/scalaz/zio/testkit/SchedulerSpec.scala
+++ b/testkit/jvm/src/test/scala/scalaz/zio/testkit/SchedulerSpec.scala
@@ -1,0 +1,95 @@
+package scalaz.zio.testkit
+
+import org.specs2.specification.core.SpecStructure
+import scalaz.zio._
+import SchedulerSpec._
+import scalaz.zio.internal.Scheduler
+import scalaz.zio.duration._
+
+class SchedulerSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntime {
+
+  override def is: SpecStructure = "SchedulerSpec".title ^ s2"""
+    Scheduled tasks get executed $e1
+    Scheduled tasks only get executed when time has passed $e2
+    Scheduled tasks can be canceled $e3
+    Tasks that are cancelled after completion are not reported as interrupted $e4
+    """
+
+  def e1 =
+    unsafeRun(
+      for {
+        res       <- mkScheduler
+        clock     = res._1
+        scheduler = res._2
+        promise   <- Promise.make[Nothing, Unit]
+        _ <- ZIO.effectTotal(scheduler.schedule(new Runnable {
+              override def run(): Unit = unsafeRun(promise.done(ZIO.unit).void)
+            }, 10.seconds))
+        _        <- clock.sleep(10.seconds)
+        _        <- ZIO.effectTotal(scheduler.shutdown())
+        executed <- promise.poll.map(_.nonEmpty)
+      } yield executed must beTrue
+    )
+
+  def e2 =
+    unsafeRun(
+      for {
+        res       <- mkScheduler
+        clock     = res._1
+        scheduler = res._2
+        promise   <- Promise.make[Nothing, Unit]
+        _ <- ZIO.effectTotal(scheduler.schedule(new Runnable {
+              override def run(): Unit = unsafeRun(promise.done(ZIO.unit).void)
+            }, 10.seconds + 1.nanosecond))
+        _        <- clock.sleep(10.seconds)
+        _        <- ZIO.effectTotal(scheduler.shutdown())
+        executed <- promise.poll.map(_.nonEmpty)
+      } yield executed must beFalse
+    )
+
+  def e3 =
+    unsafeRun(
+      for {
+        res       <- mkScheduler
+        clock     = res._1
+        scheduler = res._2
+        promise   <- Promise.make[Nothing, Unit]
+        cancel <- ZIO.effectTotal(scheduler.schedule(new Runnable {
+                   override def run(): Unit = unsafeRun(promise.done(ZIO.unit).void)
+                 }, 10.seconds))
+        canceled <- ZIO.effectTotal(cancel())
+        _        <- clock.sleep(10.seconds)
+        _        <- ZIO.effectTotal(scheduler.shutdown())
+        executed <- promise.poll.map(_.nonEmpty)
+      } yield (!executed && canceled) must beTrue
+    )
+
+  def e4 =
+    unsafeRun(
+      for {
+        res       <- mkScheduler
+        clock     = res._1
+        scheduler = res._2
+        promise   <- Promise.make[Nothing, Unit]
+        cancel <- ZIO.effectTotal(scheduler.schedule(new Runnable {
+                   override def run(): Unit = unsafeRun(promise.done(ZIO.unit).void)
+                 }, 10.seconds))
+        _        <- clock.sleep(10.seconds)
+        _        <- ZIO.effectTotal(scheduler.shutdown())
+        canceled <- ZIO.effectTotal(cancel())
+        executed <- promise.poll.map(_.nonEmpty)
+      } yield (executed && !canceled) must beTrue
+    )
+
+}
+
+object SchedulerSpec {
+
+  def mkScheduler: UIO[(TestClock, Scheduler)] =
+    for {
+      clockData <- Ref.make(TestClock.Zero)
+      clock     = TestClock(clockData)
+      scheduler <- TestScheduler(clockData).scheduler
+    } yield (clock, scheduler)
+
+}

--- a/testkit/jvm/src/test/scala/scalaz/zio/testkit/SchedulerSpec.scala
+++ b/testkit/jvm/src/test/scala/scalaz/zio/testkit/SchedulerSpec.scala
@@ -3,6 +3,7 @@ package scalaz.zio.testkit
 import org.specs2.specification.core.SpecStructure
 import scalaz.zio._
 import SchedulerSpec._
+import scalaz.zio.clock.Clock
 import scalaz.zio.internal.Scheduler
 import scalaz.zio.duration._
 
@@ -18,7 +19,7 @@ class SchedulerSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Tes
   def e1 =
     unsafeRun(
       for {
-        res       <- mkScheduler
+        res       <- mkScheduler(this)
         clock     = res._1
         scheduler = res._2
         promise   <- Promise.make[Nothing, Unit]
@@ -34,7 +35,7 @@ class SchedulerSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Tes
   def e2 =
     unsafeRun(
       for {
-        res       <- mkScheduler
+        res       <- mkScheduler(this)
         clock     = res._1
         scheduler = res._2
         promise   <- Promise.make[Nothing, Unit]
@@ -50,7 +51,7 @@ class SchedulerSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Tes
   def e3 =
     unsafeRun(
       for {
-        res       <- mkScheduler
+        res       <- mkScheduler(this)
         clock     = res._1
         scheduler = res._2
         promise   <- Promise.make[Nothing, Unit]
@@ -67,7 +68,7 @@ class SchedulerSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Tes
   def e4 =
     unsafeRun(
       for {
-        res       <- mkScheduler
+        res       <- mkScheduler(this)
         clock     = res._1
         scheduler = res._2
         promise   <- Promise.make[Nothing, Unit]
@@ -85,11 +86,11 @@ class SchedulerSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Tes
 
 object SchedulerSpec {
 
-  def mkScheduler: UIO[(TestClock, Scheduler)] =
+  def mkScheduler(runtime: Runtime[Clock]): UIO[(TestClock, Scheduler)] =
     for {
       clockData <- Ref.make(TestClock.Zero)
       clock     = TestClock(clockData)
-      scheduler <- TestScheduler(clockData).scheduler
+      scheduler <- TestScheduler(clockData, runtime).scheduler
     } yield (clock, scheduler)
 
 }


### PR DESCRIPTION
One thing to note is doing it this way requires scheduler.shutdown() to be called before any assert are made. Otherwise some scheduled tasks might not have been executed