### PR TITLE
Preliminary STM benchmarks and low-hanging fruit optimizations

### DIFF
--- a/benchmarks/src/main/scala/scalaz/zio/IOBenchmarks.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/IOBenchmarks.scala
@@ -8,8 +8,8 @@ object IOBenchmarks extends DefaultRuntime {
     Scheduler.computation().withExecutionModel(SynchronousExecution)
   }
 
-  def repeat[R, E, A](n: Int)(zio: ZIO[R, E, A]): ZIO[R, E, A] = 
-    if (n <= 1) zio 
+  def repeat[R, E, A](n: Int)(zio: ZIO[R, E, A]): ZIO[R, E, A] =
+    if (n <= 1) zio
     else zio *> repeat(n - 1)(zio)
 
   class Thunk[A](val unsafeRun: () => A) {

--- a/benchmarks/src/main/scala/scalaz/zio/IOBenchmarks.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/IOBenchmarks.scala
@@ -8,6 +8,10 @@ object IOBenchmarks extends DefaultRuntime {
     Scheduler.computation().withExecutionModel(SynchronousExecution)
   }
 
+  def repeat[R, E, A](n: Int)(zio: ZIO[R, E, A]): ZIO[R, E, A] = 
+    if (n <= 1) zio 
+    else zio *> repeat(n - 1)(zio)
+
   class Thunk[A](val unsafeRun: () => A) {
     def map[B](ab: A => B): Thunk[B] =
       new Thunk(() => ab(unsafeRun()))

--- a/benchmarks/src/main/scala/scalaz/zio/IOBenchmarks.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/IOBenchmarks.scala
@@ -4,8 +4,11 @@ import cats._
 import cats.effect.{ Fiber => CFiber }
 import scala.concurrent.ExecutionContext
 import cats.effect.{ ContextShift, IO => CIO }
+import scalaz.zio.internal._
 
 object IOBenchmarks extends DefaultRuntime {
+  override val Platform: Platform = PlatformLive.makeDefault(Int.MaxValue)
+
   import monix.execution.Scheduler
   implicit val contextShift: ContextShift[CIO] = CIO.contextShift(ExecutionContext.global)
 

--- a/benchmarks/src/main/scala/scalaz/zio/IOBenchmarks.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/IOBenchmarks.scala
@@ -1,7 +1,13 @@
 package scalaz.zio
 
+import cats._
+import cats.effect.{ Fiber => CFiber }
+import scala.concurrent.ExecutionContext
+import cats.effect.{ ContextShift, IO => CIO }
+
 object IOBenchmarks extends DefaultRuntime {
   import monix.execution.Scheduler
+  implicit val contextShift: ContextShift[CIO] = CIO.contextShift(ExecutionContext.global)
 
   implicit val monixScheduler: Scheduler = {
     import monix.execution.ExecutionModel.SynchronousExecution
@@ -11,6 +17,18 @@ object IOBenchmarks extends DefaultRuntime {
   def repeat[R, E, A](n: Int)(zio: ZIO[R, E, A]): ZIO[R, E, A] =
     if (n <= 1) zio
     else zio *> repeat(n - 1)(zio)
+
+  def catsForkAll[A](as: Iterable[CIO[A]]): CIO[CFiber[CIO, List[A]]] = {
+    type Fiber[A] = CFiber[CIO, A]
+
+    as.foldRight[CIO[CFiber[CIO, List[A]]]](CIO(Applicative[Fiber].pure(Nil))) { (io, listFiber) =>
+      Applicative[CIO].map2(listFiber, io.start)((f1, f2) => Applicative[Fiber].map2(f1, f2)((as, a) => a :: as))
+    }
+  }
+
+  def catsRepeat[A](n: Int)(io: CIO[A]): CIO[A] =
+    if (n <= 1) io
+    else io.flatMap(_ => catsRepeat(n - 1)(io))
 
   class Thunk[A](val unsafeRun: () => A) {
     def map[B](ab: A => B): Thunk[B] =

--- a/benchmarks/src/main/scala/scalaz/zio/IODeepFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/IODeepFlatMapBenchmark.scala
@@ -117,10 +117,10 @@ class IODeepFlatMapBenchmark {
   @Benchmark
   def scalazDeepFlatMap(): BigInt = {
     def fib(n: Int): UIO[BigInt] =
-      if (n <= 1) IO.succeedLazy[BigInt](n)
+      if (n <= 1) ZIO.succeedLazy[BigInt](n)
       else
         fib(n - 1).flatMap { a =>
-          fib(n - 2).flatMap(b => IO.succeedLazy(a + b))
+          fib(n - 2).flatMap(b => ZIO.succeedLazy(a + b))
         }
 
     unsafeRun(fib(depth))

--- a/benchmarks/src/main/scala/scalaz/zio/QueueParallelBenchmark.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/QueueParallelBenchmark.scala
@@ -3,7 +3,6 @@ package scalaz.zio
 import java.util.concurrent.TimeUnit
 import scala.concurrent.ExecutionContext
 import cats.effect.{ ContextShift, IO => CIO }
-import cats.implicits._
 import org.openjdk.jmh.annotations._
 import scalaz.zio.IOBenchmarks._
 import scalaz.zio.stm._
@@ -38,13 +37,9 @@ class QueueParallelBenchmark {
   @Benchmark
   def zioQueue(): Int = {
 
-    def repeat(task: UIO[Unit], max: Int): UIO[Unit] =
-      if (max < 1) IO.unit
-      else task.flatMap(_ => repeat(task, max - 1))
-
     val io = for {
-      offers <- IO.forkAll(List.fill(parallelism)(repeat(zioQ.offer(0).map(_ => ()), totalSize / parallelism))).fork
-      takes  <- IO.forkAll(List.fill(parallelism)(repeat(zioQ.take.map(_ => ()), totalSize / parallelism))).fork
+      offers <- IO.forkAll(List.fill(parallelism)(repeat(totalSize / parallelism)(zioQ.offer(0).unit)))
+      takes  <- IO.forkAll(List.fill(parallelism)(repeat(totalSize / parallelism)(zioQ.take.unit)))
       _      <- offers.join
       _      <- takes.join
     } yield 0
@@ -55,13 +50,9 @@ class QueueParallelBenchmark {
   @Benchmark
   def zioTQueue(): Int = {
 
-    def repeat(task: UIO[Unit], max: Int): UIO[Unit] =
-      if (max < 1) IO.unit
-      else task.flatMap(_ => repeat(task, max - 1))
-
     val io = for {
-      offers <- IO.forkAll(List.fill(parallelism)(repeat(zioTQ.offer(0).unit.commit, totalSize / parallelism))).fork
-      takes  <- IO.forkAll(List.fill(parallelism)(repeat(zioTQ.take.unit.commit, totalSize / parallelism))).fork
+      offers <- IO.forkAll(List.fill(parallelism)(repeat(totalSize / parallelism)(zioTQ.offer(0).unit.commit)))
+      takes  <- IO.forkAll(List.fill(parallelism)(repeat(totalSize / parallelism)(zioTQ.take.unit.commit)))
       _      <- offers.join
       _      <- takes.join
     } yield 0
@@ -72,13 +63,9 @@ class QueueParallelBenchmark {
   @Benchmark
   def fs2Queue(): Int = {
 
-    def repeat(task: CIO[Unit], max: Int): CIO[Unit] =
-      if (max < 1) CIO.unit
-      else task >> repeat(task, max - 1)
-
     val io = for {
-      offers <- List.fill(parallelism)(repeat(fs2Q.enqueue1(0), totalSize / parallelism)).sequence.start
-      takes  <- List.fill(parallelism)(repeat(fs2Q.dequeue1.map(_ => ()), totalSize / parallelism)).sequence.start
+      offers <- catsForkAll(List.fill(parallelism)(catsRepeat(totalSize / parallelism)(fs2Q.enqueue1(0))))
+      takes  <- catsForkAll(List.fill(parallelism)(catsRepeat(totalSize / parallelism)(fs2Q.dequeue1.map(_ => ()))))
       _      <- offers.join
       _      <- takes.join
     } yield 0

--- a/benchmarks/src/main/scala/scalaz/zio/stm/SemaphoreBenchmark.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/stm/SemaphoreBenchmark.scala
@@ -1,0 +1,36 @@
+package scalaz.zio.stm
+
+import scalaz.zio._
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import IOBenchmarks._
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class SemaphoreBenchmark {
+  @Param(Array("10"))
+  var fibers: Int = _
+
+  @Param(Array("1000"))
+  var ops: Int = _
+
+  @Benchmark
+  def semaphoreContention() = 
+    unsafeRun(for {
+      sem <- Semaphore.make(fibers / 2L)
+      fiber <- ZIO.forkAll(List.fill(fibers)(repeat(ops)(sem.withPermit(ZIO.succeed(1)))))
+      _     <- fiber.join
+    } yield ())
+
+  @Benchmark
+  def tsemaphoreContention() = 
+    unsafeRun(for {
+      sem <- TSemaphore.make(fibers / 2L).commit
+      fiber <- ZIO.forkAll(List.fill(fibers)(repeat(ops)(sem.withPermit(STM.succeed(1)).commit)))
+      _     <- fiber.join
+    } yield ())
+}

--- a/benchmarks/src/main/scala/scalaz/zio/stm/SemaphoreBenchmark.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/stm/SemaphoreBenchmark.scala
@@ -19,17 +19,17 @@ class SemaphoreBenchmark {
   var ops: Int = _
 
   @Benchmark
-  def semaphoreContention() = 
+  def semaphoreContention() =
     unsafeRun(for {
-      sem <- Semaphore.make(fibers / 2L)
+      sem   <- Semaphore.make(fibers / 2L)
       fiber <- ZIO.forkAll(List.fill(fibers)(repeat(ops)(sem.withPermit(ZIO.succeed(1)))))
       _     <- fiber.join
     } yield ())
 
   @Benchmark
-  def tsemaphoreContention() = 
+  def tsemaphoreContention() =
     unsafeRun(for {
-      sem <- TSemaphore.make(fibers / 2L).commit
+      sem   <- TSemaphore.make(fibers / 2L).commit
       fiber <- ZIO.forkAll(List.fill(fibers)(repeat(ops)(sem.withPermit(STM.succeed(1)).commit)))
       _     <- fiber.join
     } yield ())

--- a/benchmarks/src/main/scala/scalaz/zio/stm/SemaphoreBenchmark.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/stm/SemaphoreBenchmark.scala
@@ -3,7 +3,8 @@ package scalaz.zio.stm
 import scalaz.zio._
 
 import java.util.concurrent.TimeUnit
-
+import scala.concurrent.ExecutionContext
+import cats.effect.{ ContextShift, IO => CIO }
 import org.openjdk.jmh.annotations._
 
 import IOBenchmarks._
@@ -33,4 +34,17 @@ class SemaphoreBenchmark {
       fiber <- ZIO.forkAll(List.fill(fibers)(repeat(ops)(sem.withPermit(STM.succeed(1)).commit)))
       _     <- fiber.join
     } yield ())
+
+  @Benchmark
+  def semaphoreCatsContention() = {
+    import cats.effect.concurrent.Semaphore
+    import cats.effect.Concurrent
+    implicit val contextShift: ContextShift[CIO] = CIO.contextShift(ExecutionContext.global)
+
+    (for {
+      sem   <- Semaphore(fibers / 2L)(Concurrent[CIO])
+      fiber <- catsForkAll(List.fill(fibers)(catsRepeat(ops)(sem.withPermit(CIO(1)))))
+      _     <- fiber.join
+    } yield ()).unsafeRunSync()
+  }
 }

--- a/benchmarks/src/main/scala/scalaz/zio/stm/SingleRefBenchmark.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/stm/SingleRefBenchmark.scala
@@ -19,17 +19,17 @@ class SingleRefBenchmark {
   var ops: Int = _
 
   @Benchmark
-  def refContention() = 
+  def refContention() =
     unsafeRun(for {
-      ref <- Ref.make(0)
+      ref   <- Ref.make(0)
       fiber <- ZIO.forkAll(List.fill(fibers)(repeat(ops)(ref.update(_ + 1))))
       _     <- fiber.join
     } yield ())
 
   @Benchmark
-  def trefContention() = 
+  def trefContention() =
     unsafeRun(for {
-      tref <- TRef.make(0).commit
+      tref  <- TRef.make(0).commit
       fiber <- ZIO.forkAll(List.fill(fibers)(repeat(ops)(tref.update(_ + 1).commit)))
       _     <- fiber.join
     } yield ())

--- a/benchmarks/src/main/scala/scalaz/zio/stm/SingleRefBenchmark.scala
+++ b/benchmarks/src/main/scala/scalaz/zio/stm/SingleRefBenchmark.scala
@@ -1,0 +1,36 @@
+package scalaz.zio.stm
+
+import scalaz.zio._
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import IOBenchmarks._
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class SingleRefBenchmark {
+  @Param(Array("10"))
+  var fibers: Int = _
+
+  @Param(Array("1000"))
+  var ops: Int = _
+
+  @Benchmark
+  def refContention() = 
+    unsafeRun(for {
+      ref <- Ref.make(0)
+      fiber <- ZIO.forkAll(List.fill(fibers)(repeat(ops)(ref.update(_ + 1))))
+      _     <- fiber.join
+    } yield ())
+
+  @Benchmark
+  def trefContention() = 
+    unsafeRun(for {
+      tref <- TRef.make(0).commit
+      fiber <- ZIO.forkAll(List.fill(fibers)(repeat(ops)(tref.update(_ + 1).commit)))
+      _     <- fiber.join
+    } yield ())
+}

--- a/core/js/src/main/scala/scalaz/zio/internal/PlatformLive.scala
+++ b/core/js/src/main/scala/scalaz/zio/internal/PlatformLive.scala
@@ -41,6 +41,6 @@ object PlatformLive {
         new HashMap[A, B]()
     }
 
-  final def fromExecutionContext(ec: ExecutionContext): Platform =
-    fromExecutor(Executor.fromExecutionContext(1024)(ec))
+  final def fromExecutionContext(ec: ExecutionContext, yieldOpCount: Int = 2048): Platform =
+    fromExecutor(Executor.fromExecutionContext(yieldOpCount)(ec))
 }

--- a/core/jvm/src/main/scala/scalaz/zio/internal/PlatformLive.scala
+++ b/core/jvm/src/main/scala/scalaz/zio/internal/PlatformLive.scala
@@ -26,7 +26,7 @@ object PlatformLive {
   lazy val Default = makeDefault()
   lazy val Global  = fromExecutionContext(ExecutionContext.global)
 
-  final def makeDefault(): Platform = fromExecutor(ExecutorUtil.makeDefault())
+  final def makeDefault(yieldOpCount: Int = 2048): Platform = fromExecutor(ExecutorUtil.makeDefault(yieldOpCount))
 
   final def fromExecutor(executor0: Executor) =
     new Platform {
@@ -36,7 +36,7 @@ object PlatformLive {
         t.isInstanceOf[VirtualMachineError]
 
       def reportFailure(cause: Cause[_]): Unit =
-        if (!cause.interrupted) println(cause.toString)
+        if (!cause.interrupted) System.err.println(cause.toString)
 
       def newWeakHashMap[A, B](): JMap[A, B] =
         new WeakHashMap[A, B]()
@@ -46,8 +46,8 @@ object PlatformLive {
     fromExecutor(Executor.fromExecutionContext(1024)(ec))
 
   object ExecutorUtil {
-    final def makeDefault(): Executor =
-      fromThreadPoolExecutor(_ => 1024) {
+    final def makeDefault(yieldOpCount: Int): Executor =
+      fromThreadPoolExecutor(_ => yieldOpCount) {
         val corePoolSize  = Runtime.getRuntime.availableProcessors() * 2
         val maxPoolSize   = corePoolSize
         val keepAliveTime = 1000L

--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -482,7 +482,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
       p1 <- Promise.make[Nothing, Unit]
       p2 <- Promise.make[Nothing, Int]
       s <- (p1.succeed(()) *> p2.await)
-            .ensuringR(r.set(true) *> clock.sleep(10.millis))
+            .ensuring(r.set(true) *> clock.sleep(10.millis))
             .fork
       _    <- p1.await
       _    <- s.interrupt

--- a/core/shared/src/main/scala/scalaz/zio/Runtime.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Runtime.scala
@@ -65,9 +65,9 @@ trait Runtime[+R] {
    * This method is effectful and should only be invoked at the edges of your program.
    */
   final def unsafeRunAsync[E, A](zio: ZIO[R, E, A])(k: Exit[E, A] => Unit): Unit = {
-    val context = new FiberContext[E, A](Platform)
+    val context = new FiberContext[E, A](Platform, Environment.asInstanceOf[AnyRef])
 
-    context.evaluateNow(zio.provide(Environment))
+    context.evaluateNow(zio.asInstanceOf[IO[E, A]])
     context.runAsync(k)
   }
 

--- a/core/shared/src/main/scala/scalaz/zio/ZIO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/ZIO.scala
@@ -1627,7 +1627,7 @@ trait ZIOFunctions extends Serializable {
   /**
    * Strictly-evaluated unit lifted into the `ZIO` monad.
    */
-  final def unit[R >: LowerR]: ZIO[R, Nothing, Unit] = succeed(())
+  final val unit: ZIO[Any, Nothing, Unit] = succeed(())
 
   /**
    * The moral equivalent of `if (p) exp`

--- a/core/shared/src/main/scala/scalaz/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/scalaz/zio/internal/FiberContext.scala
@@ -296,10 +296,10 @@ private[zio] final class FiberContext[E, A](
                 case ZIO.Tags.Provide =>
                   val io = curIo.asInstanceOf[ZIO.Provide[Any, E, Any]]
 
-                  environment.push(io.r.asInstanceOf[AnyRef])
+                  val push = ZIO.effectTotal(environment.push(io.r.asInstanceOf[AnyRef]))
+                  val pop  = ZIO.effectTotal(environment.pop())
 
-                  // TODO: Could be interrupted after push but before pop
-                  curIo = io.next.ensuring(ZIO.effectTotal { environment.pop() })
+                  curIo = push.bracket_(pop, io.next)
               }
             }
           } else {

--- a/core/shared/src/main/scala/scalaz/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/scalaz/zio/internal/FiberContext.scala
@@ -140,7 +140,7 @@ private[zio] final class FiberContext[E, A](
 
                   // A mini interpreter for the left side of FlatMap that evaluates
                   // anything that is 1-hop away. This eliminates heap usage for the
-                  // happy path. TODO: Expand.
+                  // happy path.
                   (nested.tag: @switch) match {
                     case ZIO.Tags.Succeed =>
                       val io2 = nested.asInstanceOf[ZIO.Succeed[Any]]

--- a/core/shared/src/main/scala/scalaz/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stm/STM.scala
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.{ AtomicBoolean, AtomicLong, AtomicReference 
 
 import scalaz.zio.{ IO, UIO }
 
-import scala.collection.mutable.{ Map => MutableMap }
+import java.util.{ HashMap => MutableMap }
 import scala.util.{ Failure, Success, Try }
 
 /**
@@ -87,11 +87,16 @@ final class STM[+E, +A] private[stm] (
     new STM(
       journal =>
         (self exec journal) match {
-          case TRez.Fail(e)    => TRez.Fail(e)
-          case TRez.Succeed(a) => if (pf isDefinedAt a) TRez.Succeed(pf(a)) else TRez.Retry
-          case TRez.Retry      => TRez.Retry
+          case t @ TRez.Fail(_) => t
+          case TRez.Succeed(a)  => if (pf isDefinedAt a) TRez.Succeed(pf(a)) else TRez.Retry
+          case TRez.Retry       => TRez.Retry
         }
     )
+
+  /**
+   * Commits this transaction atomically.
+   */
+  final def commit: IO[E, A] = STM.atomically(self)
 
   /**
    * Maps the success value of this effect to the specified constant value.
@@ -221,20 +226,15 @@ final class STM[+E, +A] private[stm] (
     (self map (Left[A, B](_))) orElse (that map (Right[A, B](_)))
 
   /**
-   * Commits this transaction atomically.
+   * Maps the success value of this effect to unit.
    */
-  final def commit: IO[E, A] = STM.atomically(self)
+  final def unit: STM[E, Unit] = const(())
 
   /**
    * Maps the success value of this effect to unit.
    */
   @deprecated("use unit", "1.0.0")
   final def void: STM[E, Unit] = unit
-
-  /**
-   * Maps the success value of this effect to unit.
-   */
-  final def unit: STM[E, Unit] = const(())
 
   /**
    * Same as [[filter]]
@@ -280,19 +280,50 @@ object STM {
     /**
      * Resets the journal so that it does not modify any entries.
      */
-    final def resetJournal(journal: Journal): Unit =
-      journal.values foreach (_.reset())
+    final def resetJournal(journal: Journal): Unit = {
+      val it = journal.entrySet.iterator
+      while (it.hasNext()) {
+        it.next.getValue.reset()
+      }
+    }
+
+    /**
+     * Commits the journal.
+     */
+    final def commit(journal: Journal): Unit = {
+      val it = journal.entrySet.iterator
+      while (it.hasNext()) it.next.getValue.commit()
+    }
+
+    /**
+     * Determines if the journal is valid.
+     */
+    final def isValid(journal: Journal): Boolean = {
+      var valid = true
+      val it = journal.entrySet.iterator
+      while (valid && it.hasNext()) {
+        valid = it.next.getValue.isValid
+      }
+      valid
+    }
+
+    /**
+     * Determines if the journal is invalid.
+     */
+    final def isInvalid(journal: Journal): Boolean = !isValid(journal)
 
     /**
      * Atomically collects and clears all the todos from any `TRef` that
-     * participated in the transaction. This is not a pure function, despite
-     * the return type (it effectfully clears todos from `TRef` values).
+     * participated in the transaction.
      */
-    final def collectTodos(trefs: Iterable[TRef[_]]): Iterable[Todo] = {
-      val allTodos  = MutableMap.empty[Long, Todo]
+    final def collectTodos(journal: Journal): MutableMap[Long, Todo] = {
+      val allTodos  = new MutableMap[Long, Todo](4)
       val emptyTodo = Map.empty[Long, Todo]
 
-      trefs foreach { tref =>
+      val it = journal.entrySet().iterator()
+
+      while (it.hasNext()) {
+        val tref = it.next().getValue().tref
         val todo = tref.todo
 
         var loop = true
@@ -302,20 +333,34 @@ object STM {
           loop = !todo.compareAndSet(oldTodo, emptyTodo)
 
           if (!loop) {
-            allTodos ++= oldTodo
+            import collection.JavaConverters._
+
+            allTodos.putAll(oldTodo.asJava)
           }
         }
       }
 
-      allTodos.values
+      allTodos
+    }
+
+    /**
+     * Executes the todos in the current thread, sequentially.
+     */
+    final def execTodos(todos: MutableMap[Long, Todo]): Unit = {
+      val it = todos.entrySet().iterator()
+      while (it.hasNext()) it.next().getValue().apply()
     }
 
     /**
      * For the given transaction id, adds the specified todo effect to all
      * `TRef` values.
      */
-    final def addTodo(txnId: Long, trefs: Iterable[TRef[_]], todoEffect: Todo): Unit =
-      trefs foreach { tref =>
+    final def addTodo(txnId: Long, journal: Journal, todoEffect: Todo): Unit = {
+      val it = journal.entrySet().iterator()
+
+      while (it.hasNext()) {
+        val tref = it.next().getValue().tref
+
         var loop = true
         while (loop) {
           val oldTodo = tref.todo.get
@@ -325,6 +370,7 @@ object STM {
           loop = !tref.todo.compareAndSet(oldTodo, newTodo)
         }
       }
+    }
 
     final val succeedUnit: TRez[Nothing, Unit] =
       TRez.Succeed(())
@@ -359,11 +405,10 @@ object STM {
         newValue.asInstanceOf[B]
 
       /**
-       * Resets the value of this entry, so that if committed, it will have
-       * no effect on the TRef.
+       * Commits the new value to the `TRef`.
        */
-      final def reset(): Unit =
-        newValue = expected.value
+      final def commit(): Unit =
+        tref.versioned = new Versioned(newValue)
 
       /**
        * Determines if the entry is invalid. This is the negated version of
@@ -379,10 +424,11 @@ object STM {
         tref.versioned eq expected
 
       /**
-       * Commits the new value to the `TRef`.
+       * Resets the value of this entry, so that if committed, it will have
+       * no effect on the TRef.
        */
-      final def commit(): Unit =
-        tref.versioned = new Versioned(newValue)
+      final def reset(): Unit =
+        newValue = expected.value
     }
 
     object Entry {
@@ -407,18 +453,17 @@ object STM {
    * Atomically performs a batch of operations in a single transaction.
    */
   final def atomically[E, A](stm: STM[E, A]): IO[E, A] =
-    UIO.effectTotalWith(platform => platform -> new AtomicReference[UIO[Unit]](UIO.unit)) flatMap {
-      case (platform, ref) =>
+    UIO.effectTotalWith { platform =>
+        val txnId = makeTxnId()
+
+        val done = new AtomicBoolean(false)
+
+        val ref = new AtomicReference(UIO[Unit](done synchronized {
+          done set true
+        }))
+
         IO.effectAsyncMaybe[E, A] { k =>
           import internal.globalLock
-
-          val txnId = makeTxnId()
-
-          val done = new AtomicBoolean(false)
-
-          ref set UIO(done synchronized {
-            done set true
-          })
 
           def tryTxn(): Option[IO[E, A]] =
             if (done.get) None
@@ -432,15 +477,16 @@ object STM {
                   var loop = true
 
                   while (loop) {
-                    journal = MutableMap.empty[Long, Entry]
+                    journal = if (journal eq null) new MutableMap[Long, Entry](4) else { journal.clear(); journal }
                     value = stm exec journal
 
                     value match {
                       case _: TRez.Succeed[_] =>
                         globalLock.acquire()
 
-                        try if (journal.values forall (_.isValid)) {
-                          journal.values foreach (_.commit())
+                        try 
+                        if (isValid(journal)) {
+                          commit(journal)
 
                           loop = false
                         } finally globalLock.release()
@@ -448,11 +494,11 @@ object STM {
                       case _: TRez.Fail[_] =>
                         globalLock.acquire()
 
-                        try loop = journal.values exists (_.isInvalid)
+                        try loop = isInvalid(journal)
                         finally globalLock.release()
 
                       case TRez.Retry =>
-                        addTodo(txnId, journal.values map (_.tref), tryTxnAsync)
+                        addTodo(txnId, journal, tryTxnAsync)
 
                         loop = false
                     }
@@ -461,11 +507,9 @@ object STM {
                   def completed(io: IO[E, A]): Option[IO[E, A]] = {
                     done set true
 
-                    platform.executor.submitOrThrow { () =>
-                      val trefs = journal.values map (_.tref)
+                    val todos = collectTodos(journal)
 
-                      collectTodos(trefs) foreach (_())
-                    }
+                    if (todos.size > 0) platform.executor.submitOrThrow(() => execTodos(todos))
 
                     Some(io)
                   }
@@ -474,7 +518,7 @@ object STM {
                     case TRez.Succeed(a) => completed(IO.succeed(a))
                     case TRez.Fail(e)    => completed(IO.fail(e))
                     case TRez.Retry =>
-                      val stale = journal.values exists (entry => entry.tref.versioned ne entry.expected)
+                      val stale = isInvalid(journal)
 
                       if (stale) tryTxn() else None
                   }
@@ -490,7 +534,7 @@ object STM {
 
           tryTxn()
         } ensuring UIO(ref.get).flatten
-    }
+    }.flatten
 
   /**
    * Checks the condition, and if it's true, returns unit, otherwise, retries.

--- a/core/shared/src/main/scala/scalaz/zio/stm/TRef.scala
+++ b/core/shared/src/main/scala/scalaz/zio/stm/TRef.scala
@@ -101,11 +101,11 @@ class TRef[A] private (
     }
 
   private final def getOrMakeEntry(journal: Journal): Entry =
-    if (journal contains id) journal(id)
+    if (journal containsKey id) journal.get(id)
     else {
       val expected = versioned
       val entry    = Entry(self, expected.value, expected)
-      journal update (id, entry)
+      journal put (id, entry)
       entry
     }
 }
@@ -126,7 +126,7 @@ object TRef {
 
       val tvar = new TRef(id, versioned, todo)
 
-      journal update (id, Entry(tvar, value, versioned))
+      journal.put(id, Entry(tvar, value, versioned))
 
       TRez.Succeed(tvar)
     })

--- a/microsite/src/main/tut/datatypes/managed.md
+++ b/microsite/src/main/tut/datatypes/managed.md
@@ -108,6 +108,6 @@ val data: IO[IOException, String] = for {
       fiber  <- res.acquire.fork
       ex     <- fiber.interrupt
       data   <- ex.toEither.fold(e => IO.fail(new InterruptedIOException("Stop!")), file => readFile(file))
-    } yield data).ensuringR(res.release)
+    } yield data).ensuring(res.release)
 } yield result
 ```


### PR DESCRIPTION
A few STM benchmarks and a variety of performance improvements, including:

 - Addressing performance regression caused by ZIO environment (the cost of `provide` was dominating short-lived benchmarks due to the use of finalizers; now the top-level environment is "free")
 - Refactored STM to use `java.util.HashMap`, mainly because it is easier to minimize allocations compared to Scala's mutable map (iteration through a Scala map will always allocate tuples)
 - Introduced specializations for `effect*` variants
 - Make `ensuringR` cost-free, which means it became `ensuring`, which allowed elimination of environmental access in `bracket`
 - As a result of other cost-free changes, made more operators polymorphic in `R`
 - `bracketExit` is now fast enough (no forking) it can be the sole implementation

There's much more work to be done, but the runtime system is generating very clean, allocation-free code; STM has been through "first-pass" optimization; and overall, things are looking cleaner and more uniform thanks to the cost-free refactorings.

The main learning of STM benchmarks is that `TSemaphore` is as fast as the hand-written ZIO `Semaphore`; and `TQueue` is as fast as FS2 Queue in parallel access, although only 50% as fast in two other scenarios. With further optimization, it seems likely STM can produce performance competitive with hand-written, hand-optimized `Ref` + `Promise` code.