### PR TITLE
Fixed:739 -- Minor function renames with old fun deprecation message

### DIFF
--- a/benchmarks/src/main/scala/scalaz/zio/KleisliIOBenchmarks.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/KleisliIOBenchmarks.scala
@@ -53,7 +53,7 @@ object ScalazIOArray {
           ) >>>
           extractIAndIncrementI
       )
-    sort.run(0).void
+    sort.run(0).unit
   }
 }
 

--- a/core/jvm/src/main/scala-2.11/blocking.scala
+++ b/core/jvm/src/main/scala-2.11/blocking.scala
@@ -26,6 +26,10 @@ package object blocking {
   def blocking[R1 <: Blocking, E, A](zio: ZIO[R1, E, A]): ZIO[R1, E, A] =
     ZIO.accessM(_.blocking.blocking(zio))
 
+  @deprecated("use effectBlocking()", "1.0.0")
   def interruptible[A](effect: => A): ZIO[Blocking, Throwable, A] =
+    effectBlocking(effect)
+
+  def effectBlocking[A](effect: => A): ZIO[Blocking, Throwable, A] =
     ZIO.accessM(_.blocking.effectBlocking(effect))
 }

--- a/core/jvm/src/main/scala-2.11/blocking.scala
+++ b/core/jvm/src/main/scala-2.11/blocking.scala
@@ -27,5 +27,5 @@ package object blocking {
     ZIO.accessM(_.blocking.blocking(zio))
 
   def interruptible[A](effect: => A): ZIO[Blocking, Throwable, A] =
-    ZIO.accessM(_.blocking.interruptible(effect))
+    ZIO.accessM(_.blocking.effectBlocking(effect))
 }

--- a/core/jvm/src/main/scala/scalaz/zio/blocking/Blocking.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/blocking/Blocking.scala
@@ -52,7 +52,7 @@ object Blocking extends Serializable {
      * If the returned `IO` is interrupted, the blocked thread running the synchronous effect
      * will be interrupted via `Thread.interrupt`.
      */
-    @deprecated("use unit", "1.0.0")
+    @deprecated("use effectBlocking()", "1.0.0")
     def interruptible[A](effect: => A): ZIO[R, Throwable, A] =
       ZIO.flatten(ZIO.effectTotal {
         import java.util.concurrent.locks.ReentrantLock

--- a/core/jvm/src/main/scala/scalaz/zio/blocking/Blocking.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/blocking/Blocking.scala
@@ -52,6 +52,7 @@ object Blocking extends Serializable {
      * If the returned `IO` is interrupted, the blocked thread running the synchronous effect
      * will be interrupted via `Thread.interrupt`.
      */
+    @deprecated("use unit", "1.0.0")
     def interruptible[A](effect: => A): ZIO[R, Throwable, A] =
       ZIO.flatten(ZIO.effectTotal {
         import java.util.concurrent.locks.ReentrantLock
@@ -107,6 +108,70 @@ object Blocking extends Serializable {
                         }).fork
                 a <- fiber.join.absolve.unsandbox
               } yield a).ensuring(interruptThread *> awaitInterruption)
+        } yield a
+      })
+
+    /**
+      * Imports a synchronous effect that does blocking IO into a pure value.
+      *
+      * If the returned `IO` is interrupted, the blocked thread running the synchronous effect
+      * will be interrupted via `Thread.interrupt`.
+      */
+    def effectBlocking[A](effect: => A): ZIO[R, Throwable, A] =
+      ZIO.flatten(ZIO.effectTotal {
+        import java.util.concurrent.locks.ReentrantLock
+        import java.util.concurrent.atomic.AtomicReference
+        import scalaz.zio.internal.OneShot
+
+        val lock    = new ReentrantLock()
+        val thread  = new AtomicReference[Option[Thread]](None)
+        val barrier = OneShot.make[Unit]
+
+        def withMutex[B](b: => B): B =
+          try {
+            lock.lock(); b
+          } finally lock.unlock()
+
+        val interruptThread: UIO[Unit] =
+          ZIO.effectTotal {
+            var looping = true
+            var n       = 0L
+            val base    = 2L
+            while (looping) {
+              withMutex(thread.get match {
+                case None         => looping = false; ()
+                case Some(thread) => thread.interrupt()
+              })
+
+              if (looping) {
+                n += 1
+                Thread.sleep(math.min(50, base * n))
+              }
+            }
+          }
+
+        val awaitInterruption: UIO[Unit] = ZIO.effectTotal(barrier.get())
+
+        for {
+          a <- (for {
+            fiber <- blocking(ZIO.effectTotal[Either[Cause[Throwable], A]] {
+              val current = Some(Thread.currentThread)
+
+              withMutex(thread.set(current))
+
+              try Right(effect)
+              catch {
+                case _: InterruptedException =>
+                  Thread.interrupted // Clear interrupt status
+                  Left(Cause.interrupt)
+                case t: Throwable =>
+                  Left(Cause.fail(t))
+              } finally {
+                withMutex { thread.set(None); barrier.set(()) }
+              }
+            }).fork
+            a <- fiber.join.absolve.unsandbox
+          } yield a).ensuring(interruptThread *> awaitInterruption)
         } yield a
       })
   }

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -129,7 +129,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
     manual sync interruption                $testManualSyncInterruption
 
   RTS interruption
-    blocking IO is interruptible            $testBlockingIOIsInterruptible
+    blocking IO is effect blocking          $testBlockingIOIsEffectBlocking
     sync forever is interruptible           $testInterruptSyncForever
     interrupt of never                      $testNeverIsInterruptible
     asyncPure is interruptible              $testAsyncPureIsInterruptible
