### PR TITLE
Add ZManaged#useForever

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/ZManagedSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/ZManagedSpec.scala
@@ -1,3 +1,4 @@
+
 package scalaz.zio
 
 import org.scalacheck.{ Gen, _ }
@@ -21,8 +22,6 @@ class ZManagedSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Test
     Invokes cleanups in reverse order of acquisition. $invokesCleanupsInReverse
     Properly performs parallel acquire and release. $parallelAcquireAndRelease
     Constructs an uninterruptible Managed value. $uninterruptible
-  ZManaged.traverse
-    Invokes cleanups in reverse order of acquisition. $traverse
   ZManaged.reserve 
     Interruption is possible when using this form. $interruptible
   ZManaged.foldM
@@ -35,6 +34,7 @@ class ZManagedSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Test
   ZManaged.foreach
     Returns elements in the correct order $foreachOrder
     Runs finalizers $foreachFinalizers
+    Invokes cleanups in reverse order of acquisition. $foreachFinalizerOrder
   ZManaged.foreachPar
     Returns elements in the correct order $foreachParOrder
     Runs finalizers $foreachParFinalizers
@@ -141,18 +141,6 @@ class ZManagedSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Test
 
     result must haveSize(2)
     result.size === cleanups.size
-  }
-
-  private def traverse = {
-    val effects = new mutable.ListBuffer[Int]
-    def res(x: Int) =
-      ZManaged.make(IO.effectTotal { effects += x; () })(_ => IO.effectTotal { effects += x; () })
-
-    val resources = ZManaged.foreach(List(1, 2, 3))(res)
-
-    unsafeRun(resources.use(_ => IO.unit))
-
-    effects must be_===(List(1, 2, 3, 3, 2, 1))
   }
 
   private def uninterruptible =
@@ -404,6 +392,18 @@ class ZManagedSpec(implicit ee: org.specs2.concurrent.ExecutionEnv) extends Test
       managed.use[Any, Nothing, Unit](_ => ZIO.unit)
     }
     effect must be_===(4)
+  }
+
+  def foreachFinalizerOrder = {
+    val effects = new mutable.ListBuffer[Int]
+    def res(x: Int) =
+      ZManaged.make(IO.effectTotal { effects += x; () })(_ => IO.effectTotal { effects += x; () })
+
+    val resources = ZManaged.foreach(List(1, 2, 3))(res)
+
+    unsafeRun(resources.use(_ => IO.unit))
+
+    effects must be_===(List(1, 2, 3, 3, 2, 1))
   }
 
   def foreachParOrder = {

--- a/core/jvm/src/test/scala/scalaz/zio/ZManagedSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/ZManagedSpec.scala
@@ -1,4 +1,3 @@
-
 package scalaz.zio
 
 import org.scalacheck.{ Gen, _ }

--- a/core/shared/src/main/scala/scalaz/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/scalaz/zio/ZManaged.scala
@@ -521,6 +521,12 @@ final case class ZManaged[-R, +E, +A](reserve: ZIO[R, E, Reservation[R, E, A]]) 
     use(_ => f)
 
   /**
+   * Use the resource until interruption.
+   * Useful for resources that you want to acquire and use as long as the application is running, like a HTTP server.
+   */
+  final val useForever: ZIO[R, E, Nothing] = use(_ => ZIO.never)
+
+  /**
    * The moral equivalent of `if (p) exp`
    */
   final def when(b: Boolean): ZManaged[R, E, Unit] =


### PR DESCRIPTION
Also renames & moves a test that was using an old name (`traverse`).

Let me know if I should write some test for `useForever` or if it's simple enough to be added as is :)