### PR TITLE
Run test on ci one time less

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,10 @@ jobs:
       stage: test
       name: "Lint"
       script: sbt ++$TRAVIS_SCALA_VERSION scalafmtCheck test:scalafmtCheck scalafmtSbtCheck unusedCompileDependenciesTest
-    - &test
+    - &package
       stage: test
-      name: "Test for Scala"
-      script: sbt ++$TRAVIS_SCALA_VERSION test package packageSrc publishLocal
+      name: "Package"
+      script: sbt ++$TRAVIS_SCALA_VERSION package packageSrc publishLocal
     - &scaladoc
       stage: microsite
       name: "Generate Scaladoc"


### PR DESCRIPTION
CI runs tests for 2.12.8 two times. One by default task and second time during "Test for Scala".
I removed `test` target and renamed this job.
This should speed up build.