@@ -1075,7 +1075,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
     } yield workers1 == workers2 && thread1 == thread2) must_=== Exit.Success(true)
   }
 
-  def testBlockingIOIsInterruptible = unsafeRun(
+  def testBlockingIOIsEffectBlocking = unsafeRun(
     for {
       done  <- Ref.make(false)
       start <- IO.succeed(internal.OneShot.make[Unit])

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -1079,7 +1079,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
     for {
       done  <- Ref.make(false)
       start <- IO.succeed(internal.OneShot.make[Unit])
-      fiber <- blocking.interruptible { start.set(()); Thread.sleep(Long.MaxValue) }.ensuring(done.set(true)).fork
+      fiber <- blocking.effectBlocking { start.set(()); Thread.sleep(Long.MaxValue) }.ensuring(done.set(true)).fork
       _     <- IO.succeed(start.get())
       res   <- fiber.interrupt
       value <- done.get

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -419,7 +419,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
 
   def testBracketRegression1 = {
     def makeLogger: Ref[List[String]] => String => UIO[Unit] =
-      (ref: Ref[List[String]]) => (line: String) => ref.update(_ ::: List(line)).void
+      (ref: Ref[List[String]]) => (line: String) => ref.update(_ ::: List(line)).unit
 
     unsafeRun(for {
       ref <- Ref.make[List[String]](Nil)
@@ -500,7 +500,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
 
   def testDeepAttemptIsStackSafe =
     unsafeRun((0 until 10000).foldLeft(IO.effect[Unit](())) { (acc, _) =>
-      acc.either.void
+      acc.either.unit
     }) must_=== (())
 
   def testDeepFlatMapIsStackSafe = {
@@ -694,7 +694,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
       release <- scalaz.zio.Promise.make[Nothing, Int]
       latch   = internal.OneShot.make[Unit]
       async = IO.effectAsyncInterrupt[Any, Nothing, Unit] { _ =>
-        latch.set(()); Left(release.succeed(42).void)
+        latch.set(()); Left(release.succeed(42).unit)
       }
       fiber  <- async.fork
       _      <- IO.effectTotal(latch.get(1000))
@@ -764,7 +764,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
       release <- Promise.make[Nothing, Int]
       acquire <- Promise.make[Nothing, Unit]
       task = IO.effectAsyncM[Nothing, Unit] { _ =>
-        IO.bracket(acquire.succeed(()))(_ => release.succeed(42).void)(_ => IO.never)
+        IO.bracket(acquire.succeed(()))(_ => release.succeed(42).unit)(_ => IO.never)
       }
       fiber <- task.fork
       _     <- acquire.await
@@ -780,7 +780,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
       release <- Promise.make[Nothing, Int]
       latch   = scala.concurrent.Promise[Unit]()
       async = IO.effectAsyncInterrupt[Any, Nothing, Nothing] { _ =>
-        latch.success(()); Left(release.succeed(42).void)
+        latch.success(()); Left(release.succeed(42).unit)
       }
       fiber <- async.fork
       _ <- IO.effectAsync[Throwable, Unit] { k =>
@@ -864,8 +864,8 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
       f <- (
             p1.succeed(())
               .bracket_[Any, Nothing]
-              .apply[Any](pa.succeed(1).void)(IO.never) race //    TODO: Dotty doesn't infer this properly
-              p2.succeed(()).bracket_[Any, Nothing].apply[Any](pb.succeed(2).void)(IO.never)
+              .apply[Any](pa.succeed(1).unit)(IO.never) race //    TODO: Dotty doesn't infer this properly
+              p2.succeed(()).bracket_[Any, Nothing].apply[Any](pb.succeed(2).unit)(IO.never)
           ).supervise.fork
       _ <- p1.await *> p2.await
 
@@ -883,9 +883,9 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
       f <- (
             p1.succeed(())
               .bracket_[Any, Nothing]
-              .apply[Any](pa.succeed(1).void)(IO.never)
+              .apply[Any](pa.succeed(1).unit)(IO.never)
               .fork *> //    TODO: Dotty doesn't infer this properly
-              p2.succeed(()).bracket_[Any, Nothing].apply[Any](pb.succeed(2).void)(IO.never).fork *>
+              p2.succeed(()).bracket_[Any, Nothing].apply[Any](pb.succeed(2).unit)(IO.never).fork *>
               IO.never
           ).supervise.fork
       _ <- p1.await *> p2.await
@@ -904,9 +904,9 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
             _ <- p1
                   .succeed(())
                   .bracket_[Any, Nothing]
-                  .apply[Any](pa.succeed(1).void)(IO.never)
+                  .apply[Any](pa.succeed(1).unit)(IO.never)
                   .fork //    TODO: Dotty doesn't infer this properly
-            _ <- p2.succeed(()).bracket_[Any, Nothing].apply[Any](pb.succeed(2).void)(IO.never).fork
+            _ <- p2.succeed(()).bracket_[Any, Nothing].apply[Any](pb.succeed(2).unit)(IO.never).fork
             _ <- p1.await *> p2.await
           } yield ()).supervise
       r <- pa.await zip pb.await
@@ -952,7 +952,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
       s      <- Semaphore.make(0L)
       effect <- Promise.make[Nothing, Int]
       winner = s.acquire *> IO.effectAsync[Throwable, Unit](_(IO.unit))
-      loser  = IO.bracket(s.release)(_ => effect.succeed(42).void)(_ => IO.never)
+      loser  = IO.bracket(s.release)(_ => effect.succeed(42).unit)(_ => IO.never)
       race   = winner raceEither loser
       _      <- race.either
       b      <- effect.await

--- a/core/jvm/src/test/scala/scalaz/zio/SemaphoreSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/SemaphoreSpec.scala
@@ -38,14 +38,14 @@ class SemaphoreSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Tes
 
   def e3 =
     offsettingReleasesAcquires(
-      (s, permits) => IO.foreach(permits)(s.acquireN).void,
-      (s, permits) => IO.foreach(permits.reverse)(s.releaseN).void
+      (s, permits) => IO.foreach(permits)(s.acquireN).unit,
+      (s, permits) => IO.foreach(permits.reverse)(s.releaseN).unit
     )
 
   def e4 =
     offsettingReleasesAcquires(
-      (s, permits) => IO.foreachPar(permits)(amount => s.acquireN(amount)).void,
-      (s, permits) => IO.foreachPar(permits.reverse)(amount => s.releaseN(amount)).void
+      (s, permits) => IO.foreachPar(permits)(amount => s.acquireN(amount)).unit,
+      (s, permits) => IO.foreachPar(permits.reverse)(amount => s.releaseN(amount)).unit
     )
 
   def e5 = {

--- a/core/jvm/src/test/scala/scalaz/zio/stm/STMSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/stm/STMSpec.scala
@@ -501,7 +501,7 @@ final class STMSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Tes
           _ <- tvar.update(_ + 100)
           _ <- STM.retry
         } yield ()
-        right = tvar.update(_ + 100).void
+        right = tvar.update(_ + 100).unit
         _     <- (left orElse right).commit
         v     <- tvar.get.commit
       } yield v must_=== 100
@@ -515,7 +515,7 @@ final class STMSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Tes
           _ <- tvar.update(_ + 100)
           _ <- STM.fail("Uh oh!")
         } yield ()
-        right = tvar.update(_ + 100).void
+        right = tvar.update(_ + 100).unit
         _     <- (left orElse right).commit
         v     <- tvar.get.commit
       } yield v must_=== 100
@@ -572,7 +572,7 @@ object Examples {
         _     <- mutex.set(true)
       } yield ()).commit
     def release(mutex: Mutex): UIO[Unit] =
-      mutex.set(false).commit.void
+      mutex.set(false).commit.unit
     def withMutex[R, E, A](mutex: Mutex)(zio: ZIO[R, E, A]): ZIO[R, E, A] =
       acquire(mutex).bracket_[R, E].apply[R](release(mutex))[R, E, A](zio)
   }
@@ -586,7 +586,7 @@ object Examples {
         _     <- semaphore.set(value - n)
       } yield ()).commit
     def release(semaphore: Semaphore, n: Int): UIO[Unit] =
-      semaphore.update(_ + n).commit.void
+      semaphore.update(_ + n).commit.unit
   }
   object promise {
     type Promise[A] = TRef[Option[A]]

--- a/core/shared/src/main/scala/scalaz/zio/Chunk.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Chunk.scala
@@ -442,7 +442,7 @@ sealed trait Chunk[@specialized +A] { self =>
       i += 1
     }
 
-    zio.void
+    zio.unit
   }
 
   /**

--- a/core/shared/src/main/scala/scalaz/zio/Fiber.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Fiber.scala
@@ -266,7 +266,7 @@ object Fiber {
    * Joins all fibers, awaiting their completion.
    */
   final def joinAll(fs: Iterable[Fiber[_, _]]): UIO[Unit] =
