### PR TITLE
Extra import to summon a Timer[Task] instance

### DIFF
--- a/core/jvm/src/main/scala/scalaz/zio/App.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/App.scala
@@ -39,6 +39,8 @@ package scalaz.zio
  */
 trait App extends DefaultRuntime {
 
+  implicit val runtime: Runtime[Environment] = this
+
   /**
    * The main function of the application, which will be passed the command-line
    * arguments to the program and has to return an `IO` with the errors fully handled.

--- a/core/jvm/src/main/scala/scalaz/zio/App.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/App.scala
@@ -39,8 +39,6 @@ package scalaz.zio
  */
 trait App extends DefaultRuntime {
 
-  implicit val runtime: Runtime[Environment] = this
-
   /**
    * The main function of the application, which will be passed the command-line
    * arguments to the program and has to return an `IO` with the errors fully handled.

--- a/interop-cats/jvm/src/main/scala/scalaz/zio/interop/catsjvm.scala
+++ b/interop-cats/jvm/src/main/scala/scalaz/zio/interop/catsjvm.scala
@@ -29,18 +29,19 @@ abstract class CatsPlatform extends CatsInstances {
   val console = interop.console.cats
 
   object implicits {
-    implicit def taskTimer(implicit T: effect.Timer[ZIO[Clock, Throwable, ?]]): effect.Timer[Task] = new effect.Timer[Task] {
-      override def clock: effect.Clock[Task] = new effect.Clock[Task] {
-        override def monotonic(unit: TimeUnit): Task[Long] =
-          T.clock.monotonic(unit).provide(Clock.Live)
+    implicit def taskTimer(implicit T: effect.Timer[ZIO[Clock, Throwable, ?]]): effect.Timer[Task] =
+      new effect.Timer[Task] {
+        override def clock: effect.Clock[Task] = new effect.Clock[Task] {
+          override def monotonic(unit: TimeUnit): Task[Long] =
+            T.clock.monotonic(unit).provide(Clock.Live)
 
-        override def realTime(unit: TimeUnit): Task[Long] =
-          T.clock.realTime(unit).provide(Clock.Live)
+          override def realTime(unit: TimeUnit): Task[Long] =
+            T.clock.realTime(unit).provide(Clock.Live)
+        }
+
+        override def sleep(duration: FiniteDuration): Task[Unit] =
+          T.sleep(duration).provide(Clock.Live)
       }
-
-      override def sleep(duration: FiniteDuration): Task[Unit] =
-        T.sleep(duration).provide(Clock.Live)
-    }
   }
 }
 

--- a/interop-cats/jvm/src/main/scala/scalaz/zio/interop/catsjvm.scala
+++ b/interop-cats/jvm/src/main/scala/scalaz/zio/interop/catsjvm.scala
@@ -27,6 +27,21 @@ import scala.concurrent.duration.{ FiniteDuration, NANOSECONDS, TimeUnit }
 
 abstract class CatsPlatform extends CatsInstances {
   val console = interop.console.cats
+
+  object implicits {
+    implicit def taskTimer(implicit T: effect.Timer[ZIO[Clock, Throwable, ?]]): effect.Timer[Task] = new effect.Timer[Task] {
+      override def clock: effect.Clock[Task] = new effect.Clock[Task] {
+        override def monotonic(unit: TimeUnit): Task[Long] =
+          T.clock.monotonic(unit).provide(Clock.Live)
+
+        override def realTime(unit: TimeUnit): Task[Long] =
+          T.clock.realTime(unit).provide(Clock.Live)
+      }
+
+      override def sleep(duration: FiniteDuration): Task[Unit] =
+        T.sleep(duration).provide(Clock.Live)
+    }
+  }
 }
 
 abstract class CatsInstances extends CatsInstances1 {

--- a/interop-cats/jvm/src/test/scala/scalaz/zio/interop/catzSpec.scala
+++ b/interop-cats/jvm/src/test/scala/scalaz/zio/interop/catzSpec.scala
@@ -143,7 +143,7 @@ class catzSpec
   }
 
   object summoningRuntimeInstancesTest {
-    import cats.effect.{Clock => CatzClock, _}
+    import cats.effect.{ Clock => CatzClock, _ }
     import scalaz.zio.interop.catz.implicits._
 
     ContextShift[Task]

--- a/interop-cats/jvm/src/test/scala/scalaz/zio/interop/catzSpec.scala
+++ b/interop-cats/jvm/src/test/scala/scalaz/zio/interop/catzSpec.scala
@@ -150,6 +150,10 @@ class catzSpec
     ContextShift[TaskR[String, ?]]
     CatzClock[Task]
     Timer[Task]
+
+    ContextShift[UIO[?]]
+    CatzClock[UIO[?]]
+    Timer[UIO[?]]
   }
 
   implicit def catsEQ[E, A: Eq]: Eq[IO[E, A]] =

--- a/interop-cats/jvm/src/test/scala/scalaz/zio/interop/catzSpec.scala
+++ b/interop-cats/jvm/src/test/scala/scalaz/zio/interop/catzSpec.scala
@@ -142,6 +142,16 @@ class catzSpec
     def effect[R: Runtime]           = Effect[TaskR[R, ?]]
   }
 
+  object summoningRuntimeInstancesTest {
+    import cats.effect.{Clock => CatzClock, _}
+    import scalaz.zio.interop.catz.implicits._
+
+    ContextShift[Task]
+    ContextShift[TaskR[String, ?]]
+    CatzClock[Task]
+    Timer[Task]
+  }
+
   implicit def catsEQ[E, A: Eq]: Eq[IO[E, A]] =
     new Eq[IO[E, A]] {
       import scalaz.zio.duration._

--- a/microsite/src/main/tut/interop/catseffect.md
+++ b/microsite/src/main/tut/interop/catseffect.md
@@ -8,9 +8,9 @@ title:  "Cats Effect"
 
 Checkout `interop-cats` module for inter-operation support.
 
-### `IO` cats' `Effect` instance
+### `IO` Cats Effect's instances
 
-**ZIO** integrates with Typelevel libraries by providing an instance of `Effect` for `IO` as required, for instance, by `fs2`, `doobie` and `http4s`. Actually, I lied a little bit, it is not possible to implement `Effect` for any error type since `Effect` extends `MonadError` of `Throwable`.
+**ZIO** integrates with Typelevel libraries by providing an instance of `ConcurrentEffect` for `IO` as required, for instance, by `fs2`, `doobie` and `http4s`. Actually, I lied a little bit, it is not possible to implement `ConcurrentEffect` for any error type since `ConcurrentEffect` extends `MonadError` of `Throwable`.
 
 For convenience we have defined an alias as follow:
 
@@ -18,7 +18,17 @@ For convenience we have defined an alias as follow:
   type Task[A] = IO[Throwable, A]
 ```
 
-Therefore, we provide an instance of `Effect[Task]`.
+Therefore, we provide an instance of `ConcurrentEffect[Task]`.
+
+#### Timer
+
+In order to get a `cats.effect.Timer[Task]` instance we need an extra import:
+
+```scala
+import scalaz.zio.interop.catz.implicits._
+```
+
+The reason it is not provided by the default by the interop import is that it makes testing programs that require timing capabilities hard so an extra import wherever needed makes reasoning about it much easier.
 
 #### Example
 

--- a/microsite/src/main/tut/interop/catseffect.md
+++ b/microsite/src/main/tut/interop/catseffect.md
@@ -28,7 +28,7 @@ In order to get a `cats.effect.Timer[Task]` instance we need an extra import:
 import scalaz.zio.interop.catz.implicits._
 ```
 
-The reason it is not provided by the default by the interop import is that it makes testing programs that require timing capabilities hard so an extra import wherever needed makes reasoning about it much easier.
+The reason it is not provided by the default "interop" import is that it makes testing programs that require timing capabilities hard so an extra import wherever needed makes reasoning about it much easier.
 
 #### Example
 


### PR DESCRIPTION
closes #694 

I wrote the `Timer[Task]` instance given the existing one. Is there a better way?

I also suggested adding the default `implicit val runtime` in a different trait but haven't done it. Let me know what you think.