### PR TITLE
Cats MTL instances: ApplicativeAsk and ApplicativeLocal

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,7 +95,7 @@ lazy val interopCats = crossProject(JSPlatform, JVMPlatform)
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "cats-effect"   % "1.2.0" % Optional,
       "org.typelevel" %%% "cats-mtl-core" % "0.5.0" % Optional,
-      "co.fs2"        %%% "fs2-core"      % "1.0.3" % Test,
+      "co.fs2"        %%% "fs2-core"      % "1.0.3" % Test
     )
   )
   .dependsOn(core % "test->test;compile->compile")

--- a/build.sbt
+++ b/build.sbt
@@ -93,8 +93,9 @@ lazy val interopCats = crossProject(JSPlatform, JVMPlatform)
   .settings(stdSettings("zio-interop-cats"))
   .settings(
     libraryDependencies ++= Seq(
-      "org.typelevel" %%% "cats-effect" % "1.2.0" % Optional,
-      "co.fs2"        %%% "fs2-core"    % "1.0.3" % Test
+      "org.typelevel" %%% "cats-effect"   % "1.2.0" % Optional,
+      "org.typelevel" %%% "cats-mtl-core" % "0.5.0" % Optional,
+      "co.fs2"        %%% "fs2-core"      % "1.0.3" % Test,
     )
   )
   .dependsOn(core % "test->test;compile->compile")
@@ -139,6 +140,7 @@ lazy val interopCatsJVM = interopCats.jvm
     libraryDependencies ++= Seq(
       "org.typelevel"              %% "cats-effect-laws"                                                 % "1.2.0"                              % Test,
       "org.typelevel"              %% "cats-testkit"                                                     % "1.6.0"                              % Test,
+      "org.typelevel"              %% "cats-mtl-laws"                                                    % "0.5.0"                              % Test,
       "com.github.alexarchambault" %% s"scalacheck-shapeless_${majorMinor(CatsScalaCheckVersion.value)}" % CatsScalaCheckShapelessVersion.value % Test
     ),
     dependencyOverrides += "org.scalacheck" %% "scalacheck" % ScalaCheckVersion.value % Test

--- a/interop-cats/js/src/main/scala/scalaz/zio/interop/catsjs.scala
+++ b/interop-cats/js/src/main/scala/scalaz/zio/interop/catsjs.scala
@@ -17,3 +17,5 @@
 package scalaz.zio.interop
 
 abstract class CatsPlatform {}
+
+abstract class CatsMtlPlatform {}

--- a/interop-cats/jvm/src/main/scala/scalaz/zio/interop/catsmtljvm.scala
+++ b/interop-cats/jvm/src/main/scala/scalaz/zio/interop/catsmtljvm.scala
@@ -14,8 +14,21 @@
  * limitations under the License.
  */
 
-package scalaz.zio.interop
+package scalaz.zio
+package interop
 
