### PR TITLE
Take extends Product with Serializable

### DIFF
--- a/streams/shared/src/main/scala/scalaz/stream/Take.scala
+++ b/streams/shared/src/main/scala/scalaz/stream/Take.scala
@@ -23,7 +23,7 @@ import scalaz.zio.IO
  * values. A `Take` may be a failure value `E`, an element value `A`, or end-of-
  * stream marker.
  */
-sealed trait Take[+E, +A] { self =>
+sealed trait Take[+E, +A] extends Product with Serializable { self =>
   final def map[B](f: A => B): Take[E, B] = self match {
     case t @ Take.Fail(_) => t
     case Take.Value(a)    => Take.Value(f(a))


### PR DESCRIPTION
This makes the inference a bit more accurate. In scenarios like the following
```scala
scala> import scalaz.zio.stream.{Take, ZStream}
<console>:11: warning: Unused import
       import scalaz.zio.stream.{Take, ZStream}
                                 ^
<console>:11: warning: Unused import
       import scalaz.zio.stream.{Take, ZStream}
                                       ^
import scalaz.zio.stream.{Take, ZStream}

scala> (ZStream.range(1, 10) map Take.Value.apply) ++ ZStream.succeed(Take.End)
res0: scalaz.zio.stream.ZStream[Any,Nothing,Product with Serializable with scalaz.zio.stream.Take[Nothing,Int]] = scalaz.zio.stream.ZStream$$anon$1@332829f8
```
`Product with Serializable with scalaz.zio.stream.Take[Nothing,Int]` is inferred for `Take[Nothing, Int]`. After the change it becomes
```scala
scala> import scalaz.zio.stream.{Take, ZStream}
<console>:11: warning: Unused import
       import scalaz.zio.stream.{Take, ZStream}
                                 ^
<console>:11: warning: Unused import
       import scalaz.zio.stream.{Take, ZStream}
                                       ^
import scalaz.zio.stream.{Take, ZStream}

scala> (ZStream.range(1, 10) map Take.Value.apply) ++ ZStream.succeed(Take.End)
res0: scalaz.zio.stream.ZStream[Any,Nothing,scalaz.zio.stream.Take[Nothing,Int]] = scalaz.zio.stream.ZStream$$anon$1@9b8469f
```
notice `scalaz.zio.stream.ZStream[Any,Nothing,scalaz.zio.stream.Take[Nothing,Int]]`.
Anyway feel free to close the PR if this is not a priority.