### PR TITLE
Simplify raceWith and effectAsyncM impls

### DIFF
--- a/core/shared/src/main/scala/scalaz/zio/ZIO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/ZIO.scala
@@ -262,17 +262,17 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
       ZIO.flatten(race.modify((c: Int) => (if (c > 0) ZIO.unit else f(res, loser).to(done).unit) -> (c + 1)))
 
     for {
-      done  <- Promise.make[E2, C]
-      race  <- Ref.make[Int](0)
-      child <- Ref.make[UIO[Any]](ZIO.unit)
-      c <- ((for {
-            left  <- self.fork.tap(f => child update (_ *> f.interrupt))
-            right <- that.fork.tap(f => child update (_ *> f.interrupt))
-            _     <- left.await.flatMap(arbiter(leftDone, right, race, done)).fork
-            _     <- right.await.flatMap(arbiter(rightDone, left, race, done)).fork
-          } yield ()).uninterruptible *> done.await).onInterrupt(
-            ZIO.flatten(child.get)
-          )
+      done <- Promise.make[E2, C]
+      race <- Ref.make[Int](0)
+      c <- ZIO.uninterruptibleMask { restore =>
+            for {
+              left  <- self.fork
+              right <- that.fork
+              _     <- left.await.flatMap(arbiter(leftDone, right, race, done)).fork
+              _     <- right.await.flatMap(arbiter(rightDone, left, race, done)).fork
+              c     <- restore(done.await).onInterrupt(left.interrupt *> right.interrupt)
+            } yield c
+          }
     } yield c
   }
 
@@ -1312,15 +1312,13 @@ private[zio] trait ZIOFunctions extends Serializable {
     register: (ZIO[R, E, A] => Unit) => ZIO[R, Nothing, _]
   ): ZIO[R, E, A] =
     for {
-      p   <- Promise.make[E, A]
-      ref <- Ref.make[UIO[Any]](ZIO.unit)
-      a <- (for {
-            r <- ZIO.runtime[R]
-            _ <- register(k => r.unsafeRunAsync_(k.to(p))).fork
-                  .tap(f => ref.set(f.interrupt))
-                  .uninterruptible
-            a <- p.await
-          } yield a).onInterrupt(flatten(ref.get))
+      p <- Promise.make[E, A]
+      r <- ZIO.runtime[R]
+      a <- ZIO.uninterruptibleMask { restore =>
+            register(k => r.unsafeRunAsync_(k.to(p))).fork.flatMap { f =>
+              restore(p.await).onInterrupt(f.interrupt)
+            }
+          }
     } yield a
 
   /**


### PR DESCRIPTION
Removes `Ref`s used for control flow logic and replaces them with `uninterruptibleMask`.