-object catz extends CatsPlatform {
-  object mtl extends CatsMtlPlatform
+import cats.Applicative
+import cats.mtl._
+import scalaz.zio._
+
+abstract class CatsMtlPlatform extends CatsMtlInstances
+
+abstract class CatsMtlInstances {
+
+  implicit def zioApplicativeAsk[R, E](implicit ev: Applicative[ZIO[R, E, ?]]): ApplicativeAsk[ZIO[R, E, ?], R] =
+    new DefaultApplicativeAsk[ZIO[R, E, ?], R] {
+      val applicative: Applicative[ZIO[R, E, ?]] = ev
+      def ask: ZIO[R, Nothing, R]                = ZIO.environment
+    }
+
 }

--- a/interop-cats/jvm/src/main/scala/scalaz/zio/interop/catsmtljvm.scala
+++ b/interop-cats/jvm/src/main/scala/scalaz/zio/interop/catsmtljvm.scala
@@ -25,10 +25,15 @@ abstract class CatsMtlPlatform extends CatsMtlInstances
 
 abstract class CatsMtlInstances {
 
-  implicit def zioApplicativeAsk[R, E](implicit ev: Applicative[ZIO[R, E, ?]]): ApplicativeAsk[ZIO[R, E, ?], R] =
-    new DefaultApplicativeAsk[ZIO[R, E, ?], R] {
+  implicit def zioApplicativeLocalAsk[R, E](
+    implicit ev: Applicative[ZIO[R, E, ?]]
+  ): ApplicativeLocal[ZIO[R, E, ?], R] =
+    new DefaultApplicativeLocal[ZIO[R, E, ?], R] {
       val applicative: Applicative[ZIO[R, E, ?]] = ev
       def ask: ZIO[R, Nothing, R]                = ZIO.environment
+      def local[A](f: R => R)(fa: ZIO[R, E, A]): ZIO[R, E, A] = ZIO.accessM { env =>
+        fa.provide(f(env))
+      }
     }
 
 }

--- a/interop-cats/jvm/src/test/scala/scalaz/zio/interop/catzMtlSpec.scala
+++ b/interop-cats/jvm/src/test/scala/scalaz/zio/interop/catzMtlSpec.scala
@@ -3,8 +3,8 @@ package interop
 
 import cats.Eq
 import cats.implicits._
-import cats.mtl.ApplicativeAsk
-import cats.mtl.laws.discipline.ApplicativeAskTests
+import cats.mtl.{ ApplicativeAsk, ApplicativeLocal }
+import cats.mtl.laws.discipline.{ ApplicativeAskTests, ApplicativeLocalTests }
 import org.scalacheck.{ Arbitrary, Cogen }
 import org.scalatest.prop.Checkers
 import org.scalatest.{ BeforeAndAfterAll, FunSuite, Matchers }
@@ -30,8 +30,13 @@ class catzMtlSpec extends FunSuite with BeforeAndAfterAll with Matchers with Che
   trait Error
 
   checkAll("ApplicativeAsk[ZIO[Ctx, Error, ?]]", ApplicativeAskTests[ZIO[Ctx, Error, ?], Ctx].applicativeAsk[Ctx])
+  checkAll(
+    "ApplicativeLocal[ZIO[Ctx, Error, ?]]",
+    ApplicativeLocalTests[ZIO[Ctx, Error, ?], Ctx].applicativeLocal[Ctx, Int]
+  )
 
-  def askSummoner[R, E] = ApplicativeAsk[ZIO[R, E, ?], R]
+  def askSummoner[R, E]   = ApplicativeAsk[ZIO[R, E, ?], R]
+  def localSummoner[R, E] = ApplicativeLocal[ZIO[R, E, ?], R]
 
   implicit def catsEQ[R: Arbitrary, E, A: Eq]: Eq[ZIO[R, E, A]] =
     new Eq[ZIO[R, E, A]] {

--- a/interop-cats/jvm/src/test/scala/scalaz/zio/interop/catzMtlSpec.scala
+++ b/interop-cats/jvm/src/test/scala/scalaz/zio/interop/catzMtlSpec.scala
@@ -1,0 +1,55 @@
+package scalaz.zio
+package interop
+
+import cats.Eq
+import cats.implicits._
+import cats.mtl.ApplicativeAsk
+import cats.mtl.laws.discipline.ApplicativeAskTests
+import org.scalacheck.{ Arbitrary, Cogen }
+import org.scalatest.prop.Checkers
+import org.scalatest.{ BeforeAndAfterAll, FunSuite, Matchers }
+import org.typelevel.discipline.scalatest.Discipline
+import scalaz.zio.blocking.Blocking
+import scalaz.zio.clock.Clock
+import scalaz.zio.console.Console
+import scalaz.zio.internal.PlatformLive
+import scalaz.zio.interop.catz._
+import scalaz.zio.interop.catz.mtl._
+import scalaz.zio.random.Random
+import scalaz.zio.system.System
+
+class catzMtlSpec extends FunSuite with BeforeAndAfterAll with Matchers with Checkers with Discipline with GenIO {
+
+  type Env = Clock with Console with System with Random with Blocking
+
+  implicit val rts: Runtime[Env] = new DefaultRuntime {
+    override val Platform = PlatformLive.makeDefault().withReportFailure(_ => ())
+  }
+
+  type Ctx = String
+  trait Error
+
+  checkAll("ApplicativeAsk[ZIO[Ctx, Error, ?]]", ApplicativeAskTests[ZIO[Ctx, Error, ?], Ctx].applicativeAsk[Ctx])
+
+  def askSummoner[R, E] = ApplicativeAsk[ZIO[R, E, ?], R]
+
+  implicit def catsEQ[R: Arbitrary, E, A: Eq]: Eq[ZIO[R, E, A]] =
+    new Eq[ZIO[R, E, A]] {
+      import scalaz.zio.duration._
+
+      def eqv(io1: ZIO[R, E, A], io2: ZIO[R, E, A]): Boolean = {
+        val ctx = Arbitrary.arbitrary[R].sample.get
+        val v1  = rts.unsafeRunSync(io1.provide(ctx).timeout(20.seconds)).map(_.get)
+        val v2  = rts.unsafeRunSync(io2.provide(ctx).timeout(20.seconds)).map(_.get)
+        val res = v1 === v2
+        if (!res) {
+          println(s"Mismatch: $v1 != $v2")
+        }
+        res
+      }
+    }
+
+  implicit def zioArbitrary[E, A: Arbitrary: Cogen, R: Arbitrary: Cogen]: Arbitrary[ZIO[R, E, A]] =
+    Arbitrary(genSuccess[E, A])
+
+}


### PR DESCRIPTION
There are a few other typeclasses that might be worth implementing but as a first try I think these two are the most important now that ZIO is a trifunctor able to carry context.

I added the `cats-mtl` dependency to the `interop-cats` module, meaning that users will pull this dependency even if they don't use it so maybe we can create a new `interop-cats-mtl` module?

