### PR TITLE
Fix flaky tests

### DIFF
--- a/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
+++ b/core/jvm/src/test/scala/scalaz/zio/RTSSpec.scala
@@ -968,7 +968,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
     } yield result must_=== 10
   }
 
-  def testInterruptStatusIsHeritable = unsafeRun {
+  def testInterruptStatusIsHeritable = nonFlaky {
     for {
       latch <- Promise.make[Nothing, Unit]
       ref   <- Ref.make(InterruptStatus.interruptible)
@@ -977,16 +977,15 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
     } yield v must_=== InterruptStatus.uninterruptible
   }
 
-  def testExecutorIsHeritable = unsafeRun {
-    for {
+  def testExecutorIsHeritable =
+    nonFlaky(for {
       ref  <- Ref.make(Option.empty[internal.Executor])
       exec = internal.Executor.fromExecutionContext(100)(scala.concurrent.ExecutionContext.Implicits.global)
-      _    <- IO.descriptor.map(_.executor).flatMap(e => ref.set(Some(e))).fork.lock(exec)
+      _    <- withLatch(release => IO.descriptor.map(_.executor).flatMap(e => ref.set(Some(e)) *> release).fork.lock(exec))
       v    <- ref.get
-    } yield v must_=== Some(exec)
-  }
+    } yield v must_=== Some(exec))
 
-  def testSupervisionIsHeritable = unsafeRun {
+  def testSupervisionIsHeritable = nonFlaky {
     for {
       latch <- Promise.make[Nothing, Unit]
       ref   <- Ref.make(SuperviseStatus.unsupervised)
@@ -996,18 +995,15 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
   }
 
   def testSupervisingInheritance = {
-    def forkAwaitStart[A](io: UIO[A]) =
-      for {
-        latch <- Promise.make[Nothing, Unit]
-        _     <- (latch.succeed(()) *> io).fork
-        _     <- latch.await
-      } yield ()
+    def forkAwaitStart[A](io: UIO[A], refs: Ref[List[Fiber[_, _]]]): UIO[Fiber[Nothing, A]] =
+      withLatch(release => (release *> io).fork.tap(f => refs.update(f :: _)))
 
-    unsafeRun(
+    nonFlaky(
       (for {
-        _    <- forkAwaitStart(forkAwaitStart(forkAwaitStart(IO.succeed(()))))
+        ref  <- Ref.make[List[Fiber[_, _]]](Nil) // To make strong ref
+        _    <- forkAwaitStart(forkAwaitStart(forkAwaitStart(IO.succeed(()), ref), ref), ref)
         fibs <- ZIO.children
-      } yield fibs must have size 3).supervised
+      } yield fibs must have size 1).supervised
     )
   }
 
@@ -1435,4 +1431,10 @@ class RTSSpec(implicit ee: ExecutionEnv) extends TestRuntime {
     unsafeRun(
       IO.mergeAll(List.empty[UIO[Int]])(0)(_ + _)
     ) must_=== 0
+
+  def nonFlaky(v: => ZIO[Environment, Any, org.specs2.matcher.MatchResult[_]]): org.specs2.matcher.MatchResult[_] =
+    (1 to 50).foldLeft[org.specs2.matcher.MatchResult[_]](true must_=== true) {
+      case (acc, _) =>
+        acc and unsafeRun(v)
+    }
 }


### PR DESCRIPTION
This fixes all the flakiness in the new tests.

@ghostdogpr I had to change the semantics of supervision inheritance. Basically, if we share the sets between child and parent, then operations like `interruptChildren` will actually interrupt parent fibers, because they'll be sharing the same set.

I think we could fix that by having the parent set be the effective union of its own internal set, plus the set of children. Then if you turn supervision on in the parent, and it stays on in the child, the parent can see its own fibers and the child fibers, but the child can only see its own fibers. That might be sensible, but the current semantic was not, so I changed it in this pull request.