### PR TITLE
Simplified 'provideSomeM'

### DIFF
--- a/core/shared/src/main/scala/scalaz/zio/ZIO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/ZIO.scala
@@ -89,9 +89,17 @@ sealed trait ZIO[-R, +E, +A] extends Serializable { self =>
   /**
    * An effectful version of `provideSome`, useful when the act of partial
    * provision requires an effect.
+   *
+   * {{{
+   * val effect: ZIO[Console with Logging, Nothing, Unit] = ???
+   *
+   * val r0: ZIO[Console, Nothing, Console with Logging] = ???
+   *
+   * effect.provideSomeM(r0)
+   * }}}
    */
-  final def provideSomeM[R0, R1 >: R0, E1 >: E](f: R1 => ZIO[R0, E1, R]): ZIO[R0, E1, A] =
-    ZIO.accessM(r0 => f(r0).flatMap(self.provide))
+  final def provideSomeM[R0, E1 >: E](r0: ZIO[R0, E1, R]): ZIO[R0, E1, A] =
+    r0.flatMap(self.provide)
 
   /**
    * Returns an effect whose success is mapped by the specified `f` function.


### PR DESCRIPTION
This PR aims to simplify the signature of `provideSomeM` dropping one type variable (`R1`). 

An example of what should be a common scenario when using this API looks like
```scala
type MyEnv = FirstModule with SecondModule

def program: ZIO[MyEnv, Throwable, Unit] = ???

def buildEnv: ZIO[FirstModule, Throwable, MyEnv] = ???
```
where `FirstModule` and `SecondModule` (definitions omitted for brevity) are standard ZIO modules as described in this great @jdegoes [article](http://degoes.net/articles/zio-environment)

In this case, an attempt to use `provideSomeM` (e.g. to effectfully build a part of the environment which depends on another part of it) leads to something like this: 
```scala
program.provideSomeM[FirstModule, Any, Throwable](_ => buildEnv)
```
or 
```scala
program.provideSomeM(_: Any => buildEnv)
```

which is not so clean due to a type variable (R1) which cannot be inferred automatically from `buildEnv` function (in fact, with R0 AND R1, we have two "environments". 

Removing the type variable R1, leads to a cleaner 
```scala
program.provideSomeM(buildEnv)
```

This PR originated from a discussion with the community on Gitter, where even @jdegoes was involved: 
![Schermata 2019-05-23 alle 12 32 33](https://user-images.githubusercontent.com/17480403/58328022-5c630000-7e31-11e9-9546-ff0bead93047.png)
