### PR TITLE
WIP Re-add support for Scala 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: false
 scala:
 - 2.12.8
 - 2.11.12
+- 2.13.0-RC1
 
 jdk:
 - openjdk8

--- a/build.sbt
+++ b/build.sbt
@@ -217,7 +217,7 @@ lazy val interopReactiveStreams = crossProject(JVMPlatform)
     libraryDependencies ++= Seq(
       "org.reactivestreams" % "reactive-streams"     % "1.0.2",
       "org.reactivestreams" % "reactive-streams-tck" % "1.0.2" % "test",
-      "org.scalatest"       %% "scalatest"           % "3.0.7" % "test",
+      "org.scalatest"       %% "scalatest"           % "3.0.8-RC2" % "test",
       "com.typesafe.akka"   %% "akka-stream"         % akkaVersion % "test",
       "com.typesafe.akka"   %% "akka-stream-testkit" % akkaVersion % "test"
     )

--- a/build.sbt
+++ b/build.sbt
@@ -144,7 +144,7 @@ val CatsScalaCheckShapelessVersion = Def.setting {
     case Some((2, v)) if v <= 12 =>
       "1.1.8"
     case _ =>
-      "1.2.0-1+7-a4ed6f38-SNAPSHOT" // TODO: Stable version
+      "1.2.1" // TODO: Stable version
   }
 }
 

--- a/core/shared/src/main/scala/scalaz/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/scalaz/zio/internal/FiberContext.scala
@@ -335,10 +335,10 @@ private[zio] final class FiberContext[E, A](
     UIO {
       val set = supervised.peekOrElse(null)
 
-      if (set eq null) Array.empty[Fiber[_, _]]
+      if (set eq null) Array.empty[Fiber[_, _]].toIndexedSeq // FIXME use ArraySeq.unsafeWrapArray (only in 2.13)
       else {
         val arr = Array.ofDim[Fiber[_, _]](set.size)
-        set.toArray[Fiber[_, _]](arr)
+        set.toArray[Fiber[_, _]](arr).toIndexedSeq // FIXME use ArraySeq.unsafeWrapArray (only in 2.13)
       }
     }
 

--- a/core/shared/src/main/scala/scalaz/zio/stm/TQueue.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stm/TQueue.scala
@@ -28,7 +28,7 @@ class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
 
   // TODO: Scala doesn't allow Iterable???
   final def offerAll(as: List[A]): STM[Nothing, Unit] =
-    ref.update(_.enqueue(as)).unit
+    ref.update(_.enqueueAll(as)).unit // FIXME only available in 2.13
 
   final def poll: STM[Nothing, Option[A]] = takeUpTo(1).map(_.headOption)
 

--- a/project/ScalazBuild.scala
+++ b/project/ScalazBuild.scala
@@ -26,7 +26,7 @@ object Scalaz {
     "-language:existentials",
     "-explaintypes",
     "-Yrangepos",
-    "-Xfuture",
+    // "-Xfuture",
     "-Xsource:2.13",
     "-Xlint:_,-type-parameter-shadow",
     "-Ywarn-numeric-widen",
@@ -101,7 +101,7 @@ object Scalaz {
   def stdSettings(prjName: String) = Seq(
     name := s"scalaz-$prjName",
     scalacOptions := stdOptions,
-    crossScalaVersions := Seq("2.12.8", "2.11.12"),
+    crossScalaVersions := Seq("2.13.0-RC1", "2.12.8", "2.11.12"),
     scalaVersion in ThisBuild := crossScalaVersions.value.head,
     scalacOptions := stdOptions ++ extraOptions(scalaVersion.value),
     libraryDependencies ++= compileOnlyDeps ++ testDeps ++ Seq(

--- a/project/ScalazBuild.scala
+++ b/project/ScalazBuild.scala
@@ -26,7 +26,6 @@ object Scalaz {
     "-language:existentials",
     "-explaintypes",
     "-Yrangepos",
-    // "-Xfuture",
     "-Xsource:2.13",
     "-Xlint:_,-type-parameter-shadow",
     "-Ywarn-numeric-widen",
@@ -82,7 +81,8 @@ object Scalaz {
           "-Ywarn-inaccessible",
           "-Ywarn-infer-any",
           "-Ywarn-nullary-override",
-          "-Ywarn-nullary-unit"
+          "-Ywarn-nullary-unit",
+          "-Xfuture"
         ) ++ std2xOptions
       case Some((2, 11)) =>
         Seq(
@@ -93,7 +93,8 @@ object Scalaz {
           "-Ywarn-nullary-override",
           "-Ywarn-nullary-unit",
           "-Xexperimental",
-          "-Ywarn-unused-import"
+          "-Ywarn-unused-import",
+          "-Xfuture"
         ) ++ std2xOptions
       case _ => Seq.empty
     }

--- a/project/ScalazBuild.scala
+++ b/project/ScalazBuild.scala
@@ -102,7 +102,7 @@ object Scalaz {
   def stdSettings(prjName: String) = Seq(
     name := s"scalaz-$prjName",
     scalacOptions := stdOptions,
-    crossScalaVersions := Seq("2.13.0-RC1", "2.12.8", "2.11.12"),
+    crossScalaVersions := Seq("2.12.8", "2.11.12", "2.13.0-RC1"),
     scalaVersion in ThisBuild := crossScalaVersions.value.head,
     scalacOptions := stdOptions ++ extraOptions(scalaVersion.value),
     libraryDependencies ++= compileOnlyDeps ++ testDeps ++ Seq(


### PR DESCRIPTION
This is a first attempt at https://github.com/scalaz/scalaz-zio/issues/732.
A few dependencies haven't yet been published:
* cats  https://github.com/typelevel/cats/pull/2783
* akka https://github.com/akka/akka/issues/26691

Also I get the following error when running `coreJVM/test`:
```
[error] /Users/denisgarcia/dev/github/scalaz-zio/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala:1082:25: object interruptible is not a member of package scalaz.zio.blocking
[error]       fiber <- blocking.interruptible { start.set(()); Thread.sleep(Long.MaxValue) }.ensuring(done.set(true)).fork
[error]                         ^
[error] /Users/denisgarcia/dev/github/scalaz-zio/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala:1068:16: object blockingExecutor is not a member of package scalaz.zio.blocking
[error]       blocking.blockingExecutor.map(_.metrics.get.workersCount)
[error]                ^
[error] /Users/denisgarcia/dev/github/scalaz-zio/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala:1071:28: object blocking is not a member of package scalaz.zio.blocking
[error] did you mean Blocking?
[error]       thread1  <- blocking.blocking(IO.effectTotal(Thread.currentThread()))
[error]                            ^
[error] three errors found
```
I think it has to do with package object but I'm not sure how to fix it.