### PR TITLE
Switch from tut to mdoc #687

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -272,8 +272,8 @@ lazy val microsite = project.module
     scalacOptions ~= { _ filterNot (_ startsWith "-Xlint") },
     skip in publish := true,
     libraryDependencies ++= Seq(
-      "com.github.ghik" %% "silencer-lib" % "1.3.3" % "provided",
-      "commons-io"      % "commons-io"    % "2.6"   % "provided",
+      "com.github.ghik"     %% "silencer-lib"             % "1.3.3" % "provided",
+      "commons-io"          % "commons-io"                % "2.6"   % "provided",
       "org.reactivestreams" % "reactive-streams-examples" % "1.0.2" % "provided"
     ),
     micrositeFooterText := Some(

--- a/build.sbt
+++ b/build.sbt
@@ -305,5 +305,6 @@ lazy val microsite = project.module
     ),
     micrositeShareOnSocial := false,
     micrositeCompilingDocsTool := WithMdoc,
-    mdocIn := file("microsite/src/main/tut")
+    mdocIn := file("microsite/src/main/tut"),
+    mdocExtraArguments := List("--no-link-hygiene")
   )

--- a/build.sbt
+++ b/build.sbt
@@ -272,8 +272,8 @@ lazy val microsite = project.module
     scalacOptions ~= { _ filterNot (_ startsWith "-Xlint") },
     skip in publish := true,
     libraryDependencies ++= Seq(
-      "com.github.ghik" %% "silencer-lib" % "1.3.3",
-      "commons-io"      % "commons-io"    % "2.6"
+      "com.github.ghik" %% "silencer-lib" % "1.3.3" % "provided",
+      "commons-io"      % "commons-io"    % "2.6"   % "provided"
     ),
     micrositeFooterText := Some(
       """

--- a/build.sbt
+++ b/build.sbt
@@ -300,5 +300,7 @@ lazy val microsite = project.module
       "gray-lighter"    -> "#F4F3F4",
       "white-color"     -> "#FFFFFF"
     ),
-    micrositeShareOnSocial := false
+    micrositeShareOnSocial := false,
+    micrositeCompilingDocsTool := WithMdoc,
+    mdocIn := file("microsite/src/main/tut")
   )

--- a/build.sbt
+++ b/build.sbt
@@ -266,12 +266,13 @@ lazy val microsite = project.module
   .settings(
     unusedCompileDependenciesFilter -= moduleFilter("org.scalameta", "mdoc"),
     scalacOptions -= "-Yno-imports",
+    scalacOptions -= "-Xfatal-warnings",
     scalacOptions ~= { _ filterNot (_ startsWith "-Ywarn") },
     scalacOptions ~= { _ filterNot (_ startsWith "-Xlint") },
     skip in publish := true,
     libraryDependencies ++= Seq(
-      "com.github.ghik" %% "silencer-lib" % "1.3.1" % Tut,
-      "commons-io"      % "commons-io"    % "2.6"   % Tut
+      "com.github.ghik" %% "silencer-lib" % "1.3.1",
+      "commons-io"      % "commons-io"    % "2.6"
     ),
     micrositeFooterText := Some(
       """

--- a/build.sbt
+++ b/build.sbt
@@ -273,7 +273,7 @@ lazy val microsite = project.module
     skip in publish := true,
     libraryDependencies ++= Seq(
       "com.github.ghik" %% "silencer-lib" % "1.3.3" % "provided",
-      "commons-io"      % "commons-io"    % "2.6"   % "provided"
+      "commons-io"      % "commons-io"    % "2.6"   % "provided",
       "org.reactivestreams" % "reactive-streams-examples" % "1.0.2" % "provided"
     ),
     micrositeFooterText := Some(

--- a/microsite/src/main/tut/advanced/system.md
+++ b/microsite/src/main/tut/advanced/system.md
@@ -8,7 +8,7 @@ title: "System"
 
 Sometimes, environment variables are relevant information to an application. ZIO provides a `system` package to interface with this functionality.
 
-```tut:silent
+```scala mdoc:silent
 import scalaz.zio.system
 ```
 
@@ -16,7 +16,7 @@ import scalaz.zio.system
 
 With the `env` method, you can safely read an environment variable:
 
-```tut
+```scala mdoc
 // Read an environment variable
 system.env("JAVA_HOME")
 ```
@@ -25,7 +25,7 @@ system.env("JAVA_HOME")
 
 With the `property` method, you can safely access Java properties:
 
-```tut
+```scala mdoc
 // Read a system property
 system.property("java.version")
 ```
@@ -34,6 +34,6 @@ system.property("java.version")
 
 With the `lineSeparator` method, you can determine the line separator for the underlying platform:
 
-```tut
+```scala mdoc
 system.lineSeparator
 ```

--- a/microsite/src/main/tut/datatypes/fiber.md
+++ b/microsite/src/main/tut/datatypes/fiber.md
@@ -10,11 +10,11 @@ To perform an effect without blocking the current process, you can use fibers, w
 
 You can `fork` any `IO[E, A]` to immediately yield an `UIO[Fiber[E, A]]`. The provided `Fiber` can be used to `join` the fiber, which will resume on production of the fiber's value, or to `interrupt` the fiber, which immediately terminates the fiber and safely releases all resources acquired by the fiber.
 
-```tut:silent
+```scala mdoc:silent
 import scalaz.zio._
 ```
 
-```tut:invisible
+```scala mdoc:invisible
 sealed trait Analysis
 case object Analyzed extends Analysis
 
@@ -24,7 +24,7 @@ def analyzeData[A](data: A): UIO[Analysis] = IO.succeed(Analyzed)
 def validateData[A](data: A): UIO[Boolean] = IO.succeed(true)
 ```
 
-```tut:silent
+```scala mdoc:silent
 val analyzed =
   for {
     fiber1   <- analyzeData(data).fork  // IO[E, Analysis]
@@ -39,7 +39,7 @@ val analyzed =
 
 On the JVM, fibers will use threads, but will not consume *unlimited* threads. Instead, fibers yield cooperatively during periods of high-contention.
 
-```tut:silent
+```scala mdoc:silent
 def fib(n: Int): UIO[Int] =
   if (n <= 1) {
     IO.succeedLazy(1)
@@ -81,13 +81,13 @@ There are no circumstances in which any errors will be "lost", which makes the `
 
 To execute actions in parallel, the `zipPar` method can be used:
 
-```tut:invisible
+```scala mdoc:invisible
 case class Matrix()
 def computeInverse(m: Matrix): UIO[Matrix] = IO.succeed(m)
 def applyMatrices(m1: Matrix, m2: Matrix, m3: Matrix): UIO[Matrix] = IO.succeed(m1)
 ```
 
-```tut:silent
+```scala mdoc:silent
 def bigCompute(m1: Matrix, m2: Matrix, v: Matrix): UIO[Matrix] =
   for {
     t <- computeInverse(m1).zipPar(computeInverse(m2))
@@ -102,7 +102,7 @@ The `zipPar` combinator has resource-safe semantics. If one computation fails, t
 
 Two `IO` actions can be *raced*, which means they will be executed in parallel, and the value of the first action that completes successfully will be returned.
 
-```tut:silent
+```scala mdoc:silent
 fib(100) race fib(200)
 ```
 

--- a/microsite/src/main/tut/datatypes/fiberlocal.md
+++ b/microsite/src/main/tut/datatypes/fiberlocal.md
@@ -10,7 +10,7 @@ A `FiberLocal[A]` is a container for fiber-local storage that enables you to bin
 
 `FiberLocal` is the pure equivalent of thread-local storage (e.g. Java's `ThreadLocal`) on a fiber architecture.
 
-```tut:silent
+```scala mdoc:silent
 import scalaz.zio._
 
 for {
@@ -33,7 +33,7 @@ When binding data to a fiber manually, it is important to always unbind that dat
 
 Instead of using `set` and `empty`, you should always use another method, `locally`, that automatically runs a specified `IO` with fiber-bound data, and guarantees that any bound data is unbound, avoiding possible leaks.
 
-```tut:silent
+```scala mdoc:silent
 for {
   local <- FiberLocal.make[Int]
   f     <- local.locally(10)(local.get).fork

--- a/microsite/src/main/tut/datatypes/io.md
+++ b/microsite/src/main/tut/datatypes/io.md
@@ -21,7 +21,7 @@ You can lift pure values into `IO` with `IO.succeedLazy`:
 ```scala mdoc:silent
 import scalaz.zio._
 
-val z: UIO[String] = IO.succeedLazy("Hello World")
+val lazyValue: UIO[String] = IO.succeedLazy("Hello World")
 ```
 
 The constructor uses non-strict evaluation, so the parameter will not be evaluated until when and if the `IO` action is executed at runtime, which is useful if the construction is costly and the value may never be needed.
@@ -29,7 +29,7 @@ The constructor uses non-strict evaluation, so the parameter will not be evaluat
 Alternately, you can use the `IO.succeed` constructor to perform strict evaluation of the value:
 
 ```scala mdoc:silent
-val z: UIO[String] = IO.succeed("Hello World")
+val value: UIO[String] = IO.succeed("Hello World")
 ```
 
 You should never use either constructor for importing impure code into `IO`. The result of doing so is undefined.
@@ -49,7 +49,7 @@ because the `Nothing` type is _uninhabitable_, i.e. there can be no actual value
 You can use the `effectTotal` method of `IO` to import effectful synchronous code into your purely functional program:
 
 ```scala mdoc:silent
-val z: Task[Long] = IO.effectTotal(System.nanoTime())
+val effectTotalTask: Task[Long] = IO.effectTotal(System.nanoTime())
 ```
 
 ```scala mdoc:invisible
@@ -96,13 +96,13 @@ You can change an `IO[E, A]` to an `IO[E, B]` by calling the `map` method with a
 ```scala mdoc:silent
 import scalaz.zio._
 
-val z: UIO[Int] = IO.succeedLazy(21).map(_ * 2)
+val mappedLazyValue: UIO[Int] = IO.succeedLazy(21).map(_ * 2)
 ```
 
 You can transform an `IO[E, A]` into an `IO[E2, A]` by calling the `mapError` method with a function `E => E2`:
 
 ```scala mdoc:silent
-val z: IO[Exception, String] = IO.fail("No no!").mapError(msg => new Exception(msg))
+val mappedError: IO[Exception, String] = IO.fail("No no!").mapError(msg => new Exception(msg))
 ```
 
 # Chaining
@@ -110,7 +110,7 @@ val z: IO[Exception, String] = IO.fail("No no!").mapError(msg => new Exception(m
 You can execute two actions in sequence with the `flatMap` method. The second action may depend on the value produced by the first action.
 
 ```scala mdoc:silent
-val z: UIO[List[Int]] = IO.succeedLazy(List(1, 2, 3)).flatMap { list =>
+val chainedActionsValue: UIO[List[Int]] = IO.succeedLazy(List(1, 2, 3)).flatMap { list =>
   IO.succeedLazy(list.map(_ + 1))
 }
 ```
@@ -118,7 +118,7 @@ val z: UIO[List[Int]] = IO.succeedLazy(List(1, 2, 3)).flatMap { list =>
 You can use Scala's `for` comprehension syntax to make this type of code more compact:
 
 ```scala mdoc:silent
-val z: UIO[List[Int]] = for {
+val chainedActionsValueWithForComprehension: UIO[List[Int]] = for {
   list <- IO.succeedLazy(List(1, 2, 3))
   added <- IO.succeedLazy(list.map(_ + 1))
 } yield added
@@ -148,7 +148,7 @@ def groupData(u: Unit): IO[IOException, Unit] = IO.unit
 ```
 
 ```scala mdoc:silent
-val z: IO[IOException, Unit] = openFile("data.json").bracket(closeFile(_)) { file =>
+val groupedFileData: IO[IOException, Unit] = openFile("data.json").bracket(closeFile(_)) { file =>
   for {
     data    <- decodeData(file)
     grouped <- groupData(data)

--- a/microsite/src/main/tut/datatypes/io.md
+++ b/microsite/src/main/tut/datatypes/io.md
@@ -18,7 +18,7 @@ A value of type `IO[E, A]` describes an effect that may fail with an `E`, run fo
 
 You can lift pure values into `IO` with `IO.succeedLazy`:
 
-```tut:silent
+```scala mdoc:silent
 import scalaz.zio._
 
 val z: UIO[String] = IO.succeedLazy("Hello World")
@@ -28,7 +28,7 @@ The constructor uses non-strict evaluation, so the parameter will not be evaluat
 
 Alternately, you can use the `IO.succeed` constructor to perform strict evaluation of the value:
 
-```tut:silent
+```scala mdoc:silent
 val z: UIO[String] = IO.succeed("Hello World")
 ```
 
@@ -48,11 +48,11 @@ because the `Nothing` type is _uninhabitable_, i.e. there can be no actual value
 
 You can use the `effectTotal` method of `IO` to import effectful synchronous code into your purely functional program:
 
-```tut:silent
+```scala mdoc:silent
 val z: Task[Long] = IO.effectTotal(System.nanoTime())
 ```
 
-```tut:invisible
+```scala mdoc:invisible
 import java.io.File
 import org.apache.commons.io.FileUtils
 import java.io.IOException
@@ -62,7 +62,7 @@ The resulting effect may fail for any `Throwable`.
 
 If this is too broad, the `refineOrDie` method of `ZIO` may be used to retain only certain types of exceptions, and to die on any other types of exceptions:
 
-```tut:silent
+```scala mdoc:silent
 def readFile(name: String): IO[String, Array[Byte]] =
   IO.effect(FileUtils.readFileToByteArray(new File(name))).refineOrDie {
     case e : IOException => "Could not read file"
@@ -71,7 +71,7 @@ def readFile(name: String): IO[String, Array[Byte]] =
 
 You can use the `effectAsync` method of `IO` to import effectful asynchronous code into your purely functional program:
 
-```tut:invisible
+```scala mdoc:invisible
 case class HttpException()
 case class Request()
 case class Response()
@@ -82,7 +82,7 @@ object Http {
 }
 ```
 
-```tut:silent
+```scala mdoc:silent
 def makeRequest(req: Request): IO[HttpException, Response] =
   IO.effectAsync[HttpException, Response](k => Http.req(req, k))
 ```
@@ -93,7 +93,7 @@ In this example, it's assumed the `Http.req` method will invoke the specified ca
 
 You can change an `IO[E, A]` to an `IO[E, B]` by calling the `map` method with a function `A => B`. This lets you transform values produced by actions into other values.
 
-```tut:silent
+```scala mdoc:silent
 import scalaz.zio._
 
 val z: UIO[Int] = IO.succeedLazy(21).map(_ * 2)
@@ -101,7 +101,7 @@ val z: UIO[Int] = IO.succeedLazy(21).map(_ * 2)
 
 You can transform an `IO[E, A]` into an `IO[E2, A]` by calling the `mapError` method with a function `E => E2`:
 
-```tut:silent
+```scala mdoc:silent
 val z: IO[Exception, String] = IO.fail("No no!").mapError(msg => new Exception(msg))
 ```
 
@@ -109,7 +109,7 @@ val z: IO[Exception, String] = IO.fail("No no!").mapError(msg => new Exception(m
 
 You can execute two actions in sequence with the `flatMap` method. The second action may depend on the value produced by the first action.
 
-```tut:silent
+```scala mdoc:silent
 val z: UIO[List[Int]] = IO.succeedLazy(List(1, 2, 3)).flatMap { list =>
   IO.succeedLazy(list.map(_ + 1))
 }
@@ -117,7 +117,7 @@ val z: UIO[List[Int]] = IO.succeedLazy(List(1, 2, 3)).flatMap { list =>
 
 You can use Scala's `for` comprehension syntax to make this type of code more compact:
 
-```tut:silent
+```scala mdoc:silent
 val z: UIO[List[Int]] = for {
   list <- IO.succeedLazy(List(1, 2, 3))
   added <- IO.succeedLazy(list.map(_ + 1))
@@ -134,11 +134,11 @@ Brackets consist of an *acquire* action, a *utilize* action (which uses the acqu
 
 The release action is guaranteed to be executed by the runtime system, even if the utilize action throws an exception or the executing fiber is interrupted.
 
-```tut:silent
+```scala mdoc:silent
 import scalaz.zio._
 ```
 
-```tut:invisible
+```scala mdoc:invisible
 import java.io.{ File, IOException }
 
 def openFile(s: String): IO[IOException, File] = IO.succeedLazy(???)
@@ -147,7 +147,7 @@ def decodeData(f: File): IO[IOException, Unit] = IO.unit
 def groupData(u: Unit): IO[IOException, Unit] = IO.unit
 ```
 
-```tut:silent
+```scala mdoc:silent
 val z: IO[IOException, Unit] = openFile("data.json").bracket(closeFile(_)) { file =>
   for {
     data    <- decodeData(file)
@@ -160,7 +160,7 @@ Brackets have compositional semantics, so if a bracket is nested inside another 
 
 A helper method called `ensuring` provides a simpler analogue of `finally`:
 
-```tut:silent
+```scala mdoc:silent
 var i: Int = 0
 val action: Task[String] = Task.effectTotal(i += 1) *> Task.fail(new Throwable("Boom!"))
 val cleanupAction: UIO[Unit] = UIO.effectTotal(i -= 1)

--- a/microsite/src/main/tut/datatypes/managed.md
+++ b/microsite/src/main/tut/datatypes/managed.md
@@ -16,8 +16,8 @@ Resources do not survive the scope of `use`, meaning that if you attempt to capt
 import scalaz.zio._
 def doSomething(queue: Queue[Int]): UIO[Unit] = IO.unit
 
-val resource = Managed.make(Queue.unbounded[Int])(_.shutdown)
-val res: UIO[Unit] = resource.use { queue => doSomething(queue) }
+val managedResource = Managed.make(Queue.unbounded[Int])(_.shutdown)
+val usedToDoSomething: UIO[Unit] = managedResource.use { queue => doSomething(queue) }
 ```
 
 In this example, the queue will be created when `use` is called, and `shutdown` will be called when `doSomething` completes.
@@ -31,13 +31,13 @@ It can also be created from an effect. In this case the release function will do
 import scalaz.zio._
 def acquire: IO[String, Int] = IO.succeedLazy(???)
 
-val resource: Managed[String, Int] = Managed.fromEffect(acquire)
+val managedResourceFromEffect: Managed[String, Int] = Managed.fromEffect(acquire)
 ```
 
 You can create a `Managed` from a pure value as well.
 ```scala mdoc:silent
 import scalaz.zio._
-val resource: Managed[Nothing, Int] = Managed.succeed(3)
+val managedResourceFromValue: Managed[Nothing, Int] = Managed.succeed(3)
 ```
 
 ## Managed with ZIO environment
@@ -48,8 +48,8 @@ val resource: Managed[Nothing, Int] = Managed.succeed(3)
 import scalaz.zio._
 import scalaz.zio.console._
 
-val resource: ZManaged[Console, Nothing, Unit] = ZManaged.make(console.putStrLn("acquiring"))(_ => console.putStrLn("releasing"))
-val res: ZIO[Console, Nothing, Unit] = resource.use { _ => console.putStrLn("running") }
+val zManagedResource: ZManaged[Console, Nothing, Unit] = ZManaged.make(console.putStrLn("acquiring"))(_ => console.putStrLn("releasing"))
+val usedToPutStrLn: ZIO[Console, Nothing, Unit] = zManagedResource.use { _ => console.putStrLn("running") }
 ```
 
 ## Combining Managed
@@ -77,6 +77,6 @@ val combined: Managed[IOException, (Queue[Int], File)] = for {
     file  <- managedFile
 } yield (queue, file)
 
-val res: IO[IOException, Unit] = combined.use { case (queue, file) => doSomething(queue, file) }
+val combinedManagedResource: IO[IOException, Unit] = combined.use { case (queue, file) => doSomething(queue, file) }
 
 ```

--- a/microsite/src/main/tut/datatypes/managed.md
+++ b/microsite/src/main/tut/datatypes/managed.md
@@ -12,7 +12,7 @@ A `Managed[E, A]` is a managed resource of type `A`, which may be used by invoki
 
 Resources do not survive the scope of `use`, meaning that if you attempt to capture the resource, leak it from `use`, and then use it after the resource has been consumed, the resource will not be valid anymore and may fail with some checked error, as per the type of the functions provided by the resource.
 
-```tut:silent
+```scala mdoc:silent
 import scalaz.zio._
 def doSomething(queue: Queue[Int]): UIO[Unit] = IO.unit
 
@@ -27,7 +27,7 @@ In this example, the queue will be created when `use` is called, and `shutdown` 
 As shown in the previous example, a `Managed` can be created by passing an `acquire` function and a `release` function.
 
 It can also be created from an effect. In this case the release function will do nothing.
-```tut:silent
+```scala mdoc:silent
 import scalaz.zio._
 def acquire: IO[String, Int] = IO.succeedLazy(???)
 
@@ -35,7 +35,7 @@ val resource: Managed[String, Int] = Managed.fromEffect(acquire)
 ```
 
 You can create a `Managed` from a pure value as well.
-```tut:silent
+```scala mdoc:silent
 import scalaz.zio._
 val resource: Managed[Nothing, Int] = Managed.succeed(3)
 ```
@@ -44,7 +44,7 @@ val resource: Managed[Nothing, Int] = Managed.succeed(3)
 
 `Managed[E, A]` is actually an alias for `ZManaged[Any, E, A]`. If you'd like your `acquire`, `release` or `use` functions to require an environment R, just use `ZManaged` instead of `Managed`.
 
-```tut:silent
+```scala mdoc:silent
 import scalaz.zio._
 import scalaz.zio.console._
 
@@ -56,11 +56,11 @@ val res: ZIO[Console, Nothing, Unit] = resource.use { _ => console.putStrLn("run
 
 It is possible to combine multiple `Managed` using `flatMap` to obtain a single `Managed` that will acquire and release all the resources.
 
-```tut:silent
+```scala mdoc:silent
 import scalaz.zio._
 ```
 
-```tut:invisible
+```scala mdoc:invisible
 import java.io.{ File, IOException }
 
 def openFile(s: String): IO[IOException, File] = IO.succeedLazy(???)
@@ -68,7 +68,7 @@ def closeFile(f: File): UIO[Unit] = IO.succeedLazy(???)
 def doSomething(queue: Queue[Int], file: File): UIO[Unit] = IO.succeedLazy(???)
 ```
 
-```tut:silent
+```scala mdoc:silent
 val managedQueue: Managed[Nothing, Queue[Int]] = Managed.make(Queue.unbounded[Int])(_.shutdown)
 val managedFile: Managed[IOException, File] = Managed.make(openFile("data.json"))(closeFile)
 

--- a/microsite/src/main/tut/datatypes/promise.md
+++ b/microsite/src/main/tut/datatypes/promise.md
@@ -29,15 +29,15 @@ import scalaz.zio.syntax._
 ```
 
 ```scala mdoc:silent
-val ioPromise: UIO[Promise[Exception, String]] = Promise.make[Exception, String]
-val ioBoolean: UIO[Boolean] = ioPromise.flatMap(promise => promise.succeed("I'm done"))
+val ioPromise1: UIO[Promise[Exception, String]] = Promise.make[Exception, String]
+val ioBooleanSucceeded: UIO[Boolean] = ioPromise1.flatMap(promise => promise.succeed("I'm done"))
 ```
 
 You can also signal failure using `fail(...)`. For example,
 
 ```scala mdoc:silent
-val ioPromise: UIO[Promise[Exception, Nothing]] = Promise.make[Exception, Nothing]
-val ioBoolean: UIO[Boolean] = ioPromise.flatMap(promise => promise.fail(new Exception("boom")))
+val ioPromise2: UIO[Promise[Exception, Nothing]] = Promise.make[Exception, Nothing]
+val ioBooleanFailed: UIO[Boolean] = ioPromise2.flatMap(promise => promise.fail(new Exception("boom")))
 ```
 
 To re-iterate, the `Boolean` tells us whether or not the operation took place successfully (`true`) i.e. the Promise
@@ -49,8 +49,8 @@ As an alternative to using `succeed(...)` or `fail(...)` you can also use `succe
 You can get a value from a Promise using `await`
 
 ```scala mdoc:silent
-val ioPromise: UIO[Promise[Exception, String]] = Promise.make[Exception, String]
-val ioGet: IO[Exception, String] = ioPromise.flatMap(promise => promise.await)
+val ioPromise3: UIO[Promise[Exception, String]] = Promise.make[Exception, String]
+val ioGet: IO[Exception, String] = ioPromise3.flatMap(promise => promise.await)
 ```
 
 The computation will suspend (in a non-blocking fashion) until the Promise is completed with a value or an error.
@@ -58,9 +58,9 @@ If you don't want to suspend and you only want to query the state of whether or 
 you can use `poll`:
 
 ```scala mdoc:silent
-val ioPromise: UIO[Promise[Exception, String]] = Promise.make[Exception, String]
-val ioIsItDone: UIO[Option[IO[Exception, String]]] = ioPromise.flatMap(p => p.poll)
-val ioIsItDone2: IO[Unit, IO[Exception, String]] = ioPromise.flatMap(p => p.poll.get)
+val ioPromise4: UIO[Promise[Exception, String]] = Promise.make[Exception, String]
+val ioIsItDone: UIO[Option[IO[Exception, String]]] = ioPromise4.flatMap(p => p.poll)
+val ioIsItDone2: IO[Unit, IO[Exception, String]] = ioPromise4.flatMap(p => p.poll.get)
 ```
 
 If the Promise was not completed when you called `poll` then the IO will fail with the `Unit` value otherwise,

--- a/microsite/src/main/tut/datatypes/promise.md
+++ b/microsite/src/main/tut/datatypes/promise.md
@@ -23,19 +23,19 @@ For example, `p.succeed("I'm done!")`. The act of completing a Promise results i
 the `Boolean` represents whether the promise value has been set (`true`) or whether it was already set (`false`).
 This is demonstrated below:
 
-```tut:silent
+```scala mdoc:silent
 import scalaz.zio._
 import scalaz.zio.syntax._
 ```
 
-```tut:silent
+```scala mdoc:silent
 val ioPromise: UIO[Promise[Exception, String]] = Promise.make[Exception, String]
 val ioBoolean: UIO[Boolean] = ioPromise.flatMap(promise => promise.succeed("I'm done"))
 ```
 
 You can also signal failure using `fail(...)`. For example,
 
-```tut:silent
+```scala mdoc:silent
 val ioPromise: UIO[Promise[Exception, Nothing]] = Promise.make[Exception, Nothing]
 val ioBoolean: UIO[Boolean] = ioPromise.flatMap(promise => promise.fail(new Exception("boom")))
 ```
@@ -48,7 +48,7 @@ As an alternative to using `succeed(...)` or `fail(...)` you can also use `succe
 
 You can get a value from a Promise using `await`
 
-```tut:silent
+```scala mdoc:silent
 val ioPromise: UIO[Promise[Exception, String]] = Promise.make[Exception, String]
 val ioGet: IO[Exception, String] = ioPromise.flatMap(promise => promise.await)
 ```
@@ -57,7 +57,7 @@ The computation will suspend (in a non-blocking fashion) until the Promise is co
 If you don't want to suspend and you only want to query the state of whether or not the Promise has been completed,
 you can use `poll`:
 
-```tut:silent
+```scala mdoc:silent
 val ioPromise: UIO[Promise[Exception, String]] = Promise.make[Exception, String]
 val ioIsItDone: UIO[Option[IO[Exception, String]]] = ioPromise.flatMap(p => p.poll)
 val ioIsItDone2: IO[Unit, IO[Exception, String]] = ioPromise.flatMap(p => p.poll.get)
@@ -70,7 +70,7 @@ that the Promise successfully completed with an `A` value.
 ## Example Usage
 Here is a scenario where we use a `Promise` to hand-off a value between two `Fiber`s
 
-```tut:silent
+```scala mdoc:silent
 import java.io.IOException
 import scalaz.zio.console._
 import scalaz.zio.duration._

--- a/microsite/src/main/tut/datatypes/queue.md
+++ b/microsite/src/main/tut/datatypes/queue.md
@@ -10,7 +10,7 @@ title:  "Queue"
 
 A `Queue[A]` contains values of type `A` and has two basic operations: `offer`, which places an `A` in the `Queue`, and `take` which removes and returns the oldest value in the `Queue`.
 
-```tut:silent
+```scala mdoc:silent
 import scalaz.zio._
 
 val res: UIO[Int] = for {
@@ -31,22 +31,22 @@ There are several strategies to process new values when the queue is full:
 - A `sliding` queue will drop old items when the queue is full.
 
 To create a back-pressured bounded queue:
-```tut:silent
+```scala mdoc:silent
 val queue: UIO[Queue[Int]] = Queue.bounded[Int](100)
 ```
 
 To create a dropping queue:
-```tut:silent
+```scala mdoc:silent
 val queue: UIO[Queue[Int]] = Queue.dropping[Int](100)
 ```
 
 To create a sliding queue:
-```tut:silent
+```scala mdoc:silent
 val queue: UIO[Queue[Int]] = Queue.sliding[Int](100)
 ```
 
 To create an unbounded queue:
-```tut:silent
+```scala mdoc:silent
 val queue: UIO[Queue[Int]] = Queue.unbounded[Int]
 ```
 
@@ -54,7 +54,7 @@ val queue: UIO[Queue[Int]] = Queue.unbounded[Int]
 
 The simplest way to add a value to the queue is `offer`:
 
-```tut:silent
+```scala mdoc:silent
 val res: UIO[Unit] = for {
   queue <- Queue.bounded[Int](100)
   _ <- queue.offer(1)
@@ -63,7 +63,7 @@ val res: UIO[Unit] = for {
 
 When using a back-pressured queue, offer might suspend if the queue is full: you can use `fork` to wait in a different fiber.
 
-```tut:silent
+```scala mdoc:silent
 val res: UIO[Unit] = for {
   queue <- Queue.bounded[Int](1)
   _ <- queue.offer(1)
@@ -75,7 +75,7 @@ val res: UIO[Unit] = for {
 
 It is also possible to add multiple values at once with `offerAll`:
 
-```tut:silent
+```scala mdoc:silent
 val res: UIO[Unit] = for {
   queue <- Queue.bounded[Int](100)
   items = Range.inclusive(1, 10).toList
@@ -87,7 +87,7 @@ val res: UIO[Unit] = for {
 
 The `take` operation removes the oldest item from the queue and returns it. If the queue is empty, this will suspend, and resume only when an item has been added to the queue. As with `offer`, you can use `fork` to wait for the value in a different fiber.
 
-```tut:silent
+```scala mdoc:silent
 val res: UIO[String] = for {
   queue <- Queue.bounded[String](100)
   f <- queue.take.fork // will be suspended because the queue is empty
@@ -98,7 +98,7 @@ val res: UIO[String] = for {
 
 You can consume the first item with `poll`. If the queue is empty you will get `None`, otherwise the top item will be returned wrapped in `Some`.
 
-```tut:silent
+```scala mdoc:silent
 val res: UIO[Option[Int]] = for {
   queue <- Queue.bounded[Int](100)
   _ <- queue.offer(10)
@@ -109,7 +109,7 @@ val res: UIO[Option[Int]] = for {
 
 You can consume multiple items at once with `takeUpTo`. If the queue doesn't have enough items to return, it will return all the items without waiting for more offers.
 
-```tut:silent
+```scala mdoc:silent
 val res: UIO[List[Int]] = for {
   queue <- Queue.bounded[Int](100)
   _ <- queue.offer(10)
@@ -120,7 +120,7 @@ val res: UIO[List[Int]] = for {
 
 Similarly, you can get all items at once with `takeAll`. It also returns without waiting (an empty list if the queue is empty).
 
-```tut:silent
+```scala mdoc:silent
 val res: UIO[List[Int]] = for {
   queue <- Queue.bounded[Int](100)
   _ <- queue.offer(10)
@@ -133,7 +133,7 @@ val res: UIO[List[Int]] = for {
 
 It is possible with `shutdown` to interrupt all the fibers that are suspended on `offer*` or `take*`. It will also empty the queue and make all future calls to `offer*` and `take*` terminate immediately.
 
-```tut:silent
+```scala mdoc:silent
 val res: UIO[Unit] = for {
   queue <- Queue.bounded[Int](3)
   f <- queue.take.fork
@@ -144,7 +144,7 @@ val res: UIO[Unit] = for {
 
 You can use `awaitShutdown` to execute an effect when the queue is shut down. This will wait until the queue is shut down. If the queue is already shutdown, it will resume right away.
 
-```tut:silent
+```scala mdoc:silent
 val res: UIO[Unit] = for {
   queue <- Queue.bounded[Int](3)
   p <- Promise.make[Nothing, Boolean]
@@ -174,7 +174,7 @@ With separate type parameters for input and output, there are rich composition o
 
 The output of the queue may be mapped:
 
-```tut:silent
+```scala mdoc:silent
 val res: UIO[String] = 
   for {
     queue  <- Queue.bounded[Int](3)
@@ -189,7 +189,7 @@ val res: UIO[String] =
 We may also use an effectful function to map the output. For example,
 we could annotate each element with the timestamp at which it was dequeued:
 
-```tut:silent
+```scala mdoc:silent
 import java.util.concurrent.TimeUnit
 import scalaz.zio.clock._
 
@@ -210,7 +210,7 @@ Similarly to `mapM`, we can also apply an effectful function to
 elements as they are enqueued. This queue will annotate the elements
 with their enqueue timestamp:
 
-```tut:silent
+```scala mdoc:silent
 val res: UIO[ZQueue[Clock, Nothing, Any, Nothing, String, (Long, String)]] =
   for {
     queue <- Queue.bounded[(Long, String)](3)
@@ -227,7 +227,7 @@ the type of the environment required by the queue for enqueueing.
 To complete this example, we could combine this queue with `mapM` to
 compute the time that the elements stayed in the queue:
 
-```tut:silent
+```scala mdoc:silent
 import scalaz.zio.duration._
 
 val res: UIO[ZQueue[Clock, Nothing, Clock, Nothing, String, (Duration, String)]] =
@@ -248,7 +248,7 @@ val res: UIO[ZQueue[Clock, Nothing, Clock, Nothing, String, (Duration, String)]]
 We may also compose two queues together into a single queue that
 broadcasts offers and takes from both of the queues:
 
-```tut:silent
+```scala mdoc:silent
 val res: UIO[(Int, String)] = 
   for {
     q1       <- Queue.bounded[Int](3)

--- a/microsite/src/main/tut/datatypes/ref.md
+++ b/microsite/src/main/tut/datatypes/ref.md
@@ -8,7 +8,7 @@ title:  "Ref"
 
 `Ref[A]` models a mutable reference to a value of type `A`. The two basic operations are `set`, which fills the `Ref` with a new value, and `get`, which retrieves its current content. All operations on a `Ref` are atomic and thread-safe, providing a reliable foundation for synchronizing concurrent programs.
 
-```tut:silent
+```scala mdoc:silent
 import scalaz.zio._
 
 for {
@@ -22,7 +22,7 @@ for {
 
 The simplest way to use a `Ref` is by means of `update` or its more powerful sibling `modify`. Let's write a combinator `repeat` just because we can:
 
-```tut:silent
+```scala mdoc:silent
 def repeat[E, A](n: Int)(io: IO[E, A]): IO[E, Unit] =
   Ref.make(0).flatMap { iRef =>
     def loop: IO[E, Unit] = iRef.get.flatMap { i =>
@@ -39,7 +39,7 @@ def repeat[E, A](n: Int)(io: IO[E, A]): IO[E, Unit] =
 
 Those who live on the dark side of mutation sometimes have it easy; they can add state everywhere like it's Christmas. Behold:
 
-```tut:silent
+```scala mdoc:silent
 var idCounter = 0
 def freshVar: String = {
   idCounter += 1
@@ -52,7 +52,7 @@ val v3 = freshVar
 
 As functional programmers, we know better and have captured state mutation in the form of functions of type `S => (A, S)`. `Ref` provides such an encoding, with `S` being the type of the value, and `modify` embodying the state mutation function.
 
-```tut:silent
+```scala mdoc:silent
 Ref.make(0).flatMap { idCounter =>
   def freshVar: UIO[String] =
     idCounter.modify(cpt => (s"var${cpt + 1}", cpt + 1))
@@ -73,7 +73,7 @@ Semaphores are a classic abstract data type for controlling access to shared res
 
 Well, with `Ref`s, that's easy to do! The only difficulty is in `P`, where we must fail and retry when either `v` is negative or its value has changed between the moment we read it and the moment we try to update it. A naive implementation could look like:
 
-```tut:silent
+```scala mdoc:silent
 sealed trait S {
   def P: UIO[Unit]
   def V: UIO[Unit]
@@ -101,7 +101,7 @@ object S {
 
 Let's rock these crocodile boots we found the other day at the market and test our semaphore at the night club, yiihaa:
 
-```tut:silent
+```scala mdoc:silent
 import scalaz.zio.duration.Duration
 import scalaz.zio.clock._
 import scalaz.zio.console._

--- a/microsite/src/main/tut/datatypes/schedule.md
+++ b/microsite/src/main/tut/datatypes/schedule.md
@@ -6,7 +6,7 @@ title:  "Schedule"
 
 # {{page.title}}
 
-```tut:silent
+```scala mdoc:silent
 import scalaz.zio._
 ```
 
@@ -27,43 +27,43 @@ A `Schedule[A, B]` consumes input values of type `A` (errors in the case of `ret
 
 # Base Schedules
 
-```tut:invisible
+```scala mdoc:invisible
 import scalaz.zio.duration._
 ```
 
 A schedule that always recurs:
 
-```tut:silent
+```scala mdoc:silent
 val forever = Schedule.forever
 ```
 
 A schedule that never executes:
 
-```tut:silent
+```scala mdoc:silent
 val never = Schedule.never
 ```
 
 A schedule that recurs 10 times:
 
-```tut:silent
+```scala mdoc:silent
 val upTo10 = Schedule.recurs(10)
 ```
 
 A schedule that recurs every 10 milliseconds:
 
-```tut:silent
+```scala mdoc:silent
 val spaced = Schedule.spaced(10.milliseconds)
 ```
 
 A schedule that recurs using exponential backoff:
 
-```tut:silent
+```scala mdoc:silent
 val exponential = Schedule.exponential(10.milliseconds)
 ```
 
 A schedule that recurs using fibonacci backoff:
 
-```tut:silent
+```scala mdoc:silent
 val fibonacci = Schedule.fibonacci(10.milliseconds)
 ```
 
@@ -71,31 +71,31 @@ val fibonacci = Schedule.fibonacci(10.milliseconds)
 
 Applying random jitter to a schedule:
 
-```tut:silent
+```scala mdoc:silent
 val jitteredExp = Schedule.exponential(10.milliseconds).jittered
 ```
 
 Modifies the delay of a schedule:
 
-```tut:silent
+```scala mdoc:silent
 val boosted = Schedule.spaced(1.second).delayed(_ + 100.milliseconds)
 ```
 
 Combines two schedules sequentially, by following the first policy until it ends, and then following the second policy:
 
-```tut:silent
+```scala mdoc:silent
 val sequential = Schedule.recurs(10) andThen Schedule.spaced(1.second)
 ```
 
 Combines two schedules through intersection, by recurring only if both schedules want to recur, using the maximum of the two delays between recurrences:
 
-```tut:silent
+```scala mdoc:silent
 val expUpTo10 = Schedule.exponential(1.second) && Schedule.recurs(10)
 ```
 
 Combines two schedules through union, by recurring if either schedule wants to
 recur, using the minimum of the two delays between recurrences:
 
-```tut:silent
+```scala mdoc:silent
 val expCapped = Schedule.exponential(100.milliseconds) || Schedule.spaced(1.second)
 ```

--- a/microsite/src/main/tut/getting_started.md
+++ b/microsite/src/main/tut/getting_started.md
@@ -9,16 +9,25 @@ title:  "Getting Started"
 
 Include ZIO in your project by adding the following to your `build.sbt` file:
 
-```scala mdoc:evaluated
-if (scalaz.zio.BuildInfo.isSnapshot) println(s"""resolvers += Resolver.sonatypeRepo("snapshots")""")
-println(s"""libraryDependencies += "org.scalaz" %% "scalaz-zio" % "${scalaz.zio.BuildInfo.version}"""")
+```scala mdoc:passthrough
+if (scalaz.zio.BuildInfo.isSnapshot) {
+  println(s"""```scala\nresolvers += Resolver.sonatypeRepo("snapshots")""")
+  println(s"""libraryDependencies += "org.scalaz" %% "scalaz-zio" % "${scalaz.zio.BuildInfo.version}"""")
+} else {
+  println(s"""```scala\nlibraryDependencies += "org.scalaz" %% "scalaz-zio" % "${scalaz.zio.BuildInfo.version}"""")
+}
 ```
 
 In case you want to have ZIO streams at your disposal, the following dependency has to be included:
 
-```scala mdoc:evaluated
-if (scalaz.zio.BuildInfo.isSnapshot) println(s"""resolvers += Resolver.sonatypeRepo("snapshots")""")
-println(s"""libraryDependencies += "org.scalaz" %% "scalaz-zio-streams" % "${scalaz.zio.BuildInfo.version}"""")
+
+```scala mdoc:passthrough
+if (scalaz.zio.BuildInfo.isSnapshot) {
+  println(s"""```scala\nresolvers += Resolver.sonatypeRepo("snapshots")""")
+  println(s"""libraryDependencies += "org.scalaz" %% "calaz-zio-streams" % "${scalaz.zio.BuildInfo.version}"""")
+} else {
+  println(s"""```scala\nlibraryDependencies += "org.scalaz" %% "calaz-zio-streams" % "${scalaz.zio.BuildInfo.version}"""")
+}
 ```
 
 # Main

--- a/microsite/src/main/tut/getting_started.md
+++ b/microsite/src/main/tut/getting_started.md
@@ -8,26 +8,22 @@ title:  "Getting Started"
 # Getting Started
 
 Include ZIO in your project by adding the following to your `build.sbt` file:
-
 ```scala mdoc:passthrough
-if (scalaz.zio.BuildInfo.isSnapshot) {
-  println(s"""```scala\nresolvers += Resolver.sonatypeRepo("snapshots")""")
-  println(s"""libraryDependencies += "org.scalaz" %% "scalaz-zio" % "${scalaz.zio.BuildInfo.version}"""")
-} else {
-  println(s"""```scala\nlibraryDependencies += "org.scalaz" %% "scalaz-zio" % "${scalaz.zio.BuildInfo.version}"""")
-}
+println(s"""```""")
+if (scalaz.zio.BuildInfo.isSnapshot)
+  println(s"""resolvers += Resolver.sonatypeRepo("snapshots")""")
+println(s"""libraryDependencies += "org.scalaz" %% "scalaz-zio" % "${scalaz.zio.BuildInfo.version}"""")
+println(s"""```""")
 ```
 
 In case you want to have ZIO streams at your disposal, the following dependency has to be included:
 
-
 ```scala mdoc:passthrough
-if (scalaz.zio.BuildInfo.isSnapshot) {
-  println(s"""```scala\nresolvers += Resolver.sonatypeRepo("snapshots")""")
-  println(s"""libraryDependencies += "org.scalaz" %% "calaz-zio-streams" % "${scalaz.zio.BuildInfo.version}"""")
-} else {
-  println(s"""```scala\nlibraryDependencies += "org.scalaz" %% "calaz-zio-streams" % "${scalaz.zio.BuildInfo.version}"""")
-}
+println(s"""```""")
+if (scalaz.zio.BuildInfo.isSnapshot)
+  println(s"""resolvers += Resolver.sonatypeRepo("snapshots")""")
+println(s"""libraryDependencies += "org.scalaz" %% "calaz-zio-streams" % "${scalaz.zio.BuildInfo.version}"""")
+println(s"""```""")
 ```
 
 # Main

--- a/microsite/src/main/tut/getting_started.md
+++ b/microsite/src/main/tut/getting_started.md
@@ -9,14 +9,14 @@ title:  "Getting Started"
 
 Include ZIO in your project by adding the following to your `build.sbt` file:
 
-```tut:evaluated
+```scala mdoc:evaluated
 if (scalaz.zio.BuildInfo.isSnapshot) println(s"""resolvers += Resolver.sonatypeRepo("snapshots")""")
 println(s"""libraryDependencies += "org.scalaz" %% "scalaz-zio" % "${scalaz.zio.BuildInfo.version}"""")
 ```
 
 In case you want to have ZIO streams at your disposal, the following dependency has to be included:
 
-```tut:evaluated
+```scala mdoc:evaluated
 if (scalaz.zio.BuildInfo.isSnapshot) println(s"""resolvers += Resolver.sonatypeRepo("snapshots")""")
 println(s"""libraryDependencies += "org.scalaz" %% "scalaz-zio-streams" % "${scalaz.zio.BuildInfo.version}"""")
 ```
@@ -25,7 +25,7 @@ println(s"""libraryDependencies += "org.scalaz" %% "scalaz-zio-streams" % "${sca
 
 Your application can extend `App`, which provides a complete runtime system and allows you to write your whole program using ZIO:
 
-```tut:silent
+```scala mdoc:silent
 import scalaz.zio.App
 import scalaz.zio.console._
 
@@ -45,7 +45,7 @@ object MyApp extends App {
 
 If you are integrating ZIO into an existing application, using dependency injection, or do not control your main function, then you can use a custom runtime system in order to execute your ZIO programs:
 
-```tut:silent
+```scala mdoc:silent
 import scalaz.zio._
 import scalaz.zio.console._
 
@@ -62,7 +62,7 @@ Ideally, your application should have a single runtime, because each runtime has
 
 ZIO provides a module for interacting with the console. You can import the functions in this module with the following code snippet:
 
-```tut:silent
+```scala mdoc:silent
 import scalaz.zio.console._
 ```
 
@@ -70,7 +70,7 @@ import scalaz.zio.console._
 
 If you need to print text to the console, you can use `putStr` and `putStrLn`:
 
-```tut
+```scala mdoc
 // Print without trailing line break
 putStr("Hello World")
 
@@ -82,7 +82,7 @@ putStrLn("Hello World")
 
 If you need to read input from the console, you can use `getStrLn`:
 
-```tut
+```scala mdoc
 val echo = getStrLn flatMap putStrLn
 ```
 

--- a/microsite/src/main/tut/interop/javascript.md
+++ b/microsite/src/main/tut/interop/javascript.md
@@ -8,7 +8,7 @@ title:  "Javascript"
 
 Include ZIO in your Scala.js project by adding the following to your `build.sbt`:
 
-```scala mdoc:evaluated
+```scala mdoc
 println("""scalaJSUseMainModuleInitializer := true""")
 if (scalaz.zio.BuildInfo.isSnapshot) println(s"""resolvers += Resolver.sonatypeRepo("snapshots")""")
 println(s"""libraryDependencies += "org.scalaz" %%% "scalaz-zio" % "${scalaz.zio.BuildInfo.version}"""")

--- a/microsite/src/main/tut/interop/javascript.md
+++ b/microsite/src/main/tut/interop/javascript.md
@@ -8,7 +8,7 @@ title:  "Javascript"
 
 Include ZIO in your Scala.js project by adding the following to your `build.sbt`:
 
-```tut:evaluated
+```scala mdoc:evaluated
 println("""scalaJSUseMainModuleInitializer := true""")
 if (scalaz.zio.BuildInfo.isSnapshot) println(s"""resolvers += Resolver.sonatypeRepo("snapshots")""")
 println(s"""libraryDependencies += "org.scalaz" %%% "scalaz-zio" % "${scalaz.zio.BuildInfo.version}"""")

--- a/microsite/src/main/tut/interop/reactivestreams.md
+++ b/microsite/src/main/tut/interop/reactivestreams.md
@@ -18,7 +18,7 @@ conversions available.
 
 First, let's get a few imports out of the way.
 
-```tut:silent
+```scala mdoc:silent
 import org.reactivestreams.example.unicast._
 import scalaz.zio._
 import scalaz.zio.interop.reactiveStreams._
@@ -29,7 +29,7 @@ val runtime = new DefaultRuntime {}
 
 We use the following `Publisher` and `Subscriber` for the examples: 
 
-```tut
+```scala mdoc
 val publisher = new RangePublisher(3, 10)
 val subscriber = new SyncSubscriber[Int] {
   override protected def whenNext(v: Int): Boolean = {
@@ -44,7 +44,7 @@ val subscriber = new SyncSubscriber[Int] {
 A `Publisher` used as a `Stream` buffers up to `qSize` elements. If possible, `qSize` should be
 a power of two for best performance. The default is 16.
 
-```tut
+```scala mdoc
 val streamFromPublisher = publisher.toStream(qSize = 16)
 runtime.unsafeRun(
   streamFromPublisher.run(Sink.collect[Integer])
@@ -57,7 +57,7 @@ When running a `Stream` to a `Subscriber`, a side channel is needed for signalli
 For this reason `toSink` returns a tuple of `Promise` and `Sink`. The `Promise` must be failed
 on `Stream` failure. The type parameter on `toSink` is the error type of *the Stream*. 
 
-```tut
+```scala mdoc
 val asSink = subscriber.toSink[Throwable]
 val failingStream = Stream.range(3, 13) ++ Stream.fail(new RuntimeException("boom!"))
 runtime.unsafeRun(
@@ -69,7 +69,7 @@ runtime.unsafeRun(
 
 #### Stream to Publisher
 
-```tut
+```scala mdoc
 val stream = Stream.range(3, 13)
 runtime.unsafeRun(
   stream.toPublisher.flatMap { publisher =>
@@ -85,7 +85,7 @@ runtime.unsafeRun(
 A `Sink` used as a `Subscriber` buffers up to `qSize` elements. If possible, `qSize` should be
 a power of two for best performance. The default is 16.
 
-```tut
+```scala mdoc
 val sink = Sink.collect[Integer]
 runtime.unsafeRun(
   sink.toSubscriber(qSize = 16).flatMap { case (subscriber, result) => 
@@ -93,4 +93,3 @@ runtime.unsafeRun(
   }
 )
 ```
-

--- a/microsite/src/main/tut/overview/background.md
+++ b/microsite/src/main/tut/overview/background.md
@@ -27,7 +27,7 @@ Immutable data structures that model procedural effects are called _functional e
 
 We can build a simple description of a console program that has just three instructions:
 
-```tut:silent
+```scala mdoc:silent
 sealed trait Console[+A]
 final case class Return[A](value: () => A) extends Console[A]
 final case class PrintLine[A](line: String, rest: Console[A]) extends Console[A]
@@ -40,7 +40,7 @@ The `Console` data structure is a _tree_, and at the very end of the program, yo
 
 Although very simple, this data structure is enough to build an interactive program:
 
-```tut:silent
+```scala mdoc:silent
 val example1: Console[Unit] = 
   PrintLine("Hello, what is your name?",
     ReadLine(name =>
@@ -52,7 +52,7 @@ This program is an immutable value, and doesn't do anything&mdash;it just _descr
 
 Although this program is just a model, we can translate the model into effects quite simply using an interpreter, which recurses on the data structure, translating every operation into a side-effect:
 
-```tut:silent
+```scala mdoc:silent
 def interpret[A](program: Console[A]): A = program match {
   case Return(value) => 
     value()
@@ -68,7 +68,7 @@ Interpreting (also called _running_ or _executing_) is not functional, but in an
 
 Now in practice, it's not very convenient to build console programs using constructors directly. Instead, we can define helper functions, which look more like their effectful equivalents:
 
-```tut:silent
+```scala mdoc:silent
 def succeed[A](a: => A): Console[A] = Return(() => a)
 def printLine(line: String): Console[Unit] =
   PrintLine(line, succeed(()))
@@ -83,7 +83,7 @@ Similarly, it's not easy to build `Console` values directly, but the process can
 
  These two methods are defined as follows:
 
-```tut:silent
+```scala mdoc:silent
 implicit class ConsoleSyntax[+A](self: Console[A]) {
   def map[B](f: A => B): Console[B] =
     flatMap(a => succeed(f(a)))
@@ -101,7 +101,7 @@ implicit class ConsoleSyntax[+A](self: Console[A]) {
 
 With these `map` and `flatMap` methods, we can now take advantage of Scala's `for` comprehensions, and write programs that look like their procedural equivalents:
 
-```tut:silent
+```scala mdoc:silent
 val example2: Console[String] =
   for {
     _    <- printLine("What's your name?")

--- a/microsite/src/main/tut/overview/basic_concurrency.md
+++ b/microsite/src/main/tut/overview/basic_concurrency.md
@@ -31,7 +31,7 @@ The `Fiber[E, A]` data type in ZIO has two type parameters:
 
 Fibers do not have an `R` type parameter, because they model effects that are already being executed, and which therefore have already had their required environment provided to them.
 
-```tut:invisible
+```scala mdoc:invisible
 
 import scalaz.zio._
 ```
@@ -61,7 +61,7 @@ val z: UIO[Fiber[Nothing, Long]] =
 
 One of the methods on `Fiber` is `join`, which allows another fiber to obtain the result of the fiber being joined. This is similar to awaiting the final result of the fiber, whether that is failure or success.
 
-```tut:silent
+```scala mdoc:silent
 for {
   fiber   <- IO.succeed("Hi!").fork
   message <- fiber.join
@@ -72,7 +72,7 @@ for {
 
 Another method on `Fiber` is `await`, which allows for inspecting the result of a completed `Fiber`. This provides access to full details on how the fiber completed, represented by the `Exit` data type.
 
-```tut:silent
+```scala mdoc:silent
 for {
   fiber <- IO.succeed("Hi!").fork
   exit  <- fiber.await
@@ -85,7 +85,7 @@ A fiber whose result is no longer needed may be _interrupted_, which immediately
 
 Like `await`, `Fiber#interrupt` returns an `Exit` describing how the fiber terminated.
 
-```tut:silent
+```scala mdoc:silent
 for {
   fiber <- IO.succeed("Hi!").forever.fork
   exit  <- fiber.interrupt
@@ -94,7 +94,7 @@ for {
 
 By design, `interrupt` does not resume until the fiber has terminated. If this behavior is not desired, you can `fork` the interruption itself:
 
-```tut:silent
+```scala mdoc:silent
 for {
   fiber <- IO.succeed("Hi!").forever.fork
   _     <- fiber.interrupt.fork
@@ -107,7 +107,7 @@ Fibers may be composed in several ways.
 
 One way fibers may be composed is with `Fiber#zip` or `Fiber#zipWith`. These methods combine two fibers into a single fiber that produces the results of both. If either fiber fails, then the composed fiber will fail.
 
-```tut:silent
+```scala mdoc:silent
 for {
   fiber1 <- IO.succeed("Hi!").fork
   fiber2 <- IO.succeed("Bye!").fork
@@ -118,7 +118,7 @@ for {
 
 The second way fibers can be composed is with `orElse`. If the first fiber succeeds, the composed fiber will succeed with that result; otherwise, the composed fiber will complete with the exit of the second fiber.
 
-```tut:silent
+```scala mdoc:silent
 for {
   fiber1 <- IO.fail("Uh oh!").fork
   fiber2 <- IO.succeed("Hurray!").fork
@@ -150,7 +150,7 @@ For all the parallel operations, if one effect fails, then others will be interr
 
 ZIO allows you to race multiple effects in parallel, returning the first successful result:
 
-```tut:silent
+```scala mdoc:silent
 for {
   winner <- IO.succeed("Hello") race IO.succeed("Goodbye")
 } yield winner
@@ -162,7 +162,7 @@ If you want the first success or failure, rather than the first success, then yo
 
 ZIO lets you timeout any effect using the `ZIO#timeout` method, which succeeds with an `Option`, where a value of `None` indicates the effect timed out before producing the result.
 
-```tut:silent
+```scala mdoc:silent
 import scalaz.zio.duration._
 
 IO.succeed("Hello").timeout(10.seconds)

--- a/microsite/src/main/tut/overview/basic_operations.md
+++ b/microsite/src/main/tut/overview/basic_operations.md
@@ -6,7 +6,7 @@ title:  "Basic Operations"
 
 # {{page.title}}
 
-```tut:invisible
+```scala mdoc:invisible
 import scalaz.zio._
 import scalaz.zio.console._
 ```
@@ -15,7 +15,7 @@ import scalaz.zio.console._
 
 You can map over the success channel of an effect by calling the `ZIO#map` method. This lets you transform the success values of effects into other values.
 
-```tut:silent
+```scala mdoc:silent
 import scalaz.zio._
 
 val z: UIO[Int] = IO.succeed(21).map(_ * 2)
@@ -23,7 +23,7 @@ val z: UIO[Int] = IO.succeed(21).map(_ * 2)
 
 You can map over the error channel of an effect by calling the `ZIO#mapError` method. This lets you transform the failure values of effects into other values.
 
-```tut:silent
+```scala mdoc:silent
 val z: IO[Exception, Unit] = 
   IO.fail("No no!").mapError(msg => new Exception(msg))
 ```
@@ -34,7 +34,7 @@ Note that mapping over success or error channels does not change the success or 
 
 You can execute two effects in sequence with the `flatMap` method. The second effect may depend on the success value of the first effect:
 
-```tut:silent
+```scala mdoc:silent
 val z: UIO[List[Int]] = 
   IO.succeed(List(1, 2, 3)).flatMap { list =>
     IO.succeed(list.map(_ + 1))
@@ -45,7 +45,7 @@ val z: UIO[List[Int]] =
 
 Because the `ZIO` data type supports both `flatMap` and `map`, you can use Scala's _for comprehensions_ to build sequential effects:
 
-```tut:silent
+```scala mdoc:silent
 val program = 
   for {
     _ <- putStrLn("Hello! What is your name?")

--- a/microsite/src/main/tut/overview/basic_operations.md
+++ b/microsite/src/main/tut/overview/basic_operations.md
@@ -18,13 +18,13 @@ You can map over the success channel of an effect by calling the `ZIO#map` metho
 ```scala mdoc:silent
 import scalaz.zio._
 
-val z: UIO[Int] = IO.succeed(21).map(_ * 2)
+val succeded: UIO[Int] = IO.succeed(21).map(_ * 2)
 ```
 
 You can map over the error channel of an effect by calling the `ZIO#mapError` method. This lets you transform the failure values of effects into other values.
 
 ```scala mdoc:silent
-val z: IO[Exception, Unit] = 
+val failed: IO[Exception, Unit] = 
   IO.fail("No no!").mapError(msg => new Exception(msg))
 ```
 
@@ -35,7 +35,7 @@ Note that mapping over success or error channels does not change the success or 
 You can execute two effects in sequence with the `flatMap` method. The second effect may depend on the success value of the first effect:
 
 ```scala mdoc:silent
-val z: UIO[List[Int]] = 
+val sequenced: UIO[List[Int]] = 
   IO.succeed(List(1, 2, 3)).flatMap { list =>
     IO.succeed(list.map(_ + 1))
   }

--- a/microsite/src/main/tut/overview/creating_effects.md
+++ b/microsite/src/main/tut/overview/creating_effects.md
@@ -8,7 +8,7 @@ title:  "Creating Effects"
 
 This section explores some of the common ways to create ZIO effects from values, common Scala types, and both synchronous and asynchronous side-effects.
 
-```tut:invisible
+```scala mdoc:invisible
 import scalaz.zio._
 ```
 
@@ -16,13 +16,13 @@ import scalaz.zio._
 
 Using the `ZIO.succeed` method, you can create an effect that models success:
 
-```tut:silent
+```scala mdoc:silent
 val s1 = ZIO.succeed(42)
 ```
 
 You can also create effects using methods in the companion object of the `ZIO` type aliases:
 
-```tut:silent
+```scala mdoc:silent
 val s2: Task[Int] = Task.succeed(42)
 ```
 
@@ -30,7 +30,7 @@ The `succeed` method is eager, which means the value will be constructed before 
 
 Although `succeed` is the most common way to construct a successful effect, you can achieve lazy construction using the `ZIO.succeedLazy` method:
 
-```tut:silent
+```scala mdoc:silent
 lazy val bigList = (0 to 1000000).toList
 lazy val bigString = bigList.map(_.toString).mkString("\n")
 
@@ -43,7 +43,7 @@ The successful effect constructed with `ZIO.succeedLazy` will only construct its
 
 Using the `ZIO.fail` method, you can create an effect that models failure:
 
-```tut:silent
+```scala mdoc:silent
 val f1 = ZIO.fail("Uh oh!")
 ```
 
@@ -51,7 +51,7 @@ For the `ZIO` data type, there is no restriction on the error type. You may use 
 
 Many applications will choose to model failures with classes that extend `Throwable` or `Exception`:
 
-```tut:silent
+```scala mdoc:silent
 val f2 = Task.fail(new Exception("Uh oh!"))
 ```
 
@@ -65,7 +65,7 @@ Scala's standard library contains a number of data types that can be converted i
 
 An `Option` can be converted into a ZIO effect using `ZIO.fromOption`:
 
-```tut:silent
+```scala mdoc:silent
 val zoption: ZIO[Any, Unit, Int] = ZIO.fromOption(Some(2))
 ```
 
@@ -75,7 +75,7 @@ The error type of the resulting effect is `Unit`, because the `None` case of `Op
 
 An `Either` can be converted in to a ZIO effect using `ZIO.fromEither`:
 
-```tut:silent
+```scala mdoc:silent
 val zeither = ZIO.fromEither(Right("Success!"))
 ```
 
@@ -85,7 +85,7 @@ Unlike `ZIO.fromOption`, the error type of the resulting effect will be whatever
 
 A `Try` value can be converted into a ZIO effect using `ZIO.fromTry`:
 
-```tut:silent
+```scala mdoc:silent
 import scala.util.Try
 
 val ztry = ZIO.fromTry(Try(42 / 0))
@@ -97,7 +97,7 @@ The error type of the resulting effect will always be `Throwable`, because a `Tr
 
 A function `A => B` can be converted into a ZIO effect with `ZIO.fromFunction`:
 
-```tut:silent
+```scala mdoc:silent
 val zfun: ZIO[Int, Nothing, Int] = 
   ZIO.fromFunction((i: Int) => i * i)
 ```
@@ -108,7 +108,7 @@ The environment type of the effect is `A` (the input type of the function), beca
 
 A `Future` can be converted into a ZIO effect using `ZIO.fromFuture`:
 
-```tut:silent
+```scala mdoc:silent
 import scala.concurrent.Future
 
 lazy val future = Future.successful("Hello!")
@@ -133,7 +133,7 @@ These functions can be used to wrap non-functional code, allowing you to seamles
 
 A synchronous side-effect can be converted into a ZIO effect using `ZIO.effect`:
 
-```tut:silent
+```scala mdoc:silent
 import scala.io.StdIn
 
 val getStrLn: Task[Unit] =
@@ -144,14 +144,14 @@ The error type of the resulting effect will always be `Throwable`, because side-
 
 If a given side-effect is known not to throw any exceptions, then the side-effect can be converted into a ZIO effect using `ZIO.effectTotal`:
 
-```tut:silent
+```scala mdoc:silent
 def putStrLn(line: String): UIO[Unit] =
   ZIO.effectTotal(println(line))
 ```
 
 If a side-effect is known to throw some specific subtype of `Throwable`, then the `ZIO#refineOrDie` method may be used:
 
-```tut:silent
+```scala mdoc:silent
 import java.io.IOException
 
 val getStrLn2: IO[IOException, String] =
@@ -164,12 +164,12 @@ val getStrLn2: IO[IOException, String] =
 
 An asynchronous side-effect with a callback-based API can be converted into a ZIO effect using `ZIO.effectAsync`:
 
-```tut:invisible
+```scala mdoc:invisible
 trait User
 trait AuthError
 ```
 
-```tut:silent
+```scala mdoc:silent
 object legacy {
   def login(
     onSuccess: User      => Unit, onFailure: AuthError => Unit): Unit = ???
@@ -194,7 +194,7 @@ ZIO provides the `scalaz.zio.blocking` package, which can be used to safely conv
 
 A blocking side-effect can be converted directly into an interruptible ZIO effect with the `interruptible` method:
 
-```tut:silent
+```scala mdoc:silent
 import scalaz.zio.blocking._
 
 val sleeping = 
@@ -205,7 +205,7 @@ The resulting effect will be executed on a separate thread pool designed specifi
 
 If a side-effect has already been converted into a ZIO effect, then instead of `interruptible`, the `blocking` method can be used to shift the effect onto the blocking thread pool:
 
-```tut:silent
+```scala mdoc:silent
 import scala.io.{ Codec, Source }
 
 def download(url: String) =

--- a/microsite/src/main/tut/overview/creating_effects.md
+++ b/microsite/src/main/tut/overview/creating_effects.md
@@ -195,10 +195,8 @@ ZIO provides the `scalaz.zio.blocking` package, which can be used to safely conv
 A blocking side-effect can be converted directly into an interruptible ZIO effect with the `interruptible` method:
 
 ```scala mdoc:silent
-import scalaz.zio.blocking._
-
 val sleeping = 
-  interruptible(Thread.sleep(Long.MaxValue))
+  blocking.interruptible(Thread.sleep(Long.MaxValue))
 ```
 
 The resulting effect will be executed on a separate thread pool designed specifically for blocking effects.
@@ -214,5 +212,5 @@ def download(url: String) =
   }
 
 def safeDownload(url: String) = 
-  blocking(download(url))
+  blocking.blocking(download(url))
 ``` 

--- a/microsite/src/main/tut/overview/handling_errors.md
+++ b/microsite/src/main/tut/overview/handling_errors.md
@@ -67,7 +67,7 @@ val data: IO[IOException, Array[Byte]] =
 You can try one effect, or, if it fails, try another effect, with the `orElse` combinator:
 
 ```scala mdoc:silent
-val z: IO[IOException, Array[Byte]] = 
+val primaryOrBackupData: IO[IOException, Array[Byte]] = 
   openFile("primary.data") orElse openFile("backup.data")
 ```
 
@@ -78,9 +78,9 @@ Just like Scala's `Option` and `Either` data types have `fold`, which let you de
 The first fold method, `fold`, lets you non-effectfully handle both failure and success, by supplying a non-effectful function for each case:
 
 ```scala mdoc:silent
-lazy val DefaultData: Array[Byte] = ???
+lazy val DefaultData: Array[Byte] = Array(0, 0)
 
-val z: UIO[Array[Byte]] = 
+val primaryOrDefaultData: UIO[Array[Byte]] = 
   openFile("primary.data").fold(
     _    => DefaultData,
     data => data)
@@ -89,7 +89,7 @@ val z: UIO[Array[Byte]] =
 The second fold method, `foldM`, lets you effectfully handle both failure and success, by supplying an effectful (but still pure) function for each case:
 
 ```scala mdoc:silent
-val z: IO[IOException, Array[Byte]] = 
+val primaryOrSecondaryData: IO[IOException, Array[Byte]] = 
   openFile("primary.data").foldM(
     _    => openFile("secondary.data"),
     data => ZIO.succeed(data))
@@ -107,7 +107,7 @@ def readUrls(file: String): Task[List[String]] = IO.succeed("Hello" :: Nil)
 def fetchContent(urls: List[String]): UIO[Content] = IO.succeed(OkContent("Roger"))
 ```
 ```scala mdoc:silent
-val z: UIO[Content] =
+val urls: UIO[Content] =
   readUrls("urls.json").foldM(
     err => IO.succeedLazy(NoContent(err)), 
     fetchContent
@@ -123,7 +123,7 @@ The most basic of these is `ZIO#retry`, which takes a `Schedule` and returns a n
 ```scala mdoc:silent
 import scalaz.zio.clock._
 
-val z: ZIO[Clock, IOException, Array[Byte]] = 
+val primaryData: ZIO[Clock, IOException, Array[Byte]] = 
   openFile("primary.data").retry(Schedule.recurs(5))
 ```
 

--- a/microsite/src/main/tut/overview/handling_errors.md
+++ b/microsite/src/main/tut/overview/handling_errors.md
@@ -8,7 +8,7 @@ title:  "Handling Errors"
 
 This section looks at some of the common ways to detect and respond to effects that fail.
 
-```tut:invisible
+```scala mdoc:invisible
 import scalaz.zio._
 ```
 
@@ -16,14 +16,14 @@ import scalaz.zio._
 
 You can surface failures with `ZIO#either`, which takes an `ZIO[R, E, A]` and produces an `ZIO[R, Nothing, Either[E, A]]`.
 
-```tut:silent
+```scala mdoc:silent
 val zeither: UIO[Either[String, Int]] = 
   IO.fail("Uh oh!").either
 ```
 
 You can submerge failures with `ZIO.absolve`, which is the opposite of `either` and turns an `ZIO[R, Nothing, Either[E, A]]` into an `ZIO[R, E, A]`:
 
-```tut:silent
+```scala mdoc:silent
 def sqrt(io: UIO[Double]): IO[String, Double] =
   ZIO.absolve(
     io.map(value =>
@@ -37,14 +37,14 @@ def sqrt(io: UIO[Double]): IO[String, Double] =
 
 If you want to catch and recover from all types of errors and effectfully attempt recovery, you can use the `catchAll` method:
 
-```tut:invisible
+```scala mdoc:invisible
 import java.io.{ FileNotFoundException, IOException }
 
 def openFile(s: String): IO[IOException, Array[Byte]] =   
   IO.succeedLazy(???)
 ```
 
-```tut:silent
+```scala mdoc:silent
 val z: IO[IOException, Array[Byte]] = 
   openFile("primary.json").catchAll(_ => 
     openFile("backup.json"))
@@ -54,7 +54,7 @@ val z: IO[IOException, Array[Byte]] =
 
 If you want to catch and recover from only some types of exceptions and effectfully attempt recovery, you can use the `catchSome` method:
 
-```tut:silent
+```scala mdoc:silent
 val data: IO[IOException, Array[Byte]] = 
   openFile("primary.data").catchSome {
     case _ : FileNotFoundException => 
@@ -66,7 +66,7 @@ val data: IO[IOException, Array[Byte]] =
 
 You can try one effect, or, if it fails, try another effect, with the `orElse` combinator:
 
-```tut:silent
+```scala mdoc:silent
 val z: IO[IOException, Array[Byte]] = 
   openFile("primary.data") orElse openFile("backup.data")
 ```
@@ -77,7 +77,7 @@ Just like Scala's `Option` and `Either` data types have `fold`, which let you de
 
 The first fold method, `fold`, lets you non-effectfully handle both failure and success, by supplying a non-effectful function for each case:
 
-```tut:silent
+```scala mdoc:silent
 lazy val DefaultData: Array[Byte] = ???
 
 val z: UIO[Array[Byte]] = 
@@ -88,7 +88,7 @@ val z: UIO[Array[Byte]] =
 
 The second fold method, `foldM`, lets you effectfully handle both failure and success, by supplying an effectful (but still pure) function for each case:
 
-```tut:silent
+```scala mdoc:silent
 val z: IO[IOException, Array[Byte]] = 
   openFile("primary.data").foldM(
     _    => openFile("secondary.data"),
@@ -99,14 +99,14 @@ Nearly all error handling methods are defined in terms of `foldM`, because it is
 
 In the following example, `foldM` is used to handle both failure and success of the `readUrls` method:
 
-```tut:invisible
+```scala mdoc:invisible
 sealed trait Content
 case class NoContent(t: Throwable) extends Content
 case class OkContent(s: String) extends Content
 def readUrls(file: String): Task[List[String]] = IO.succeed("Hello" :: Nil)
 def fetchContent(urls: List[String]): UIO[Content] = IO.succeed(OkContent("Roger"))
 ```
-```tut:silent
+```scala mdoc:silent
 val z: UIO[Content] =
   readUrls("urls.json").foldM(
     err => IO.succeedLazy(NoContent(err)), 
@@ -120,7 +120,7 @@ There are a number of useful methods on the ZIO data type for retrying failed ef
 
 The most basic of these is `ZIO#retry`, which takes a `Schedule` and returns a new effect that will retry the first one if it fails, according to the specified policy:
 
-```tut:silent
+```scala mdoc:silent
 import scalaz.zio.clock._
 
 val z: ZIO[Clock, IOException, Array[Byte]] = 

--- a/microsite/src/main/tut/overview/handling_resources.md
+++ b/microsite/src/main/tut/overview/handling_resources.md
@@ -10,7 +10,7 @@ This section looks at some of the common ways to safely handle resources using Z
 
 ZIO's resource management features work across synchronous, asynchronous, concurrent, and other effect types, and provide strong guarantees even in the presence of unexpected errors or defects in the application.
 
-```tut:invisible
+```scala mdoc:invisible
 import scalaz.zio._
 ```
 
@@ -20,7 +20,7 @@ ZIO provides similar functionality to `try` / `finally` with the `ZIO#ensuring` 
 
 Like `try` / `finally`, the `ensuring` operation guarantees that if an effect begins executing, then the finalizer will begin executing, even if the first effect fails.
 
-```tut
+```scala mdoc
 val finalizer = 
   UIO.effectTotal(println("Finalizing!"))
 
@@ -50,7 +50,7 @@ ZIO provides encapsulates this common pattern with `ZIO#bracket`, which allows y
 
 The release effect is guaranteed to be executed by the runtime system, even in the presence of errors or interruption.
 
-```tut:invisible
+```scala mdoc:invisible
 import scalaz.zio._
 import java.io.{ File, IOException }
 
@@ -60,7 +60,7 @@ def decodeData(f: File): IO[IOException, Unit] = IO.unit
 def groupData(u: Unit): IO[IOException, Unit] = IO.unit
 ```
 
-```tut:silent
+```scala mdoc:silent
 val z: IO[IOException, Unit] = openFile("data.json").bracket(closeFile(_)) { file =>
   for {
     data    <- decodeData(file)

--- a/microsite/src/main/tut/overview/handling_resources.md
+++ b/microsite/src/main/tut/overview/handling_resources.md
@@ -24,7 +24,7 @@ Like `try` / `finally`, the `ensuring` operation guarantees that if an effect be
 val finalizer = 
   UIO.effectTotal(println("Finalizing!"))
 
-val z: IO[String, Unit] = 
+val finalized: IO[String, Unit] = 
   IO.fail("Failed!").ensuring(finalizer)
 ```
 
@@ -61,7 +61,7 @@ def groupData(u: Unit): IO[IOException, Unit] = IO.unit
 ```
 
 ```scala mdoc:silent
-val z: IO[IOException, Unit] = openFile("data.json").bracket(closeFile(_)) { file =>
+val groupedFileData: IO[IOException, Unit] = openFile("data.json").bracket(closeFile(_)) { file =>
   for {
     data    <- decodeData(file)
     grouped <- groupData(data)

--- a/microsite/src/main/tut/overview/running_effects.md
+++ b/microsite/src/main/tut/overview/running_effects.md
@@ -14,7 +14,7 @@ If you construct a single effect for your whole program, then the most natural w
 
 This class provides Scala with a main function, so it can be called from IDEs and launched from the command-line. All you have to do is implement the `run` method, which will be passed command-line arguments in a `List`:
 
-```tut:silent
+```scala mdoc:silent
 import scalaz.zio._
 import scalaz.zio.console._
 
@@ -44,13 +44,13 @@ ZIO contains a default runtime called `DefaultRuntime`. This bundles together al
 
 To create a `DefaultRuntime`, merely use the `new` keyword:
 
-```tut:silent
+```scala mdoc:silent
 val runtime = new DefaultRuntime {}
 ```
 
 Once you have a runtime, you can use it to execute effects:
 
-```tut:silent
+```scala mdoc:silent
 runtime.unsafeRun(putStrLn("Hello World!"))
 ```
 
@@ -65,7 +65,7 @@ A custom `Runtime[R]` can be created with two values:
 
 For example, the following creates a `Runtime` that can provide an `Int` to effects, using the default `Platform` provided by ZIO:
 
-```tut:silent
+```scala mdoc:silent
 import scalaz.zio.internal.PlatformLive
 
 val myRuntime: Runtime[Int] = Runtime(42, PlatformLive.Default)

--- a/microsite/src/main/tut/overview/testing_effects.md
+++ b/microsite/src/main/tut/overview/testing_effects.md
@@ -138,9 +138,9 @@ To actually run such an effect, we need to implement the database module.
 
 Now we can implement a live database module, which will actually interact with our production database:
 
-```scala
+```scala mdoc:silent
 trait DatabaseLive extends Database {
-  lazy val database: Database.Service = ???
+  def database: Database.Service = ???
 }
 object DatabaseLive extends DatabaseLive
 ```
@@ -151,10 +151,10 @@ object DatabaseLive extends DatabaseLive
 
 We can now provide the live database module to our application, using `ZIO.provide`:
 
-```scala
-lazy val main: ZIO[Database, Throwable, Unit] = ???
+```scala mdoc:silent
+def main: ZIO[Database, Throwable, Unit] = ???
 
-lazy val main2: ZIO[Any, Throwable, Unit] = 
+def main2: ZIO[Any, Throwable, Unit] = 
   main.provide(DatabaseLive)
 ```
 
@@ -192,10 +192,10 @@ object TestDatabase extends TestDatabase
 
 To test code that requires the database, we need only provide it with our test database service.
 
-```scala
-lazy val code: ZIO[Database, Throwable, Unit] = ???
+```scala mdoc:silent
+def code: ZIO[Database, Throwable, Unit] = ???
 
-lazy val code2: ZIO[Any, Throwable, Unit] = 
+def code2: ZIO[Any, Throwable, Unit] = 
   code.provide(TestDatabase)
 ```
 

--- a/microsite/src/main/tut/overview/testing_effects.md
+++ b/microsite/src/main/tut/overview/testing_effects.md
@@ -110,7 +110,7 @@ In this example, the type `Database` is the _module_, which contains the `Databa
 In order to make it easier to access the database service as an environmental effect, we will define helper functions that use `ZIO.accessM`.
 
 ```scala mdoc:silent
-object database {
+object db {
   def lookup(id: UserID): ZIO[Database, Throwable, UserProfile] =
     ZIO.accessM(_.database.lookup(id))
 
@@ -126,7 +126,7 @@ We're now ready to build an example that uses the database service:
 ```scala mdoc:silent
 val lookedupProfile: ZIO[Database, Throwable, UserProfile] = 
   for {
-    profile <- database.lookup(userId)
+    profile <- db.lookup(userId)
   } yield profile
 ```
 


### PR DESCRIPTION
Replaces `tut` with `mdoc` for the `microsite`.