-    fs.foldLeft(IO.unit)((io, f) => io *> f.await.void)
+    fs.foldLeft(IO.unit)((io, f) => io *> f.await.unit)
 
   /**
    * Returns a `Fiber` that is backed by the specified `Future`.

--- a/core/shared/src/main/scala/scalaz/zio/Fiber.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Fiber.scala
@@ -155,7 +155,13 @@ trait Fiber[+E, +A] { self =>
   /**
    * Maps the output of this fiber to `()`.
    */
-  final def void: Fiber[E, Unit] = const(())
+  @deprecated("use unit", "1.0.0")
+  final def void: Fiber[E, Unit] = unit
+
+  /**
+   * Maps the output of this fiber to `()`.
+   */
+  final def unit: Fiber[E, Unit] = const(())
 
   /**
    * Converts this fiber into a [[scala.concurrent.Future]].

--- a/core/shared/src/main/scala/scalaz/zio/FunctionIO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/FunctionIO.scala
@@ -191,7 +191,13 @@ sealed trait FunctionIO[+E, -A, +B] extends Serializable { self =>
   /**
    * Maps the output of this effectful function to `Unit`.
    */
-  final def void: FunctionIO[E, A, Unit] = const(())
+  @deprecated("use unit", "1.0.0")
+  final def void: FunctionIO[E, A, Unit] = unit
+
+  /**
+   * Maps the output of this effectful function to `Unit`.
+   */
+  final def unit: FunctionIO[E, A, Unit] = const(())
 
   /**
    * Returns a new effectful function that merely applies this one for its

--- a/core/shared/src/main/scala/scalaz/zio/RefM.scala
+++ b/core/shared/src/main/scala/scalaz/zio/RefM.scala
@@ -29,7 +29,7 @@ import scalaz.zio.Exit.Cause
  * {{{
  * for {
  *   ref <- RefM(2)
- *   v   <- ref.update(_ + putStrLn("Hello World!").attempt.void *> IO.succeed(3))
+ *   v   <- ref.update(_ + putStrLn("Hello World!").attempt.unit *> IO.succeed(3))
  *   _   <- putStrLn("Value = " + v) // Value = 5
  * } yield ()
  * }}}

--- a/core/shared/src/main/scala/scalaz/zio/ZIO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/ZIO.scala
@@ -797,7 +797,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
    * Returns the effect resulting from mapping the success of this effect to unit.
    */
   @deprecated("use unit", "1.0.0")
