### PR TITLE
Duration and DurationSyntax specs moved to shared test sources.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -83,6 +83,9 @@ lazy val coreJVM = core.jvm
   )
 
 lazy val coreJS = core.js
+  .settings(
+    libraryDependencies += "org.scala-js" %%% "scalajs-java-time" % "0.2.5" % Test
+  )
 
 lazy val streams = crossProject(JSPlatform, JVMPlatform)
   .in(file("streams"))

--- a/core/shared/src/test/scala/scalaz/zio/duration/DurationSpec.scala
+++ b/core/shared/src/test/scala/scalaz/zio/duration/DurationSpec.scala
@@ -3,10 +3,11 @@ package scalaz.zio.duration
 import java.time.{ Duration => JavaDuration }
 import java.util.concurrent.TimeUnit
 
-import scala.concurrent.duration.{ Duration => ScalaDuration, FiniteDuration => ScalaFiniteDuration }
-import scalaz.zio.TestRuntime
+import org.specs2.Specification
 
-class DurationSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntime {
+import scala.concurrent.duration.{ Duration => ScalaDuration, FiniteDuration => ScalaFiniteDuration }
+
+class DurationSpec extends Specification {
 
   def is = "DurationSpec".title ^ s2"""
         Make a Duration from positive nanos and check that:

--- a/core/shared/src/test/scala/scalaz/zio/duration/DurationSyntaxSpec.scala
+++ b/core/shared/src/test/scala/scalaz/zio/duration/DurationSyntaxSpec.scala
@@ -1,8 +1,8 @@
 package scalaz.zio.duration
 
-import scalaz.zio.TestRuntime
+import org.specs2.Specification
 
-class DurationSyntaxSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends TestRuntime {
+class DurationSyntaxSpec extends Specification {
 
   def is = "DurationSyntaxSpec".title ^ s2"""
     Long:


### PR DESCRIPTION
Two cases for issue #804 .
`scalaz.zio.TestRuntime` was obviously too heavy dependency.
I'm wondering about `scalajs-java-time` artifact dependency, if it should be `Test` only, but I think it's OK for users to add this dependency by themselves.