### PR TITLE
Add Stream#flatMapPar, Stream.flatten and Stream.mergeAll

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,6 +91,7 @@ lazy val streams = crossProject(JSPlatform, JVMPlatform)
   .in(file("streams"))
   .settings(stdSettings("zio-streams"))
   .settings(buildInfoSettings)
+  .settings(replSettings)
   .enablePlugins(BuildInfoPlugin)
   .dependsOn(core % "test->test;compile->compile")
 

--- a/project/ScalazBuild.scala
+++ b/project/ScalazBuild.scala
@@ -59,9 +59,10 @@ object Scalaz {
                                                |import scalaz._
                                                |import scalaz.zio._
                                                |import scalaz.zio.console._
+                                               |import scalaz.zio.duration._
                                                |object replRTS extends DefaultRuntime {}
                                                |import replRTS._
-                                               |implicit class RunSyntax[E, A](io: IO[E, A]){ def unsafeRun: A = replRTS.unsafeRun(io) }
+                                               |implicit class RunSyntax[R >: replRTS.Environment, E, A](io: ZIO[R, E, A]){ def unsafeRun: A = replRTS.unsafeRun(io) }
     """.stripMargin
   )
 

--- a/streams/jvm/src/test/scala/scalaz/zio/stream/StreamSpec.scala
+++ b/streams/jvm/src/test/scala/scalaz/zio/stream/StreamSpec.scala
@@ -30,6 +30,8 @@ class StreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
   Stream.take
     take                     $take
     take short circuits      $takeShortCircuits
+    take(0) short circuits   $take0ShortCircuitsStreamNever
+    take(1) short circuits   $take1ShortCircuitsStreamNever
     takeWhile                $takeWhile
     takeWhile short circuits $takeWhileShortCircuits
 
@@ -205,6 +207,20 @@ class StreamSpec(implicit ee: org.specs2.concurrent.ExecutionEnv)
         _      <- stream.run(Sink.drain)
         result <- ran.get
       } yield result must_=== false
+    )
+
+  private def take0ShortCircuitsStreamNever =
+    unsafeRun(
+      for {
+        units <- Stream.never.take(0).run(Sink.collect[Unit])
+      } yield units must_=== List()
+    )
+
+  private def take1ShortCircuitsStreamNever =
+    unsafeRun(
+      for {
+        ints <- (Stream(1) ++ Stream.never).take(1).run(Sink.collect[Int])
+      } yield ints must_=== List(1)
     )
 
   private def foreach0 = {

--- a/streams/shared/src/main/scala/scalaz/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/scalaz/stream/ZStream.scala
@@ -527,7 +527,21 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
    * Takes the specified number of elements from this stream.
    */
   final def take(n: Int): ZStream[R, E, A] =
-    self.zipWithIndex.collectWhile { case (v, i) if i < n => v }
+    if (n <= 0) Stream.empty
+    else
+      new ZStream[R, E, A] {
+        override def fold[R1 <: R, E1 >: E, A1 >: A, S]: Fold[R1, E1, A1, S] =
+          IO.succeedLazy { (s, cont, f) =>
+            if (!cont(s)) UIO.succeed(s)
+            else
+              self.zipWithIndex.fold[R1, E1, (A, Int), (S, Boolean)].flatMap { f0 =>
+                f0(s -> true, tp => cont(tp._1) && tp._2, {
+                  case ((s, _), (a, i)) =>
+                    f(s, a).map((_, if (i == n - 1) false else true))
+                }).map(_._1)
+              }
+          }
+      }
 
   /**
    * Takes all elements of the stream for as long as the specified predicate

--- a/streams/shared/src/main/scala/scalaz/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/scalaz/stream/ZStream.scala
@@ -234,7 +234,7 @@ trait ZStream[-R, +E, +A] extends Serializable { self =>
                               _ <- innerFailure.await.raceWith(Fiber.joinAll(innerFibers))(
                                     // One of the inner fibers failed. It already enqueued its failure,
                                     // so we don't need to do anything except interrupt all the other fibers.
-                                    leftDone = (_, _) => ZIO.children.flatMap(Fiber.interruptAll),
+                                    leftDone = (_, _) => Fiber.interruptAll(innerFibers),
                                     // All fibers completed successfully, so we just need to signal that
                                     // we're done.
                                     rightDone = (_, failureAwait) => out.offer(Take.End) *> failureAwait.interrupt


### PR DESCRIPTION
Resolves #836.

I'm going to add a bunch of more tests that exercise errors, interruption and other issues, but I'd love to get comments on the implementation and possible simplifications.

Pending fixes:
- [x] an error in an inner fiber would enqueue a `Take.Fail`, which would cause the output stream to fail; however nothing in this case would stop the driver stream
- [ ] currently the outer stream ends completely before the inner fibers; which means that an outer stream created using `Stream.bracket` would release its resources before the inner fibers complete