### PR TITLE
Implement .interruptible operation

### DIFF
--- a/core/shared/src/main/scala/scalaz/zio/InsideUninterruptible.scala
+++ b/core/shared/src/main/scala/scalaz/zio/InsideUninterruptible.scala
@@ -1,0 +1,3 @@
+package scalaz.zio
+
+sealed trait InsideUninterruptible


### PR DESCRIPTION
Implementation for #706 

- Left old `.uninterruptible` (without `.interruptible` support) alongside with the new `ZIO.uninterruptible`.
- `ZIO.uninterruptible` type inference works with 2.11 and 2.12, but fails with Dotty (hence the failed CI). Help would be appreciated. CC-ing @fkowal.
- `ZIO.uninterruptible(ZIO.unit.interruptible.interruptible): UIO[Unit]` typechecks due to idempotent nature of `with`, so I made `.interruptible` idempotent to match that.