### PR TITLE
 Add ApplicativeHandle / FunctorRaise instance for cats-mtl interop

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,7 @@
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
 import Scalaz._
 import xerial.sbt.Sonatype._
+import explicitdeps.ExplicitDepsPlugin.autoImport.moduleFilterRemoveValue
 
 name := "scalaz-zio"
 

--- a/interop-cats/jvm/src/main/scala/scalaz/zio/interop/catsmtljvm.scala
+++ b/interop-cats/jvm/src/main/scala/scalaz/zio/interop/catsmtljvm.scala
@@ -17,7 +17,7 @@
 package scalaz.zio
 package interop
 
-import cats.Applicative
+import cats.{ Applicative, Functor }
 import cats.mtl._
 import scalaz.zio._
 
@@ -36,4 +36,13 @@ abstract class CatsMtlInstances {
       }
     }
 
+  implicit def zioApplicativeHandle[R, E](
+    implicit ev: Applicative[ZIO[R, E, ?]]
+  ): ApplicativeHandle[ZIO[R, E, ?], E] =
+    new DefaultApplicativeHandle[ZIO[R, E, ?], E] {
+      val functor: Functor[ZIO[R, E, ?]]                                      = ev
+      val applicative: Applicative[ZIO[R, E, ?]]                              = ev
+      def raise[A](e: E): IO[E, A]                                            = IO.fail(e)
+      def handleWith[A](fa: ZIO[R, E, A])(f: E => ZIO[R, E, A]): ZIO[R, E, A] = fa.catchAll(f)
+    }
 }

--- a/interop-cats/jvm/src/test/scala/scalaz/zio/interop/catzMtlSpec.scala
+++ b/interop-cats/jvm/src/test/scala/scalaz/zio/interop/catzMtlSpec.scala
@@ -4,7 +4,12 @@ package interop
 import cats.Eq
 import cats.implicits._
 import cats.mtl.{ ApplicativeAsk, ApplicativeLocal }
-import cats.mtl.laws.discipline.{ ApplicativeAskTests, ApplicativeLocalTests }
+import cats.mtl.laws.discipline.{
+  ApplicativeAskTests,
+  ApplicativeHandleTests,
+  ApplicativeLocalTests,
+  FunctorRaiseTests
+}
 import org.scalacheck.{ Arbitrary, Cogen }
 import org.scalatest.prop.Checkers
 import org.scalatest.{ BeforeAndAfterAll, FunSuite, Matchers }
@@ -26,13 +31,18 @@ class catzMtlSpec extends FunSuite with BeforeAndAfterAll with Matchers with Che
     override val Platform = PlatformLive.makeDefault().withReportFailure(_ => ())
   }
 
-  type Ctx = String
-  trait Error
+  type Ctx   = String
+  type Error = String
 
   checkAll("ApplicativeAsk[ZIO[Ctx, Error, ?]]", ApplicativeAskTests[ZIO[Ctx, Error, ?], Ctx].applicativeAsk[Ctx])
   checkAll(
     "ApplicativeLocal[ZIO[Ctx, Error, ?]]",
     ApplicativeLocalTests[ZIO[Ctx, Error, ?], Ctx].applicativeLocal[Ctx, Int]
+  )
+  checkAll("FunctorRaise[ZIO[Ctx, Error, ?]]", FunctorRaiseTests[ZIO[Ctx, Error, ?], Error].functorRaise[Int])
+  checkAll(
+    "ApplicativeHandle[ZIO[Ctx, Error, ?]]",
+    ApplicativeHandleTests[ZIO[Ctx, Error, ?], Error].applicativeHandle[Int]
   )
 
   def askSummoner[R, E]   = ApplicativeAsk[ZIO[R, E, ?], R]


### PR DESCRIPTION
It would be nice to have this before 1.0.0 :shipit: 

Btw I don't understand why cats interop is only available for the JVM?