### PR TITLE
Fixing `CatsApp` (missing import)

### DIFF
--- a/interop-cats/jvm/src/main/scala/scalaz/zio/interop/catsjvm.scala
+++ b/interop-cats/jvm/src/main/scala/scalaz/zio/interop/catsjvm.scala
@@ -19,7 +19,7 @@ package interop
 
 import cats.effect.{ Concurrent, ContextShift, ExitCase }
 import cats.{ effect, _ }
-import scalaz.zio.{ clock => zioClock, ZIO }
+import scalaz.zio.{ App, clock => zioClock, ZIO }
 import scalaz.zio.clock.Clock
 
 import scala.concurrent.ExecutionContext


### PR DESCRIPTION
I just realized that `CatsApp` is actually extending the normal scala trait `App` instead of the `zio` one when trying to update some examples using `http4s`. This should fix it.