### PR TITLE
Fixed #745 - reduce visibility of classes

### DIFF
--- a/core/jvm/src/main/scala/scalaz/zio/internal/NamedThreadFactory.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/internal/NamedThreadFactory.scala
@@ -19,7 +19,7 @@ package scalaz.zio.internal
 import java.util.concurrent._
 import java.util.concurrent.atomic.AtomicInteger
 
-final class NamedThreadFactory(name: String, daemon: Boolean) extends ThreadFactory {
+private[zio] final class NamedThreadFactory(name: String, daemon: Boolean) extends ThreadFactory {
 
   private val parentGroup =
     Option(System.getSecurityManager).fold(Thread.currentThread().getThreadGroup)(_.getThreadGroup)

--- a/core/shared/src/main/scala-2.12+/either.scala
+++ b/core/shared/src/main/scala-2.12+/either.scala
@@ -16,4 +16,4 @@
 
 package scalaz.zio
 
-trait EitherCompat {}
+private[zio] trait EitherCompat {}

--- a/core/shared/src/main/scala/scalaz/zio/ZIO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/ZIO.scala
@@ -228,12 +228,12 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
         exit.foldM[E1, Either[A, B]](
           _ => right.join.map(Right(_)),
           a => ZIO.succeedLeft(a) <* right.interrupt
-        ),
+      ),
       (exit, left) =>
         exit.foldM[E1, Either[A, B]](
           _ => left.join.map(Left(_)),
           b => ZIO.succeedRight(b) <* left.interrupt
-        )
+      )
     )
 
   /**
@@ -466,13 +466,13 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
               finalizer.foldCauseM[Any, E, Nothing](
                 cause2 => ZIO.halt(cause1 ++ cause2),
                 _ => ZIO.halt(cause1)
-              ),
+            ),
             value =>
               finalizer.foldCauseM[Any, E, A](
                 cause1 => ZIO.halt(cause1),
                 _ => ZIO.succeed(value)
-              )
-          )
+            )
+        )
     )
 
   /**
@@ -508,7 +508,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
         eb match {
           case Exit.Failure(_) => release(a)
           case _               => ZIO.unit
-        }
+      }
     )(use)
 
   /**
@@ -527,7 +527,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
         eb match {
           case Exit.Success(_)     => ZIO.unit
           case Exit.Failure(cause) => cleanup(cause)
-        }
+      }
     )(_ => self)
 
   /**
@@ -548,7 +548,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
         eb match {
           case Exit.Failure(cause) => cause.failureOrCause.fold(_ => ZIO.unit, cleanup)
           case _                   => ZIO.unit
-        }
+      }
     )(_ => self)
 
   /**
@@ -810,7 +810,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
           schedule.update(a, state).flatMap { step =>
             if (!step.cont) ZIO.succeedRight(step.finish())
             else ZIO.succeed(step.state).delay(step.delay).flatMap(s => loop(Some(step.finish), s))
-          }
+        }
       )
 
     schedule.initial.flatMap(loop(None, _))
@@ -854,7 +854,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
               decision =>
                 if (decision.cont) clock.sleep(decision.delay) *> loop(decision.state)
                 else orElse(err, decision.finish()).map(Left(_))
-            ),
+          ),
         succ => ZIO.succeedRight(succ)
       )
 
@@ -1759,7 +1759,7 @@ private[zio] trait ZIO_E_Throwable extends ZIOFunctions {
         try Right(effect)
         catch {
           case t: Throwable if !platform.fatal(t) => Left(t)
-        }
+      }
     ).absolve
 
   /**
@@ -1925,7 +1925,8 @@ object ZIO extends ZIO_R_Any {
     final val Access          = 13
     final val Provide         = 14
   }
-  private[zio] final class FlatMap[R, E, A0, A](val zio: ZIO[R, E, A0], val k: A0 => ZIO[R, E, A]) extends ZIO[R, E, A] {
+  private[zio] final class FlatMap[R, E, A0, A](val zio: ZIO[R, E, A0], val k: A0 => ZIO[R, E, A])
+      extends ZIO[R, E, A] {
     override def tag = Tags.FlatMap
   }
 

--- a/core/shared/src/main/scala/scalaz/zio/ZIO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/ZIO.scala
@@ -1091,7 +1091,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   def tag: Int
 }
 
-trait ZIOFunctions extends Serializable {
+private[zio] trait ZIOFunctions extends Serializable {
   // ALL error types in this trait must be a subtype of `UpperE`.
   type UpperE
   // ALL environment types in this trait must be a supertype of `LowerR`.
@@ -1731,7 +1731,7 @@ trait ZIOFunctions extends Serializable {
 
 }
 
-trait ZIO_E_Any extends ZIO_E_Throwable {
+private[zio] trait ZIO_E_Any extends ZIO_E_Throwable {
   type UpperE = Any
 
   /**
@@ -1741,7 +1741,7 @@ trait ZIO_E_Any extends ZIO_E_Throwable {
     effectTotal(v).flatMap(_.fold[IO[Unit, A]](fail(()))(succeed(_)))
 }
 
-trait ZIO_E_Throwable extends ZIOFunctions {
+private[zio] trait ZIO_E_Throwable extends ZIOFunctions {
   type UpperE >: Throwable
 
   /**
@@ -1791,7 +1791,7 @@ trait ZIO_E_Throwable extends ZIOFunctions {
 
     }
 }
-trait ZIO_R_Any extends ZIO_E_Any {
+private[zio] trait ZIO_R_Any extends ZIO_E_Any {
   type LowerR = Nothing
 
   /**
@@ -1832,7 +1832,7 @@ object ZIO extends ZIO_R_Any {
   private val _IdentityFn: Any => Any    = (a: Any) => a
   private[zio] def identityFn[A]: A => A = _IdentityFn.asInstanceOf[A => A]
 
-  implicit class ZIOInvariant[R, E, A](val self: ZIO[R, E, A]) extends AnyVal {
+  private[zio] implicit class ZIOInvariant[R, E, A](val self: ZIO[R, E, A]) extends AnyVal {
     final def bracket: ZIO.BracketAcquire[R, E, A] =
       new ZIO.BracketAcquire(self)
 
@@ -1908,7 +1908,7 @@ object ZIO extends ZIO_R_Any {
   private val _succeedRight: Any => IO[Any, Either[Any, Any]] =
     a => succeed[Either[Any, Any]](Right(a))
 
-  object Tags {
+  private[zio] object Tags {
     final val FlatMap         = 0
     final val Succeed         = 1
     final val Effect          = 2
@@ -1925,23 +1925,23 @@ object ZIO extends ZIO_R_Any {
     final val Access          = 13
     final val Provide         = 14
   }
-  final class FlatMap[R, E, A0, A](val zio: ZIO[R, E, A0], val k: A0 => ZIO[R, E, A]) extends ZIO[R, E, A] {
+  private[zio] final class FlatMap[R, E, A0, A](val zio: ZIO[R, E, A0], val k: A0 => ZIO[R, E, A]) extends ZIO[R, E, A] {
     override def tag = Tags.FlatMap
   }
 
-  final class Succeed[A](val value: A) extends UIO[A] {
+  private[zio] final class Succeed[A](val value: A) extends UIO[A] {
     override def tag = Tags.Succeed
   }
 
-  final class Effect[A](val effect: Platform => A) extends UIO[A] {
+  private[zio] final class Effect[A](val effect: Platform => A) extends UIO[A] {
     override def tag = Tags.Effect
   }
 
-  final class EffectAsync[E, A](val register: (IO[E, A] => Unit) => Option[IO[E, A]]) extends IO[E, A] {
+  private[zio] final class EffectAsync[E, A](val register: (IO[E, A] => Unit) => Option[IO[E, A]]) extends IO[E, A] {
     override def tag = Tags.EffectAsync
   }
 
-  final class Fold[R, E, E2, A, B](
+  private[zio] final class Fold[R, E, E2, A, B](
     val value: ZIO[R, E, A],
     val failure: Cause[E] => ZIO[R, E2, B],
     val success: A => ZIO[R, E2, B]
@@ -1953,23 +1953,23 @@ object ZIO extends ZIO_R_Any {
     final def apply(v: A): ZIO[R, E2, B] = success(v)
   }
 
-  final class Fork[E, A](val value: IO[E, A]) extends UIO[Fiber[E, A]] {
+  private[zio] final class Fork[E, A](val value: IO[E, A]) extends UIO[Fiber[E, A]] {
     override def tag = Tags.Fork
   }
 
-  final class InterruptStatus[R, E, A](val zio: ZIO[R, E, A], val flag: Boolean) extends ZIO[R, E, A] {
+  private[zio] final class InterruptStatus[R, E, A](val zio: ZIO[R, E, A], val flag: Boolean) extends ZIO[R, E, A] {
     override def tag = Tags.InterruptStatus
   }
 
-  final class CheckInterrupt[R, E, A](val k: Boolean => ZIO[R, E, A]) extends ZIO[R, E, A] {
+  private[zio] final class CheckInterrupt[R, E, A](val k: Boolean => ZIO[R, E, A]) extends ZIO[R, E, A] {
     override def tag = Tags.CheckInterrupt
   }
 
-  final class Supervised[R, E, A](val value: ZIO[R, E, A]) extends ZIO[R, E, A] {
+  private[zio] final class Supervised[R, E, A](val value: ZIO[R, E, A]) extends ZIO[R, E, A] {
     override def tag = Tags.Supervised
   }
 
-  final class Fail[E, A](val cause: Cause[E]) extends IO[E, A] { self =>
+  private[zio] final class Fail[E, A](val cause: Cause[E]) extends IO[E, A] { self =>
     override def tag = Tags.Fail
 
     override final def map[B](f: A => B): IO[E, B] =
@@ -1985,23 +1985,23 @@ object ZIO extends ZIO_R_Any {
       failure(cause)
   }
 
-  final class Descriptor[R, E, A](val k: Fiber.Descriptor => ZIO[R, E, A]) extends ZIO[R, E, A] {
+  private[zio] final class Descriptor[R, E, A](val k: Fiber.Descriptor => ZIO[R, E, A]) extends ZIO[R, E, A] {
     override def tag = Tags.Descriptor
   }
 
-  final class Lock[R, E, A](val executor: Executor, val zio: ZIO[R, E, A]) extends ZIO[R, E, A] {
+  private[zio] final class Lock[R, E, A](val executor: Executor, val zio: ZIO[R, E, A]) extends ZIO[R, E, A] {
     override def tag = Tags.Lock
   }
 
-  object Yield extends UIO[Unit] {
+  private[zio] object Yield extends UIO[Unit] {
     override def tag = Tags.Yield
   }
 
-  final class Read[R, E, A](val k: R => ZIO[R, E, A]) extends ZIO[R, E, A] {
+  private[zio] final class Read[R, E, A](val k: R => ZIO[R, E, A]) extends ZIO[R, E, A] {
     override def tag = Tags.Access
   }
 
-  final class Provide[R, E, A](val r: R, val next: ZIO[R, E, A]) extends IO[E, A] {
+  private[zio] final class Provide[R, E, A](val r: R, val next: ZIO[R, E, A]) extends IO[E, A] {
     override def tag = Tags.Provide
   }
 }

--- a/core/shared/src/main/scala/scalaz/zio/ZIO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/ZIO.scala
@@ -1832,7 +1832,7 @@ object ZIO extends ZIO_R_Any {
   private val _IdentityFn: Any => Any    = (a: Any) => a
   private[zio] def identityFn[A]: A => A = _IdentityFn.asInstanceOf[A => A]
 
-  private[zio] implicit class ZIOInvariant[R, E, A](val self: ZIO[R, E, A]) extends AnyVal {
+  implicit class ZIOInvariant[R, E, A](val self: ZIO[R, E, A]) extends AnyVal {
     final def bracket: ZIO.BracketAcquire[R, E, A] =
       new ZIO.BracketAcquire(self)
 

--- a/core/shared/src/main/scala/scalaz/zio/ZIO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/ZIO.scala
@@ -228,12 +228,12 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
         exit.foldM[E1, Either[A, B]](
           _ => right.join.map(Right(_)),
           a => ZIO.succeedLeft(a) <* right.interrupt
-      ),
+        ),
       (exit, left) =>
         exit.foldM[E1, Either[A, B]](
           _ => left.join.map(Left(_)),
           b => ZIO.succeedRight(b) <* left.interrupt
-      )
+        )
     )
 
   /**
@@ -466,13 +466,13 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
               finalizer.foldCauseM[Any, E, Nothing](
                 cause2 => ZIO.halt(cause1 ++ cause2),
                 _ => ZIO.halt(cause1)
-            ),
+              ),
             value =>
               finalizer.foldCauseM[Any, E, A](
                 cause1 => ZIO.halt(cause1),
                 _ => ZIO.succeed(value)
-            )
-        )
+              )
+          )
     )
 
   /**
@@ -508,7 +508,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
         eb match {
           case Exit.Failure(_) => release(a)
           case _               => ZIO.unit
-      }
+        }
     )(use)
 
   /**
@@ -527,7 +527,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
         eb match {
           case Exit.Success(_)     => ZIO.unit
           case Exit.Failure(cause) => cleanup(cause)
-      }
+        }
     )(_ => self)
 
   /**
@@ -548,7 +548,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
         eb match {
           case Exit.Failure(cause) => cause.failureOrCause.fold(_ => ZIO.unit, cleanup)
           case _                   => ZIO.unit
-      }
+        }
     )(_ => self)
 
   /**
@@ -810,7 +810,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
           schedule.update(a, state).flatMap { step =>
             if (!step.cont) ZIO.succeedRight(step.finish())
             else ZIO.succeed(step.state).delay(step.delay).flatMap(s => loop(Some(step.finish), s))
-        }
+          }
       )
 
     schedule.initial.flatMap(loop(None, _))
@@ -854,7 +854,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
               decision =>
                 if (decision.cont) clock.sleep(decision.delay) *> loop(decision.state)
                 else orElse(err, decision.finish()).map(Left(_))
-          ),
+            ),
         succ => ZIO.succeedRight(succ)
       )
 
@@ -1759,7 +1759,7 @@ private[zio] trait ZIO_E_Throwable extends ZIOFunctions {
         try Right(effect)
         catch {
           case t: Throwable if !platform.fatal(t) => Left(t)
-      }
+        }
     ).absolve
 
   /**

--- a/core/shared/src/main/scala/scalaz/zio/ZSchedule.scala
+++ b/core/shared/src/main/scala/scalaz/zio/ZSchedule.scala
@@ -523,7 +523,7 @@ trait ZSchedule[-R, -A, +B] extends Serializable { self =>
     }
 }
 
-trait Schedule_Functions extends Serializable {
+private[zio] trait Schedule_Functions extends Serializable {
 
   type ConformsR[A]
   implicit val ConformsAnyProof: ConformsR[Any]

--- a/core/shared/src/main/scala/scalaz/zio/internal/ExecutionMetrics.scala
+++ b/core/shared/src/main/scala/scalaz/zio/internal/ExecutionMetrics.scala
@@ -16,7 +16,7 @@
 
 package scalaz.zio.internal
 
-trait ExecutionMetrics {
+private[internal] trait ExecutionMetrics {
 
   /**
    * The concurrency level of the executor.

--- a/core/shared/src/main/scala/scalaz/zio/internal/ExecutionMetrics.scala
+++ b/core/shared/src/main/scala/scalaz/zio/internal/ExecutionMetrics.scala
@@ -16,7 +16,7 @@
 
 package scalaz.zio.internal
 
-private[internal] trait ExecutionMetrics {
+trait ExecutionMetrics {
 
   /**
    * The concurrency level of the executor.

--- a/core/shared/src/main/scala/scalaz/zio/internal/MutableConcurrentQueue.scala
+++ b/core/shared/src/main/scala/scalaz/zio/internal/MutableConcurrentQueue.scala
@@ -41,7 +41,7 @@ object MutableConcurrentQueue {
  * @note this is declared as `abstract class` since `invokevirtual`
  * is slightly cheaper than `invokeinterface`.
  */
