### PR TITLE
Handle null produced by the j.u.c.CompletionStage

### DIFF
--- a/interop-java/jvm/src/test/scala/scalaz/zio/interop/javaconcurrentSpec.scala
+++ b/interop-java/jvm/src/test/scala/scalaz/zio/interop/javaconcurrentSpec.scala
@@ -22,6 +22,7 @@ class javaconcurrentSpec(implicit ee: ExecutionEnv) extends TestRuntime {
     catch exceptions thrown by lazy block                $catchBlockExceptionCs
     return an `IO` that fails if `Future` fails          $propagateExceptionFromCs
     return an `IO` that produces the value from `Future` $produceValueFromCs
+    handle null produced by the completed `Future`       $handleNullFromCs
   `Task.toCompletableFuture` must
     produce always a successful `IO` of `Future`         $toCompletableFutureAlwaysSucceeds
     be polymorphic in error type                         $toCompletableFuturePoly
@@ -95,6 +96,11 @@ class javaconcurrentSpec(implicit ee: ExecutionEnv) extends TestRuntime {
   val produceValueFromCs = {
     def someValue: CompletionStage[Int] = CompletableFuture.completedFuture(42)
     unsafeRun(Task.fromCompletionStage(someValue _)) must_=== 42
+  }
+
+  val handleNullFromCs = {
+    def someValue: CompletionStage[String] = CompletableFuture.completedFuture[String](null)
+    unsafeRun(Task.fromCompletionStage[String](someValue _)) must_=== null
   }
 
   val toCompletableFutureAlwaysSucceeds = {

--- a/interop-java/shared/src/main/scala/scalaz/zio/interop/javaconcurrent.scala
+++ b/interop-java/shared/src/main/scala/scalaz/zio/interop/javaconcurrent.scala
@@ -30,17 +30,15 @@ object javaconcurrent {
     private def unsafeCompletionStageToIO[A](cs: CompletionStage[A]): Task[A] =
       IO.effectAsync { cb =>
         val _ = cs.handle[Unit] { (v: A, t: Throwable) =>
-          if (v != null) {
-            cb(IO.succeed(v))
-          } else {
-            val io = t match {
-              case e: CompletionException =>
-                IO.fail(e.getCause)
-              case t: Throwable =>
-                IO.fail(t)
-            }
-            cb(io)
+          val io = t match {
+            case null =>
+              IO.succeed(v)
+            case e: CompletionException =>
+              IO.fail(e.getCause)
+            case t: Throwable =>
+              IO.fail(t)
           }
+          cb(io)
         }
       }
 


### PR DESCRIPTION
I'm using zio with fdb-java with wrapper on CompletionStage and some methods from fdb can return null as expected behaviour but zio freezes with silent drop of IO.

from  j.u.c.CompletionStage#handle javadoc:
>When this stage is complete, the given function is invoked with the result (or null if none) and the exception (or null if none) of this stage as arguments, and the function's result is used to complete the returned stage.