-  final def void: ZIO[R, E, Unit] = const(())
+  final def void: ZIO[R, E, Unit] = unit
 
   /**
     * Returns the effect resulting from mapping the success of this effect to unit.

--- a/core/shared/src/main/scala/scalaz/zio/ZIO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/ZIO.scala
@@ -241,7 +241,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
       race: Ref[Int],
       done: Promise[E2, C]
     )(res: Exit[E0, A]): ZIO[R1, Nothing, _] =
-      ZIO.flatten(race.modify((c: Int) => (if (c > 0) ZIO.unit else f(res, loser).to(done).void) -> (c + 1)))
+      ZIO.flatten(race.modify((c: Int) => (if (c > 0) ZIO.unit else f(res, loser).to(done).unit) -> (c + 1)))
 
     for {
       done  <- Promise.make[E2, C]
@@ -796,7 +796,13 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   /**
    * Returns the effect resulting from mapping the success of this effect to unit.
    */
+  @deprecated("use unit", "1.0.0")
   final def void: ZIO[R, E, Unit] = const(())
+
+  /**
+    * Returns the effect resulting from mapping the success of this effect to unit.
+    */
+  final def unit: ZIO[R, E, Unit] = const(())
 
   /**
    * Returns an effect that effectfully "peeks" at the success of this effect.
@@ -1565,13 +1571,13 @@ trait ZIOFunctions extends Serializable {
    * The moral equivalent of `if (p) exp`
    */
   final def when[R >: LowerR, E <: UpperE](b: Boolean)(zio: ZIO[R, E, _]): ZIO[R, E, Unit] =
-    if (b) zio.void else unit
+    if (b) zio.unit else unit
 
   /**
    * The moral equivalent of `if (p) exp` when `p` has side-effects
    */
   final def whenM[R >: LowerR, E <: UpperE](b: ZIO[R, E, Boolean])(zio: ZIO[R, E, _]): ZIO[R, E, Unit] =
-    b.flatMap(b => if (b) zio.void else unit)
+    b.flatMap(b => if (b) zio.unit else unit)
 
   /**
    * Folds an `Iterable[A]` using an effectful function `f`, working sequentially.

--- a/core/shared/src/main/scala/scalaz/zio/ZIO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/ZIO.scala
@@ -800,8 +800,8 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   final def void: ZIO[R, E, Unit] = unit
 
   /**
-    * Returns the effect resulting from mapping the success of this effect to unit.
-    */
+   * Returns the effect resulting from mapping the success of this effect to unit.
+   */
   final def unit: ZIO[R, E, Unit] = const(())
 
   /**

--- a/core/shared/src/main/scala/scalaz/zio/ZSchedule.scala
+++ b/core/shared/src/main/scala/scalaz/zio/ZSchedule.scala
@@ -292,7 +292,13 @@ trait ZSchedule[-R, -A, +B] extends Serializable { self =>
   /**
    * Returns a new schedule that maps this schedule to a Unit output.
    */
+  @deprecated("use unit", "1.0.0")
   final def void: ZSchedule[R, A, Unit] = const(())
+
+  /**
+    * Returns a new schedule that maps this schedule to a Unit output.
+    */
+  final def unit: ZSchedule[R, A, Unit] = const(())
 
   /**
    * Returns a new schedule that effectfully reconsiders the decision made by
@@ -558,7 +564,7 @@ trait Schedule_Functions extends Serializable {
   /**
    * A schedule that executes once.
    */
-  final val once: Schedule[Any, Unit] = recurs(1).void
+  final val once: Schedule[Any, Unit] = recurs(1).unit
 
   /**
    * A new schedule derived from the specified schedule which adds the delay

--- a/core/shared/src/main/scala/scalaz/zio/ZSchedule.scala
+++ b/core/shared/src/main/scala/scalaz/zio/ZSchedule.scala
@@ -293,7 +293,7 @@ trait ZSchedule[-R, -A, +B] extends Serializable { self =>
    * Returns a new schedule that maps this schedule to a Unit output.
    */
   @deprecated("use unit", "1.0.0")
-  final def void: ZSchedule[R, A, Unit] = const(())
+  final def void: ZSchedule[R, A, Unit] = unit
 
   /**
     * Returns a new schedule that maps this schedule to a Unit output.

--- a/core/shared/src/main/scala/scalaz/zio/ZSchedule.scala
+++ b/core/shared/src/main/scala/scalaz/zio/ZSchedule.scala
@@ -296,8 +296,8 @@ trait ZSchedule[-R, -A, +B] extends Serializable { self =>
   final def void: ZSchedule[R, A, Unit] = unit
 
   /**
-    * Returns a new schedule that maps this schedule to a Unit output.
-    */
+   * Returns a new schedule that maps this schedule to a Unit output.
+   */
   final def unit: ZSchedule[R, A, Unit] = const(())
 
   /**

--- a/core/shared/src/main/scala/scalaz/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stm/STM.scala
@@ -230,8 +230,8 @@ final class STM[+E, +A] private[stm] (
   final def void: STM[E, Unit] = unit
 
   /**
-    * Maps the success value of this effect to unit.
-    */
+   * Maps the success value of this effect to unit.
+   */
   final def unit: STM[E, Unit] = const(())
 
   /**

--- a/core/shared/src/main/scala/scalaz/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stm/STM.scala
@@ -226,7 +226,13 @@ final class STM[+E, +A] private[stm] (
   /**
    * Maps the success value of this effect to unit.
    */
+  @deprecated("use unit", "1.0.0")
   final def void: STM[E, Unit] = const(())
+
+  /**
+    * Maps the success value of this effect to unit.
+    */
+  final def unit: STM[E, Unit] = const(())
 
   /**
    * Same as [[filter]]

--- a/core/shared/src/main/scala/scalaz/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stm/STM.scala
@@ -227,7 +227,7 @@ final class STM[+E, +A] private[stm] (
    * Maps the success value of this effect to unit.
    */
   @deprecated("use unit", "1.0.0")