-abstract class MutableConcurrentQueue[A] {
+protected[zio] abstract class MutableConcurrentQueue[A] {
 
   /**
    * The '''maximum''' number of elements that a queue can hold.

--- a/core/shared/src/main/scala/scalaz/zio/internal/Stack.scala
+++ b/core/shared/src/main/scala/scalaz/zio/internal/Stack.scala
@@ -74,7 +74,7 @@ private[zio] final class Stack[A <: AnyRef]() {
   final def peekOrElse(a: A): A = if (size <= 0) a else peek()
 }
 
-object Stack {
+private[zio] object Stack {
   def apply[A <: AnyRef](as: A*): Stack[A] = {
     val stack = new Stack[A]
 

--- a/core/shared/src/main/scala/scalaz/zio/internal/Stack.scala
+++ b/core/shared/src/main/scala/scalaz/zio/internal/Stack.scala
@@ -19,7 +19,7 @@ package scalaz.zio.internal
 /**
  * A very fast, growable/shrinkable, mutable stack.
  */
-final class Stack[A <: AnyRef]() {
+private[zio] final class Stack[A <: AnyRef]() {
   private[this] var array   = new Array[AnyRef](13)
   private[this] var size    = 0
   private[this] var nesting = 0

--- a/core/shared/src/main/scala/scalaz/zio/internal/StackBool.scala
+++ b/core/shared/src/main/scala/scalaz/zio/internal/StackBool.scala
@@ -20,7 +20,7 @@ package scalaz.zio.internal
  * A very fast, hand-optimized stack designed just for booleans.
  * In the common case (size < 256), achieves zero allocations.
  */
-final class StackBool private () {
+private[zio] final class StackBool private () {
   import StackBool.Entry
 
   private[this] var head  = new Entry(null)
@@ -91,7 +91,7 @@ final class StackBool private () {
 
   final override def hashCode = toList.hashCode
 }
-object StackBool {
+private[zio] object StackBool {
   def apply(): StackBool = new StackBool
 
   def apply(bools: Boolean*): StackBool = {

--- a/core/shared/src/main/scala/scalaz/zio/internal/impls/LinkedQueue.scala
+++ b/core/shared/src/main/scala/scalaz/zio/internal/impls/LinkedQueue.scala
@@ -20,7 +20,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import scalaz.zio.internal.MutableConcurrentQueue
 import java.util.concurrent.atomic.AtomicLong
 
-class LinkedQueue[A] extends MutableConcurrentQueue[A] with Serializable {
+private [zio] class LinkedQueue[A] extends MutableConcurrentQueue[A] with Serializable {
   override final val capacity: Int = Int.MaxValue
 
   private[this] val jucConcurrentQueue = new ConcurrentLinkedQueue[A]()

--- a/core/shared/src/main/scala/scalaz/zio/internal/impls/LinkedQueue.scala
+++ b/core/shared/src/main/scala/scalaz/zio/internal/impls/LinkedQueue.scala
@@ -20,7 +20,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import scalaz.zio.internal.MutableConcurrentQueue
 import java.util.concurrent.atomic.AtomicLong
 
-private [zio] class LinkedQueue[A] extends MutableConcurrentQueue[A] with Serializable {
+private[zio] class LinkedQueue[A] extends MutableConcurrentQueue[A] with Serializable {
   override final val capacity: Int = Int.MaxValue
 
   private[this] val jucConcurrentQueue = new ConcurrentLinkedQueue[A]()


### PR DESCRIPTION
Hide classes and traits which either should not be exposed or present in scaladoc.

I made ADTs for ZIO package private, since the they are only used internally, and should not be pattern matched.
Also I made MutableConcurrentQueue package protected, since it is not supposed to be used outside..