### PR TITLE
Added Resources to Documentation.

### DIFF
--- a/docs/resources/resources.md
+++ b/docs/resources/resources.md
@@ -6,6 +6,7 @@ title:  "Resources"
 ## Blog Articles
 
 Note that these articles reflect the state of ZIO at the time of their publication, so the code samples might be outdated considering ZIO was under active development at the time they were written.
+- [Performant Functional Programming to the max with ZIO](https://cloudmark.github.io/A-Journey-To-Zio/) by Mark Galea (May 2019)
 - [Using 47 Degree's Fetch library with ZIO](http://justinhj.github.io/2019/05/05/using-47degs-fetch-with-zio.html) by Justin Heyes-Jones (May 2019)
 - [ZIO & Cats Effect: A Match Made in Heaven](http://degoes.net/articles/zio-cats-effect) by John De Goes (April 2019)
 - [Hacker News API Part 5](http://justinhj.github.io/2019/04/07/hacker-news-api-5.html) by Justin Heyes-Jones (April 2019)


### PR DESCRIPTION
Added [http://cloudmark.github.io/A-Journey-To-Zio/](http://cloudmark.github.io/A-Journey-To-Zio/).  

This is a blog which takes a simple application and converts it to ZIO.  This blog covers Monad Transformers and clearly states why this technique should be *avoided*.  There is no reason to use Monad Transformers now that there is ZIO.  

I've used Monad Transformers for quite a while and I wish there was a blog out there which specifies how to achieve a more performant app using Effect Rotation (ZIO).  