### PR TITLE
Add simple test framework

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -239,6 +239,9 @@ lazy val interopTwitterJVM = interopTwitter.jvm.dependsOn(interopSharedJVM)
 lazy val testkit = crossProject(JVMPlatform)
   .in(file("testkit"))
   .settings(stdSettings("zio-testkit"))
+  .settings(
+    libraryDependencies += "org.scala-sbt" % "test-interface" % "1.0"
+  )
   .dependsOn(core % "test->test;compile->compile")
 
 lazy val testkitJVM = testkit.jvm

--- a/testkit/jvm/src/main/scala/scalaz/zio/testkit/Framework.scala
+++ b/testkit/jvm/src/main/scala/scalaz/zio/testkit/Framework.scala
@@ -1,0 +1,30 @@
+package scalaz.zio.testkit
+
+import sbt.testing.{ Fingerprint, Framework, SubclassFingerprint }
+
+import scalaz.zio.{ Runtime, Task }
+
+trait TestSpec extends Runtime[Any] { self: Singleton =>
+  def tests: Map[String, Task[Result]]
+
+  final def loadObject[T](name: String): T = Class.forName(s"${name}$$").getField("MODULE$").get(null).asInstanceOf[T]
+}
+
+sealed abstract class Result
+case object Succeeded                      extends Result
+final case class Failed(reason: Throwable) extends Result
+
+final class TestFramework extends Framework {
+  override val name = s"${Console.UNDERLINED}ZIO-Test${Console.RESET}"
+
+  val fingerprints: Array[Fingerprint] = Array(
+    new SubclassFingerprint {
+      val superclassName          = classOf[TestSpec].getCanonicalName
+      val isModule                = true
+      val requireNoArgConstructor = false
+    }
+  )
+
+  override def runner(args: Array[String], remoteArgs: Array[String], testClassLoader: ClassLoader): ZioTestRunner =
+    ZioTestRunner(args, remoteArgs, testClassLoader)
+}

--- a/testkit/jvm/src/main/scala/scalaz/zio/testkit/Matchers.scala
+++ b/testkit/jvm/src/main/scala/scalaz/zio/testkit/Matchers.scala
@@ -1,0 +1,14 @@
+package scalaz.zio.testkit
+
+final class MatchException(e: String) extends Exception(e)
+
+trait SimpleMatchers {
+  def compare[A](message: String)(f: A => Boolean)(got: A): Result =
+    if (f(got)) Succeeded else Failed(new MatchException(message))
+
+  def equals[A](expected: A, got: A) = compare[A](s"Expected ${expected}, got ${got}")(x => x == expected)(got)
+
+  def expect[A](expected: A)(got: A) = equals(expected, got)
+}
+
+object matchers extends SimpleMatchers

--- a/testkit/jvm/src/main/scala/scalaz/zio/testkit/Runner.scala
+++ b/testkit/jvm/src/main/scala/scalaz/zio/testkit/Runner.scala
@@ -1,0 +1,76 @@
+package scalaz.zio.testkit
+
+import java.util.Arrays
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.collection.JavaConverters._
+
+import com.github.ghik.silencer.silent
+
+import sbt.testing._
+
+final class ZioTestRunner(val args: Array[String], val remoteArgs: Array[String]) extends Runner {
+  private val results: ConcurrentHashMap[String, Result] = new ConcurrentHashMap
+
+  def done(): String =
+    results.asScala.map {
+      case (name, result) =>
+        result match {
+          case Succeeded => s"${Console.BOLD}${Console.GREEN}\u2713 ${name}${Console.RESET}"
+          case Failed(e) =>
+            println(s"${"=" * 10}${name}${"=" * 10}")
+            e.printStackTrace
+            println("-" * 30)
+            s"${Console.BOLD}${Console.RED}\u2717 ${name}${Console.RESET}\n${Console.YELLOW}${e.getMessage}${Console.RESET}"
+        }
+    }.mkString("\n")
+
+  def tasks(defs: Array[TaskDef]): Array[Task] = defs.map(taskDefToTask)
+
+  private def taskDefToTask(td: TaskDef): Task = new Task {
+    private def loadObject[T](name: String): T =
+      Class.forName(s"${name}$$").getField("MODULE$").get(null).asInstanceOf[T]
+    override def taskDef(): TaskDef = td
+    override def execute(eventHandler: EventHandler, loggers: Array[Logger]): Array[Task] = {
+      loggers.foreach(_.debug(s"Using args: ${ZioTestRunner.arrayToString(args)}"))
+      loggers.foreach(_.debug(s"Using remoteArgs: ${ZioTestRunner.arrayToString(remoteArgs)}"))
+
+      val testsuite = loadObject[TestSpec](td.fullyQualifiedName)
+
+      testsuite.tests.map {
+        case (name, io) =>
+          val result = testsuite
+            .unsafeRunSync(io)
+            .getOrElse(e => Failed(e.defects.headOption.getOrElse(new Exception("Unknown error"))))
+          val _ = results.put(name, result)
+
+          eventHandler.handle(new Event {
+            def throwable(): OptionalThrowable = result match {
+              case Failed(e) => new OptionalThrowable(e)
+              case _         => new OptionalThrowable()
+            }
+
+            def fullyQualifiedName = td.fullyQualifiedName
+            def status(): Status   = if (throwable().isDefined) Status.Failure else Status.Success
+            def selector()         = new TestSelector(fullyQualifiedName())
+            def duration()         = 0
+            def fingerprint = new SubclassFingerprint {
+              val superclassName          = "scalaz.zio.test.TestSpec"
+              val isModule                = true
+              val requireNoArgConstructor = false
+            }
+          })
+      }
+
+      Array.empty
+    }
+    override def tags(): Array[String] = Array.empty
+  }
+}
+
+object ZioTestRunner {
+  @silent def apply(args: Array[String], remoteArgs: Array[String], testClassLoader: ClassLoader): ZioTestRunner =
+    new ZioTestRunner(args, remoteArgs)
+
+  private def arrayToString(a: Array[String]): String = Arrays.toString(a.asInstanceOf[Array[AnyRef]])
+}


### PR DESCRIPTION
Add `testFrameworks += new TestFramework("scalaz.zio.test.TestFramework")` to your `build.sbt` and include `scalaz-zio-testkit` as a test dependency.

This is more a POC than anything.
- The matchers are super simple
- The output is not super pretty

But things work and everything seems to integrate with SBT fine.

```scala
package bla

import scalaz.zio._
import scalaz.zio.testkit._

object Bla {
  def helloWorld = ZIO.succeed("Hello World")
  def foobar     = ZIO.fail(new Exception("This is no good"))
}

object BlaSpec extends TestSpec with DefaultRuntime with SimpleMatchers {
  val tests = Map(
    "first test"  -> first,
    "second test" -> second,
    "third test"  -> third
  )

  def first: Task[Result] =
    Bla.helloWorld.map(expect("Hello World"))

  def second: Task[Result] =
    Bla.helloWorld.map(expect("FooBar"))

  def third: Task[Result] =
    Bla.foobar.mapError { e =>
      compare[Throwable]("Did not receive the expected error")(a => a.getMessage == e.getMessage)(e)
    }.flip
}
```

#717 