### PR TITLE
Decrease minimum duration of a timed test from 6 seconds to 60 ms

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,7 @@
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
 import Scalaz._
 import xerial.sbt.Sonatype._
+import explicitdeps.ExplicitDepsPlugin.autoImport.moduleFilterRemoveValue
 
 name := "scalaz-zio"
 

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -472,7 +472,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
     aroundTimeout(10.milliseconds.asScala)(ee)
       .around(
         unsafeRun(
-          clock.sleep(10.seconds) *> UIO(true)
+          clock.sleep(60.seconds) *> UIO(true)
         )
       )
       .message must_== "TIMEOUT: 10000000 nanoseconds"

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -469,9 +469,13 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
     } yield res) must_=== 42
 
   def testTimeoutOfLongComputation =
-    unsafeRun(
-      clock.sleep(10.seconds).timeoutFail(new Exception())(10.milliseconds).either.timed
-    )._1.max(50.milliseconds) must_== 50.milliseconds
+    aroundTimeout(10.milliseconds.asScala)(ee)
+      .around(
+        unsafeRun(
+          clock.sleep(10.seconds) *> UIO(true)
+        )
+      )
+      .message must_== "TIMEOUT: 10000000 nanoseconds"
 
   def testEvalOfDeepSyncEffect = {
     def incLeft(n: Int, ref: Ref[Int]): Task[Int] =

--- a/core/jvm/src/test/scala/scalaz/zio/TestRuntime.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/TestRuntime.scala
@@ -3,10 +3,10 @@ package scalaz.zio
 import scala.concurrent.duration._
 import org.specs2.Specification
 import org.specs2.concurrent.ExecutionEnv
-import org.specs2.execute.{AsResult, Failure, Result, Skipped}
+import org.specs2.execute.{ AsResult, Failure, Result, Skipped }
 import org.specs2.matcher.Expectations
 import org.specs2.matcher.TerminationMatchers.terminate
-import org.specs2.specification.{Around, AroundEach, AroundTimeout}
+import org.specs2.specification.{ Around, AroundEach, AroundTimeout }
 import scalaz.zio.internal.PlatformLive
 
 abstract class TestRuntime(implicit ee: org.specs2.concurrent.ExecutionEnv)

--- a/core/jvm/src/test/scala/scalaz/zio/TestRuntime.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/TestRuntime.scala
@@ -2,9 +2,11 @@ package scalaz.zio
 
 import scala.concurrent.duration._
 import org.specs2.Specification
-import org.specs2.specification.{ AroundEach, AroundTimeout }
-import org.specs2.execute.{ AsResult, Failure, Result, Skipped }
-
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.execute.{AsResult, Failure, Result, Skipped}
+import org.specs2.matcher.Expectations
+import org.specs2.matcher.TerminationMatchers.terminate
+import org.specs2.specification.{Around, AroundEach, AroundTimeout}
 import scalaz.zio.internal.PlatformLive
 
 abstract class TestRuntime(implicit ee: org.specs2.concurrent.ExecutionEnv)
@@ -21,5 +23,17 @@ abstract class TestRuntime(implicit ee: org.specs2.concurrent.ExecutionEnv)
     AsResult.safely(upTo(DefaultTimeout)(r)) match {
       case Skipped(m, e) if m contains "TIMEOUT" => Failure(m, e)
       case other                                 => other
+    }
+
+  override final def aroundTimeout(to: Duration)(implicit ee: ExecutionEnv): Around =
+    new Around {
+      def around[T: AsResult](t: => T): Result = {
+        lazy val result = t
+        val termination = terminate(retries = 1000, sleep = (to.toMicros / 1000).micros)
+          .orSkip(_ => "TIMEOUT: " + to)(Expectations.createExpectable(result))
+
+        if (!termination.toResult.isSkipped) AsResult(result)
+        else termination.toResult
+      }
     }
 }


### PR DESCRIPTION
Decrease minimum duration of a timed test from 6 seconds to 60 ms (speeds up tests) #695 
1. Copied code from #576
2. Ran the tests