-  final def void: STM[E, Unit] = const(())
+  final def void: STM[E, Unit] = unit
 
   /**
     * Maps the success value of this effect to unit.

--- a/core/shared/src/main/scala/scalaz/zio/stm/TQueue.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stm/TQueue.scala
@@ -28,7 +28,7 @@ class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
 
   // TODO: Scala doesn't allow Iterable???
   final def offerAll(as: List[A]): STM[Nothing, Unit] =
-    ref.update(_.enqueue(as)).void
+    ref.update(_.enqueue(as)).unit
 
   final def poll: STM[Nothing, Option[A]] = takeUpTo(1).map(_.headOption)
 

--- a/core/shared/src/main/scala/scalaz/zio/stm/TSemaphore.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stm/TSemaphore.scala
@@ -32,7 +32,7 @@ class TSemaphore private (permits: TRef[Long]) {
   final def release: STM[Nothing, Unit] = releaseN(1L)
 
   final def releaseN(n: Long): STM[Nothing, Unit] =
-    assertNonNegative(n) *> permits.update(_ + n).void
+    assertNonNegative(n) *> permits.update(_ + n).unit
 
   final def withPermit[E, B](stm: STM[E, B]): STM[E, B] =
     acquire *> stm <* release

--- a/interop-cats/jvm/src/main/scala/scalaz/zio/interop/catsjvm.scala
+++ b/interop-cats/jvm/src/main/scala/scalaz/zio/interop/catsjvm.scala
@@ -119,7 +119,7 @@ private class CatsConcurrentEffect[R](rts: Runtime[R])
           f.await
             .flatMap(exit => IO.effect(cb(exitToEither(exit)).unsafeRunAsync(_ => ())))
             .fork
-            .const(f.interrupt.void)
+            .const(f.interrupt.unit)
         }
       }
     }
@@ -132,7 +132,7 @@ private class CatsConcurrent[R] extends CatsEffect[R] with Concurrent[TaskR[R, ?
 
   private[this] final def toFiber[A](f: Fiber[Throwable, A]): effect.Fiber[TaskR[R, ?], A] =
     new effect.Fiber[TaskR[R, ?], A] {
-      override final val cancel: TaskR[R, Unit] = f.interrupt.void
+      override final val cancel: TaskR[R, Unit] = f.interrupt.unit
 
       override final val join: TaskR[R, A] = f.join
     }

--- a/interop-cats/jvm/src/test/scala/scalaz/zio/interop/Fs2ZioSpec.scala
+++ b/interop-cats/jvm/src/test/scala/scalaz/zio/interop/Fs2ZioSpec.scala
@@ -58,7 +58,7 @@ class ZioWithFs2Spec(implicit ee: ExecutionEnv) extends Specification with Aroun
         released <- Promise.make[Nothing, Unit]
         fail     <- Promise.make[Nothing, Unit]
         _ <- Stream
-              .bracket(started.succeed(()).void)(_ => released.succeed(()).void)
+              .bracket(started.succeed(()).unit)(_ => released.succeed(()).unit)
               .evalMap[Task, Unit] { _ =>
                 fail.await *> IO.fail(new Exception())
               }
@@ -79,7 +79,7 @@ class ZioWithFs2Spec(implicit ee: ExecutionEnv) extends Specification with Aroun
         released  <- Promise.make[Nothing, Unit]
         terminate <- Promise.make[Nothing, Unit]
         _ <- Stream
-              .bracket(started.succeed(()).void)(_ => released.succeed(()).void)
+              .bracket(started.succeed(()).unit)(_ => released.succeed(()).unit)
               .evalMap[Task, Unit] { _ =>
                 terminate.await *> IO.die(new Exception())
               }
@@ -99,7 +99,7 @@ class ZioWithFs2Spec(implicit ee: ExecutionEnv) extends Specification with Aroun
         started  <- Promise.make[Nothing, Unit]
         released <- Promise.make[Nothing, Unit]
         f <- Stream
-              .bracket(IO.unit)(_ => released.succeed(()).void)
+              .bracket(IO.unit)(_ => released.succeed(()).unit)
               .evalMap[Task, Unit](_ => started.succeed(()) *> IO.never)
               .compile
               .drain

--- a/interop-future/jvm/src/main/scala/scalaz/zio/interop/Future.scala
+++ b/interop-future/jvm/src/main/scala/scalaz/zio/interop/Future.scala
@@ -115,16 +115,16 @@ package object future {
 
   implicit class FutureSyntax[T](val value: Future[T]) extends AnyVal {
     final def onSuccess[U](pf: PartialFunction[T, U])(implicit ec: ExecutionContext): Unit =
-      unsafeRun(ec, value.join.flatMap[Any, Throwable, Option[U]](t => IO.effect(pf lift t)).fork.void)
+      unsafeRun(ec, value.join.flatMap[Any, Throwable, Option[U]](t => IO.effect(pf lift t)).fork.unit)
 
     final def onFailure[U](pf: PartialFunction[Throwable, U])(implicit ec: ExecutionContext): Unit =
       unsafeRun(ec, value.join.either.flatMap {
         case Left(t)  => IO.effect(pf lift t)
         case Right(_) => IO.unit
-      }.fork.void)
+      }.fork.unit)
 
     final def onComplete[U](f: Try[T] => U)(implicit ec: ExecutionContext): Unit =
-      unsafeRun(ec, value.join.either.map(toTry(_)).flatMap[Any, Throwable, U](t => IO.effect(f(t))).fork.void)
+      unsafeRun(ec, value.join.either.map(toTry(_)).flatMap[Any, Throwable, U](t => IO.effect(f(t))).fork.unit)
 
     final def isCompleted: Boolean =
       unsafeRun(Global, value.poll.map(_.fold(false)(_ => true)))

--- a/interop-reactiveStreams/jvm/src/test/scala/scalaz/zio/interop/reactiveStreams/PublisherToStreamSpec.scala
+++ b/interop-reactiveStreams/jvm/src/test/scala/scalaz/zio/interop/reactiveStreams/PublisherToStreamSpec.scala
@@ -26,7 +26,7 @@ class PublisherToStreamSpec(implicit ee: ExecutionEnv) extends TestRuntime with 
   implicit private val materializer: ActorMaterializer = ActorMaterializer()
 
   override def afterAll(): Unit =
-    unsafeRun(UIO(materializer.shutdown()) *> Task.fromFuture(_ => system.terminate()).void)
+    unsafeRun(UIO(materializer.shutdown()) *> Task.fromFuture(_ => system.terminate()).unit)
 
   private val e   = new RuntimeException("boom")
   private val seq = List.range(0, 100)

--- a/interop-reactiveStreams/jvm/src/test/scala/scalaz/zio/interop/reactiveStreams/QueueSubscriberSpec.scala
+++ b/interop-reactiveStreams/jvm/src/test/scala/scalaz/zio/interop/reactiveStreams/QueueSubscriberSpec.scala
@@ -43,8 +43,8 @@ class QueueSubscriberSpec(implicit ee: ExecutionEnv) extends TestRuntime {
         canceled             <- Promise.make[Unit, Unit]
         runtime              <- ZIO.runtime[Any]
         s = new Subscription {
-          override def request(n: Long): Unit = runtime.unsafeRun(canceled.fail(()).void)
-          override def cancel(): Unit         = runtime.unsafeRun(canceled.succeed(()).void)
+          override def request(n: Long): Unit = runtime.unsafeRun(canceled.fail(()).unit)
+          override def cancel(): Unit         = runtime.unsafeRun(canceled.succeed(()).unit)
         }
         _ <- UIO(subscriber.onSubscribe(s))
         _ <- canceled.await
@@ -59,8 +59,8 @@ class QueueSubscriberSpec(implicit ee: ExecutionEnv) extends TestRuntime {
         canceled             <- Promise.make[Unit, Unit]
         runtime              <- ZIO.runtime[Any]
         s = new Subscription {
-          override def request(n: Long): Unit = runtime.unsafeRun(canceled.fail(()).void)
-          override def cancel(): Unit         = runtime.unsafeRun(canceled.succeed(()).void)
+          override def request(n: Long): Unit = runtime.unsafeRun(canceled.fail(()).unit)
+          override def cancel(): Unit         = runtime.unsafeRun(canceled.succeed(()).unit)
         }
         _ <- UIO(subscriber.onSubscribe(s))
         _ <- stream.run(Sink.fail(boom)).catchAll(_ => UIO.unit)
@@ -77,7 +77,7 @@ class QueueSubscriberSpec(implicit ee: ExecutionEnv) extends TestRuntime {
         runtime              <- ZIO.runtime[Any]
         s = new Subscription {
           override def request(n: Long): Unit = (0 until n.toInt).foreach(subscriber.onNext)
-          override def cancel(): Unit         = runtime.unsafeRun(canceled.succeed(()).void)
+          override def cancel(): Unit         = runtime.unsafeRun(canceled.succeed(()).unit)
         }
         _ <- UIO(subscriber.onSubscribe(s))
         _ <- stream.drop(10).run(Sink.fail(boom)).catchAll(_ => UIO.unit)
@@ -97,7 +97,7 @@ class QueueSubscriberSpec(implicit ee: ExecutionEnv) extends TestRuntime {
         runtime              <- ZIO.runtime[Any]
         s = new Subscription {
           override def request(n: Long): Unit = (0 until n.toInt).foreach(subscriber.onNext)
-          override def cancel(): Unit         = runtime.unsafeRun(canceled.succeed(()).void)
+          override def cancel(): Unit         = runtime.unsafeRun(canceled.succeed(()).unit)
         }
         _ <- UIO(subscriber.onSubscribe(s))
         _ <- canceled.await
@@ -119,7 +119,7 @@ class QueueSubscriberSpec(implicit ee: ExecutionEnv) extends TestRuntime {
             runtime.unsafeRun(delivered.succeed(()))
             ()
           }
-          override def cancel(): Unit = runtime.unsafeRun(canceled.succeed(()).void)
+          override def cancel(): Unit = runtime.unsafeRun(canceled.succeed(()).unit)
         }
         _ <- UIO(subscriber.onSubscribe(s))
         _ <- delivered.await

--- a/interop-reactiveStreams/jvm/src/test/scala/scalaz/zio/interop/reactiveStreams/SubscriberToSinkSpec.scala
+++ b/interop-reactiveStreams/jvm/src/test/scala/scalaz/zio/interop/reactiveStreams/SubscriberToSinkSpec.scala
@@ -22,7 +22,7 @@ class SubscriberToSinkSpec(implicit ee: ExecutionEnv) extends TestRuntime with A
   implicit private val materializer: ActorMaterializer = ActorMaterializer()
 
   override def afterAll(): Unit =
-    unsafeRun(UIO(materializer.shutdown()) *> Task.fromFuture(_ => system.terminate()).void)
+    unsafeRun(UIO(materializer.shutdown()) *> Task.fromFuture(_ => system.terminate()).unit)
 
   private val seq = List.range(0, 100)
   private val e   = new RuntimeException("boom")

--- a/interop-reactiveStreams/shared/src/main/scala/scalaz/zio/interop/reactiveStreams/QueueSubscriber.scala
+++ b/interop-reactiveStreams/shared/src/main/scala/scalaz/zio/interop/reactiveStreams/QueueSubscriber.scala
@@ -77,9 +77,9 @@ private[reactiveStreams] object QueueSubscriber {
 
     override def onError(e: Throwable): Unit = {
       if (e == null) throw new NullPointerException("t was null in onError")
-      runtime.unsafeRun(completion.fail(e).void)
+      runtime.unsafeRun(completion.fail(e).unit)
     }
 
-    override def onComplete(): Unit = runtime.unsafeRun(completion.succeed(()).void)
+    override def onComplete(): Unit = runtime.unsafeRun(completion.succeed(()).unit)
   }
 }

--- a/interop-reactiveStreams/shared/src/main/scala/scalaz/zio/interop/reactiveStreams/SubscriberHelpers.scala
+++ b/interop-reactiveStreams/shared/src/main/scala/scalaz/zio/interop/reactiveStreams/SubscriberHelpers.scala
@@ -38,7 +38,7 @@ private[reactiveStreams] object SubscriberHelpers {
     new Subscription {
       override def request(n: Long): Unit = {
         if (n <= 0) subscriber.onError(new IllegalArgumentException("n must be > 0"))
-        runtime.unsafeRunAsync_(demand.offer(n).void)
+        runtime.unsafeRunAsync_(demand.offer(n).unit)
       }
       override def cancel(): Unit = runtime.unsafeRun(demand.shutdown)
     }

--- a/microsite/src/main/tut/datatypes/ref.md
+++ b/microsite/src/main/tut/datatypes/ref.md
@@ -83,7 +83,7 @@ object S {
   def apply(v: Long): UIO[S] =
     Ref.make(v).map { vref =>
       new S {
-        def V = vref.update(_ + 1).void
+        def V = vref.update(_ + 1).unit
 
         def P = (vref.get.flatMap { v =>
           if (v < 0)
@@ -93,7 +93,7 @@ object S {
               case false => IO.fail(())
               case true  => IO.unit
             }
-        } <> P).either.void
+        } <> P).either.unit
       }
     }
 }

--- a/microsite/src/main/tut/overview/creating_effects.md
+++ b/microsite/src/main/tut/overview/creating_effects.md
@@ -192,18 +192,18 @@ Some side-effects use blocking IO or otherwise put a thread into a waiting state
 
 ZIO provides the `scalaz.zio.blocking` package, which can be used to safely convert such blocking side-effects into ZIO effects.
 
-A blocking side-effect can be converted directly into an interruptible ZIO effect with the `interruptible` method:
+A blocking side-effect can be converted directly into a ZIO effect blocking with the `effectBlocking` method:
 
 ```tut:silent
 import scalaz.zio.blocking._
 
 val sleeping = 
-  interruptible(Thread.sleep(Long.MaxValue))
+  effectBlocking(Thread.sleep(Long.MaxValue))
 ```
 
 The resulting effect will be executed on a separate thread pool designed specifically for blocking effects.
 
-If a side-effect has already been converted into a ZIO effect, then instead of `interruptible`, the `blocking` method can be used to shift the effect onto the blocking thread pool:
+If a side-effect has already been converted into a ZIO effect, then instead of `effectBlocking`, the `blocking` method can be used to shift the effect onto the blocking thread pool:
 
 ```tut:silent
 import scala.io.{ Codec, Source }

--- a/streams/shared/src/main/scala/scalaz/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/scalaz/stream/ZSink.scala
@@ -212,7 +212,10 @@ trait ZSink[-R, +E, +A0, -A, +B] { self =>
 
   final def const[C](c: => C): ZSink[R, E, A0, A, C] = self.map(_ => c)
 
-  final def void: ZSink[R, E, A0, A, Unit] = const(())
+  @deprecated("use unit", "1.0.0")
+  final def void: ZSink[R, E, A0, A, Unit] = unit
+
+  final def unit: ZSink[R, E, A0, A, Unit] = const(())
 
   final def untilOutput(f: B => Boolean): ZSink[R, E, A0, A, B] =
     new ZSink[R, E, A0, A, B] {

--- a/streams/shared/src/main/scala/scalaz/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/scalaz/stream/ZStream.scala
@@ -126,7 +126,7 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
       .flatMap[R1, E1, Boolean] { f0 =>
         f0(true, identity, (cont, a) => if (cont) f(a) else IO.succeed(cont))
       }
-      .void
+      .unit
 
   /**
    * Performs a filter and map in a single step.
@@ -286,8 +286,8 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
           if (cont(s)) {
             (for {
               queue  <- Queue.bounded[Elem](capacity)
-              putL   = (a: A) => queue.offer(Left(Take.Value(a))).void
-              putR   = (b: B) => queue.offer(Right(Take.Value(b))).void
+              putL   = (a: A) => queue.offer(Left(Take.Value(a))).unit
+              putR   = (b: B) => queue.offer(Right(Take.Value(b))).unit
               catchL = (e: E2) => queue.offer(Left(Take.Fail(e)))
               catchR = (e: E2) => queue.offer(Right(Take.Fail(e)))
               endL   = queue.offer(Left(Take.End))
@@ -363,7 +363,7 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
                       }
                     )
                   }
-                  .onError(c => result.done(IO.halt(c)).void)
+                  .onError(c => result.done(IO.halt(c)).unit)
                   .fork
         _ <- fiber.await.flatMap {
               case Exit.Success(Left(_)) =>
@@ -372,7 +372,7 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
                 )
               case Exit.Success(Right((rstate, _, _))) => done.succeed(rstate)
               case Exit.Failure(c)                     => done.done(IO.halt(c))
-            }.fork.void
+            }.fork.unit
       } yield (fiber, result)
 
     ZManaged
@@ -525,7 +525,7 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
   final def toQueue[E1 >: E, A1 >: A](capacity: Int = 1): ZManaged[R, Nothing, Queue[Take[E1, A1]]] =
     for {
       queue    <- ZManaged.make(Queue.bounded[Take[E1, A1]](capacity))(_.shutdown)
-      offerVal = (a: A) => queue.offer(Take.Value(a)).void
+      offerVal = (a: A) => queue.offer(Take.Value(a)).unit
       offerErr = (e: E) => queue.offer(Take.Fail(e))
       enqueuer = (self.foreach[R, E](offerVal).catchAll(offerErr) *> queue.offer(Take.End)).fork
       _        <- ZManaged.make(enqueuer)(_.interrupt)

--- a/testkit/jvm/src/main/scala/scalaz/zio/testkit/TestClock.scala
+++ b/testkit/jvm/src/main/scala/scalaz/zio/testkit/TestClock.scala
@@ -32,14 +32,14 @@ case class TestClock(ref: Ref[TestClock.Data]) extends Clock.Service[Any] {
     ref.get.map(_.nanoTime)
 
   final def sleep(duration: Duration): UIO[Unit] =
-    adjust(duration) *> ref.update(data => data.copy(sleeps0 = duration :: data.sleeps0)).void
+    adjust(duration) *> ref.update(data => data.copy(sleeps0 = duration :: data.sleeps0)).unit
 
   val sleeps: UIO[List[Duration]] = ref.get.map(_.sleeps0.reverse)
 
   final def adjust(duration: Duration): UIO[Unit] =
     ref.update { data =>
       Data(data.nanoTime + duration.toNanos, data.currentTimeMillis + duration.toMillis, data.sleeps0)
-    }.void
+    }.unit
 
 }
 

--- a/testkit/jvm/src/main/scala/scalaz/zio/testkit/TestConsole.scala
+++ b/testkit/jvm/src/main/scala/scalaz/zio/testkit/TestConsole.scala
@@ -27,12 +27,12 @@ case class TestConsole(ref: Ref[TestConsole.Data]) extends Console.Service[Any] 
   override def putStr(line: String): UIO[Unit] =
     ref.update { data =>
       Data(data.input, data.output :+ line)
-    }.void
+    }.unit
 
   override def putStrLn(line: String): ZIO[Any, Nothing, Unit] =
     ref.update { data =>
       Data(data.input, data.output :+ s"$line\n")
-    }.void
+    }.unit
 
   val getStrLn: ZIO[Any, IOException, String] = {
     for {

--- a/testkit/jvm/src/main/scala/scalaz/zio/testkit/TestScheduler.scala
+++ b/testkit/jvm/src/main/scala/scalaz/zio/testkit/TestScheduler.scala
@@ -83,7 +83,7 @@ object TestScheduler {
     pause: Duration = 10.milliseconds
   ): ZIO[Clock, Nothing, Unit] =
     (task *> ref.get).flatMap { exit =>
-      if (exit) task.void // make sure everything is finished
+      if (exit) task.unit // make sure everything is finished
       else sleep(pause) *> runWhile(task, ref, pause)
     }
 

--- a/testkit/jvm/src/test/scala/scalaz/zio/testkit/SchedulerSpec.scala
+++ b/testkit/jvm/src/test/scala/scalaz/zio/testkit/SchedulerSpec.scala
@@ -23,7 +23,7 @@ class SchedulerSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Tes
         scheduler <- res._2.scheduler
         promise   <- Promise.make[Nothing, Unit]
         _ <- ZIO.effectTotal(scheduler.schedule(new Runnable {
-              override def run(): Unit = unsafeRun(promise.done(ZIO.unit).void)
+              override def run(): Unit = unsafeRun(promise.done(ZIO.unit).unit)
             }, 10.seconds))
         _        <- clock.sleep(10.seconds)
         _        <- scheduler.safeShutdown()
@@ -39,7 +39,7 @@ class SchedulerSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Tes
         scheduler <- res._2.scheduler
         promise   <- Promise.make[Nothing, Unit]
         _ <- ZIO.effectTotal(scheduler.schedule(new Runnable {
-              override def run(): Unit = unsafeRun(promise.done(ZIO.unit).void)
+              override def run(): Unit = unsafeRun(promise.done(ZIO.unit).unit)
             }, 10.seconds + 1.nanosecond))
         _        <- clock.sleep(10.seconds)
         _        <- scheduler.safeShutdown()
@@ -55,7 +55,7 @@ class SchedulerSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Tes
         scheduler <- res._2.scheduler
         promise   <- Promise.make[Nothing, Unit]
         cancel <- ZIO.effectTotal(scheduler.schedule(new Runnable {
-                   override def run(): Unit = unsafeRun(promise.done(ZIO.unit).void)
+                   override def run(): Unit = unsafeRun(promise.done(ZIO.unit).unit)
                  }, 10.seconds))
         canceled <- ZIO.effectTotal(cancel())
         _        <- clock.sleep(10.seconds)
@@ -72,7 +72,7 @@ class SchedulerSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Tes
         scheduler <- res._2.scheduler
         promise   <- Promise.make[Nothing, Unit]
         cancel <- ZIO.effectTotal(scheduler.schedule(new Runnable {
-                   override def run(): Unit = unsafeRun(promise.done(ZIO.unit).void)
+                   override def run(): Unit = unsafeRun(promise.done(ZIO.unit).unit)
                  }, 10.seconds))
         _        <- clock.sleep(10.seconds)
         _        <- scheduler.safeShutdown()


### PR DESCRIPTION
https://github.com/scalaz/scalaz-zio/issues/739