### PR TITLE
Fix #747 - equals and hashCode for Exit.Cause

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/ExitSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/ExitSpec.scala
@@ -5,15 +5,52 @@ import org.specs2.concurrent.ExecutionEnv
 import Exit.Cause
 
 class ExitSpec(implicit ee: ExecutionEnv) extends TestRuntime with ScalaCheck {
+  import Cause._
   import ArbitraryCause._
 
   def is = "ExitSpec".title ^ s2"""
     Cause
       `Cause#died` and `Cause#stripFailures` are consistent $e1
-  """
+      `Cause.equals` is symmetric $e2
+      `Cause.equals` and `Cause.hashCode` satisfy the contract $e3
+    Then 
+      `Then.equals` satisfies associativity $e4
+      `Then.equals` satisfies distributivity $e5
+    Both
+      `Both.equals` satisfies associativity $e6
+      `Both.equals` satisfies commutativity $e7
+      """
 
   private def e1 = prop { c: Cause[String] =>
     if (c.died) c.stripFailures must beSome
     else c.stripFailures must beNone
+  }
+
+  private def e2 = prop { (a: Cause[String], b: Cause[String]) =>
+    (a == b) must_== (b == a)
+  }
+
+  private def e3 =
+    prop { (a: Cause[String], b: Cause[String]) =>
+      (a == b) ==> (a.hashCode must_== (b.hashCode))
+    }.set(minTestsOk = 10, maxDiscardRatio = 99.0f)
+
+  private def e4 = prop { (a: Cause[String], b: Cause[String], c: Cause[String]) =>
+    Then(Then(a, b), c) must_== Then(a, Then(b, c))
+    Then(a, Then(b, c)) must_== Then(Then(a, b), c)
+  }
+
+  private def e5 = prop { (a: Cause[String], b: Cause[String], c: Cause[String]) =>
+    Then(a, Both(b, c)) must_== Both(Then(a, b), Then(a, c))
+    Then(Both(a, b), c) must_== Both(Then(a, c), Then(b, c))
+  }
+
+  private def e6 = prop { (a: Cause[String], b: Cause[String], c: Cause[String]) =>
+    Both(Both(a, b), c) must_== Both(a, Both(b, c))
+    Both(Both(a, b), c) must_== Both(a, Both(b, c))
+  }
+
+  private def e7 = prop { (a: Cause[String], b: Cause[String]) =>
+    Both(a, b) must_== Both(b, a)
   }
 }

--- a/core/shared/src/main/scala/scalaz/zio/Exit.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Exit.scala
@@ -332,39 +332,62 @@ object Exit extends Serializable {
     final case class Die(value: Throwable) extends Cause[Nothing]
     case object Interrupt                  extends Cause[Nothing]
 
-    final case class Then[E](left: Cause[E], right: Cause[E]) extends Cause[E] { self =>
-      final def flatten: Set[Cause[E]] = {
-        def flattenThen(c: Cause[E]): Set[Cause[E]] = c match {
-          case Then(left, right) => flattenThen(left) ++ flattenThen(right)
-          case x                 => Set(x)
-        }
+    case class Then[E](left: Cause[E], right: Cause[E]) extends Cause[E] { self =>
+      override final def equals(that: Any): Boolean = that match {
+        case other: Cause[_] => eq(other) || sym(assoc)(other, self) || sym(dist)(self, other)
+        case _               => false
+      }
+      override final def hashCode: Int = flatten(self).hashCode
 
-        flattenThen(left) ++ flattenThen(right)
+      private def eq(that: Cause[_]): Boolean = (self, that) match {
+        case (tl: Then[_], tr: Then[_]) => tl.left == tr.left && tl.right == tr.right
+        case _                          => false
       }
 
-      override final def hashCode: Int = flatten.hashCode
+      private def assoc(l: Cause[_], r: Cause[_]): Boolean = (l, r) match {
+        case (Then(Then(al, bl), cl), Then(ar, Then(br, cr))) => al == ar && bl == br && cl == cr
+        case _                                                => false
+      }
 
-      override final def equals(that: Any): Boolean = that match {
-        case that: Then[_] => self.flatten.equals(that.flatten)
-        case _             => false
+      private def dist(l: Cause[_], r: Cause[_]): Boolean = (l, r) match {
+        case (Then(al, Both(bl, cl)), Both(Then(ar1, br), Then(ar2, cr)))
+            if ar1 == ar2 && al == ar1 && bl == br && cl == cr =>
+          true
+        case (Then(Both(al, bl), cl), Both(Then(ar, cr1), Then(br, cr2)))
+            if cr1 == cr2 && al == ar && bl == br && cl == cr1 =>
+          true
+        case _ => false
       }
     }
+
     final case class Both[E](left: Cause[E], right: Cause[E]) extends Cause[E] { self =>
-      final def flatten: Set[Cause[E]] = {
-        def flattenBoth(c: Cause[E]): Set[Cause[E]] = c match {
-          case Both(left, right) => flattenBoth(left) ++ flattenBoth(right)
-          case x                 => Set(x)
-        }
-
-        flattenBoth(left) ++ flattenBoth(right)
-      }
-
-      override final def hashCode: Int = flatten.hashCode
-
       override final def equals(that: Any): Boolean = that match {
-        case that: Both[_] => self.flatten.equals(that.flatten)
-        case _             => false
+        case other: Cause[_] => eq(other) || sym(assoc)(self, other) || comm(other)
+        case _               => false
       }
+      override final def hashCode: Int = flatten(self).hashCode
+
+      private def eq(that: Cause[_]) = (self, that) match {
+        case (bl: Both[_], br: Both[_]) => bl.left == br.left && bl.right == br.right
+        case _                          => false
+      }
+      private def assoc(l: Cause[_], r: Cause[_]): Boolean = (l, r) match {
+        case (Both(Both(al, bl), cl), Both(ar, Both(br, cr))) => al == ar && bl == br && cl == cr
+        case _                                                => false
+      }
+      private def comm(that: Cause[_]): Boolean = (self, that) match {
+        case (Both(al, bl), Both(ar, br)) => al == br && bl == ar
+        case _                            => false
+      }
+    }
+
+    private[Cause] def sym(f: (Cause[_], Cause[_]) => Boolean): (Cause[_], Cause[_]) => Boolean =
+      (l, r) => f(l, r) || f(r, l)
+
+    private[Cause] def flatten(c: Cause[_]): Set[Cause[_]] = c match {
+      case Then(left, right) => flatten(left) ++ flatten(right)
+      case Both(left, right) => flatten(left) ++ flatten(right)
+      case o                 => Set(o)
     }
   }
 }


### PR DESCRIPTION
This solution would not be optimal if the tree for Cause would be very big and nested, as it's performing few different equality checks and therefore traversing tree multiple times. But probably there shouldn't be many cases when this is indeed big?
I left hashCode implementation to be based on set, as it's the easiest solution (but will mean that there will be hash clashes for Causes that contain the same "leaf" elments).