### PR TITLE
Allow effectAsyncM to fail before registering

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -87,6 +87,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
     interrupt of asyncPure register         $testAsyncPureInterruptRegister
     sleep 0 must return                     $testSleepZeroReturns
     shallow bind of async chain             $testShallowBindOfAsyncChainIsCorrect
+    effectAsyncM can fail before registering $testEffectAsyncMCanFail
 
   RTS concurrency correctness
     shallow fork/join identity              $testForkJoinIsId
@@ -608,6 +609,14 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
       _ <- fiber.interrupt.fork
       a <- release.await
     } yield a) must_=== (())
+
+  def testEffectAsyncMCanFail =
+    unsafeRun {
+      ZIO
+        .effectAsyncM[Any, String, Nothing](_ => ZIO.fail("Ouch"))
+        .flip
+        .map(_ must_=== "Ouch")
+    }
 
   def testSleepZeroReturns =
     unsafeRun(clock.sleep(1.nanos)) must_=== ((): Unit)


### PR DESCRIPTION
Not sure about this one: the fix is easy, but the semantics are unclear; what happens if the registered IO succeeds, but the body running the register fails? Maybe this is why it was `Nothing` in the first placee? :-)